### PR TITLE
feat: plugin scaffold + repo hygiene (#1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "milestone-feeder",
+  "owner": {
+    "name": "Ken Mulford",
+    "email": "ken@kenmulford.com"
+  },
+  "metadata": {
+    "description": "Brief-to-milestone feeder for Claude Code — the predecessor of milestone-driver"
+  },
+  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
+  "plugins": [
+    {
+      "name": "milestone-feeder",
+      "source": "./",
+      "description": "Decompose a feature brief into a GitHub milestone of small, well-formed issues that pass milestone-driver's triage clean — preview by default, create on --apply. Authors no code.",
+      "category": "development",
+      "tags": ["github", "milestones", "issues", "decomposition", "planning", "triage", "automation"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "milestone-feeder",
+  "version": "0.1.0",
+  "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification: it decomposes the brief into independently-buildable issues, authors each issue's full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification), encodes the Wave order in the milestone description, and self-checks every issue against the driver's own triage reviewers before any GitHub write — previewing a plan by default and creating issues only on --apply. Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
+  "author": {
+    "name": "Ken Mulford",
+    "email": "ken@kenmulford.com"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/kenmulford/milestone-feeder",
+  "homepage": "https://github.com/kenmulford/milestone-feeder#readme",
+  "keywords": [
+    "claude-code",
+    "plugin",
+    "github",
+    "milestone",
+    "issues",
+    "decomposition",
+    "planning",
+    "triage",
+    "automation",
+    "subagent"
+  ],
+  "dependencies": [
+    { "name": "superpowers", "marketplace": "claude-plugins-official" }
+  ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings in the repository to LF.
+* text=auto
+
+# The polyglot hook launcher is parsed by BOTH cmd and bash. CRLF breaks the
+# bash heredoc close (`CMDBLOCK\r` never matches the `CMDBLOCK` delimiter), so
+# it MUST stay LF in the working tree even on Windows (core.autocrlf=true).
+*.cmd text eol=lf
+
+# Shell scripts MUST be LF even in the working tree — CRLF breaks the
+# shebang and produces "bad interpreter" / "\r command not found" on
+# Linux, macOS, WSL, and git-bash.
+*.sh text eol=lf
+
+# PowerShell scripts: keep LF too for clean cross-platform diffs.
+# pwsh 7+ runs LF scripts fine on Windows, Linux, and macOS.
+*.ps1 text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# OS cruft
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# Logs and scratch
+*.log
+/tmp/
+/scratch/
+
+# milestone-driver per-clone runtime markers (preflight notice, Trello notice,
+# tests-green stamp, triage cache) — never commit the driver's clone-local state
+# into this repo. NOTE: does not match .milestone-config/ (the committed profile).
+.milestone-driver-*
+
+# milestone-driver parallel-mode worktree fleet scratch dir (per-clone)
+.milestone-driver-worktrees/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ken Mulford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Establishes the loadable plugin skeleton + repo hygiene for milestone-feeder (issue #1): the manifest pair, LF discipline, ignore rules, and license. No runtime behavior — the structural foundation every later issue builds on.

Closes #1.

## Changes
- `.claude-plugin/plugin.json` — flat manifest, `version: 0.1.0` (sole version string), object `author`, `dependencies: [superpowers]`, no `$schema`.
- `.claude-plugin/marketplace.json` — has `$schema`, no `version`, one `plugins[]` entry (`source: "./"`).
- `.gitattributes` — LF on `*.cmd`/`*.sh`/`*.ps1` (protects the polyglot launcher from CRLF).
- `.gitignore` — OS/editor/log cruft + `.milestone-driver-*` per-clone markers (keeps `.milestone-config/` tracked).
- `LICENSE` — MIT, © 2026 Ken Mulford.

## Decision Log
- plugin.json → mirrors `milestone-driver/.claude-plugin/plugin.json:1-28`; swapped name/version/repo/keywords/description/deps; kept object `author` + array-of-objects `dependencies`. Rejected adding `$schema` (driver has none).
- marketplace.json → mirrors `.claude-plugin/marketplace.json:1-21`; `$schema` present, no `version`. Rejected a `version` field (footgun — silently masks plugin.json).
- .gitattributes → verbatim `milestone-driver/.gitattributes:1-16` (LF discipline is plugin-identical).
- .gitignore → driver's general block; collapsed the four driver per-clone markers into one `.milestone-driver-*` glob (verified to match all four; keeps `.milestone-config/` tracked).
- LICENSE → verbatim `milestone-driver/LICENSE` (author + 2026 year already correct).

## Code Review
- /code-review run: yes (medium effort, light profile)
- Findings: 0 in-scope findings — clean mirrored boilerplate (no logic / control flow / call sites)
  - none
- No park-triggering findings.
- Version: version-bump only — no logic change (plugin.json created at the milestone target 0.1.0; idempotent).

## Verification (no test layer)
- `claude plugin validate .` → ✔ Validation passed
- `python3 -m json.tool` on both manifests → valid JSON
- repo-wide `grep "0.1.0"` → single match at `.claude-plugin/plugin.json:3`
- `git check-ignore` → driver markers ignored; `.milestone-config/driver.json` stays tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
