### PR TITLE
feat: no-source-edit mechanical hook (#3)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,13 @@
+{
+  "description": "milestone-feeder mechanical gate, invoked via the bash-first/pwsh-fallback launcher run-hook.cmd. no-source-edit: unconditionally deny edits to the feeder's own source globs (resolved from <repo>/.milestone-config/feeder.json first, then the driver config .milestone-config/driver.json -> root milestone-driver.json, else fail-open). The feeder reads code and authors issue text — it never writes source — so this is the only gate it needs.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" no-source-edit", "timeout": 15 }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/no-source-edit.ps1
+++ b/hooks/no-source-edit.ps1
@@ -1,0 +1,68 @@
+#!/usr/bin/env pwsh
+# milestone-feeder — no-source-edit gate (Claude PreToolUse: Write|Edit|MultiEdit|NotebookEdit)
+#
+# Unconditionally blocks edits to the feeder's own source globs. The feeder
+# reads code and authors issue text — it never writes source — so the deny
+# applies in ANY context (no subagent carve-out). The orchestrator keeps
+# /docs/, /.claude/, and /Obsidian/ paths (plus any file outside sourceGlobs)
+# editable; files matching sourceGlobs are gated even when markdown.
+#
+# Deny mechanism: exit 2 + stderr (stable across current Claude Code).
+# Deny globs: <repo>/.milestone-config/feeder.json first, then the resolved
+#   driver config (.milestone-config/driver.json -> root milestone-driver.json).
+#   First file with a non-empty sourceGlobs wins; none -> fail-open.
+# Escape hatch: CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1
+#
+# Fail-open: any parse/IO error exits 0 so a hook bug never bricks editing.
+
+if ($env:CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT -eq '1') { exit 0 }
+
+$raw = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrWhiteSpace($raw)) { exit 0 }
+try { $hook = $raw | ConvertFrom-Json -ErrorAction Stop } catch { exit 0 }
+
+# Target file (Edit/Write/MultiEdit use file_path; NotebookEdit uses notebook_path).
+$filePath = $hook.tool_input.file_path
+if (-not $filePath) { $filePath = $hook.tool_input.notebook_path }
+if (-not $filePath) { exit 0 }
+$norm = ([string]$filePath) -replace '\\', '/'
+
+# Always-exempt: docs, .claude config, Obsidian vaults. Source globs are gated even when markdown.
+if ($norm -match '/docs/')    { exit 0 }
+if ($norm -match '/\.claude/'){ exit 0 }
+if ($norm -match '/Obsidian/'){ exit 0 }
+
+# Resolve project dir.
+$projectDir = $hook.cwd
+if (-not $projectDir) { $projectDir = $env:CLAUDE_PROJECT_DIR }
+if (-not $projectDir) { $projectDir = (Get-Location).Path }
+$projectDir = ([string]$projectDir) -replace '\\', '/'
+
+# Resolve the deny globs: feeder.json first (self-protection of the feeder's own
+# repo), then the resolved driver config. First file with a non-empty
+# sourceGlobs wins; none -> fail-open.
+$globs = $null
+foreach ($cfg in @(
+    (Join-Path $projectDir '.milestone-config' 'feeder.json'),
+    (Join-Path $projectDir '.milestone-config' 'driver.json'),
+    (Join-Path $projectDir 'milestone-driver.json'))) {
+    if (-not (Test-Path $cfg)) { continue }
+    try { $parsed = Get-Content $cfg -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+    if ($parsed.sourceGlobs) { $globs = $parsed.sourceGlobs; break }
+}
+if (-not $globs) { exit 0 }
+
+# Repo-relative path for matching.
+$rel = $norm
+if ($norm.StartsWith("$projectDir/")) { $rel = $norm.Substring($projectDir.Length + 1) }
+
+foreach ($g in $globs) {
+    $pattern = ([string]$g) -replace '\\', '/'
+    $pattern = $pattern -replace '\*\*', '*'   # ** -> * ; PowerShell -like '*' already crosses '/'
+    if (($rel -like $pattern) -or ($norm -like "*/$pattern")) {
+        [Console]::Error.WriteLine("milestone-feeder: edits to source ('$rel') are blocked — the feeder authors no code. Set CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1 to override.")
+        exit 2
+    }
+}
+
+exit 0

--- a/hooks/no-source-edit.sh
+++ b/hooks/no-source-edit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# milestone-feeder — no-source-edit gate (Claude PreToolUse: Write|Edit|MultiEdit|NotebookEdit)
+#
+# Bash parity of no-source-edit.ps1. Unconditionally blocks edits to the
+# feeder's own source globs — the feeder reads code and authors issue text, it
+# never writes source, so the deny applies in ANY context (no subagent
+# carve-out). Requires `jq`.
+#
+# Deny mechanism: exit 2 + stderr. Escape hatch: CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1
+# Fail-open: missing jq / parse errors exit 0 so a hook bug never bricks editing.
+
+[ "${CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT:-}" = "1" ] && exit 0
+
+input="$(cat)"
+[ -z "$input" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null)"
+[ -z "$file_path" ] && exit 0
+norm="${file_path//\\//}"
+
+# Always-exempt paths. Source globs are gated even when markdown.
+case "$norm" in
+  */docs/*)      exit 0 ;;
+  */.claude/*)   exit 0 ;;
+  */Obsidian/*)  exit 0 ;;
+esac
+
+project_dir="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)"
+[ -z "$project_dir" ] && project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+project_dir="${project_dir//\\//}"
+
+# Resolve the deny globs: feeder.json first (self-protection of the feeder's own
+# repo), then the resolved driver config (.milestone-config/driver.json -> root
+# milestone-driver.json). First file yielding a non-empty sourceGlobs wins; if
+# none does, fail-open (exit 0).
+globs=""
+for cfg in \
+  "$project_dir/.milestone-config/feeder.json" \
+  "$project_dir/.milestone-config/driver.json" \
+  "$project_dir/milestone-driver.json"; do
+  [ -f "$cfg" ] || continue
+  globs="$(jq -r '.sourceGlobs[]? // empty' "$cfg" 2>/dev/null)"
+  [ -n "$globs" ] && break
+done
+[ -z "$globs" ] && exit 0
+
+rel="$norm"
+case "$norm" in
+  "$project_dir"/*) rel="${norm#"$project_dir"/}" ;;
+esac
+
+while IFS= read -r g; do
+  g="${g%$'\r'}"          # strip trailing CR (jq on Windows/msys emits CRLF)
+  [ -z "$g" ] && continue
+  pat="${g//\*\*/\*}"     # ** -> * ('*' in a case glob matches across '/')
+  blocked=0
+  # shellcheck disable=SC2254
+  case "$rel"  in $pat)    blocked=1 ;; esac
+  # shellcheck disable=SC2254
+  case "$norm" in */$pat)  blocked=1 ;; esac
+  if [ "$blocked" = "1" ]; then
+    echo "milestone-feeder: edits to source ('$rel') are blocked — the feeder authors no code. Set CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1 to override." >&2
+    exit 2
+  fi
+done <<EOF
+$globs
+EOF
+
+exit 0

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,31 @@
+: << 'CMDBLOCK'
+@echo off
+REM milestone-driver cross-platform polyglot launcher.
+REM Windows: cmd runs this batch half (bash first, then pwsh, else exit 0).
+REM Unix: bash runs the sh half below ( : is a no-op; heredoc swallows the batch ).
+REM Usage: run-hook.cmd <gate>   (gate = base name, e.g. force-subagent)
+if "%~1"=="" (echo run-hook.cmd: missing gate name>&2& exit /b 1)
+set "HOOK_DIR=%~dp0"
+set "GATE=%~1"
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%GATE%.sh"
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%GATE%.sh"
+    exit /b %ERRORLEVEL%
+)
+where bash >nul 2>nul && (
+    bash "%HOOK_DIR%%GATE%.sh"
+    exit /b %ERRORLEVEL%
+)
+where pwsh >nul 2>nul && (
+    pwsh -NoProfile -File "%HOOK_DIR%%GATE%.ps1"
+    exit /b %ERRORLEVEL%
+)
+exit /b 0
+CMDBLOCK
+
+# Unix: bash ran this file, so bash exists -> run the gate's .sh.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec bash "${HOOK_DIR}/$1.sh"


### PR DESCRIPTION
## Summary
Adds the feeder's single mechanical gate (issue #3): a `no-source-edit` PreToolUse hook that unconditionally denies main-thread Write/Edit/MultiEdit/NotebookEdit to the feeder's own source globs, resolving them `feeder.json` → driver config → fail-open. The safety spine that makes "authors no code" un-bypassable.

Closes #3.

## Changes
- `hooks/no-source-edit.sh` — bash gate: unconditional deny (no subagent carve-out), feeder→driver→fail-open glob resolution, `CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT` hatch, exempt `docs`/`.claude`/`Obsidian`, deny = exit 2 + stderr.
- `hooks/no-source-edit.ps1` — byte-parallel pwsh 7+.
- `hooks/run-hook.cmd` — verbatim driver launcher (mode 0755).
- `hooks/hooks.json` — registers the one gate (`Write|Edit|MultiEdit|NotebookEdit` → `run-hook.cmd no-source-edit`, timeout 15).

## Decision Log
- Resolution loop over `[feeder.json, .milestone-config/driver.json, milestone-driver.json]`, first non-empty `sourceGlobs` wins, else fail-open (SPEC §7:148,152).
- "Non-empty `sourceGlobs`" (not merely file-present) is the fall-through trigger (handles absent/empty key).
- Deleted force-subagent's subagent-allow block (`force-subagent.sh:18-21`) — deny is unconditional (feeder writes no code in any context).
- Renamed hatch to `CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT`; dropped the "dispatch implementer" stderr advice (no subagent path here).

## Code Review
- /code-review run: yes (high effort, heavy profile) — focused rigorous review of the hook logic + independent orchestrator genuineness spot-check.
- Findings: 0 Blocker/correctness; 1 Advisory.
  - [Advisory] `no-source-edit.ps1` not executed (pwsh 7 not installed on the build host) → verified by byte-parallel inspection vs the passing `.sh` and `force-subagent.ps1`. The `.sh` path (macOS/Linux/WSL/git-bash) is fully fixture-tested; the Windows-pwsh path is inspection-verified, consistent with the driver's own cross-platform hook pattern. Accepted (not a park) — flagged via the `judgment call` label.
- Version: no bump (`plugin.json` untouched; at milestone target 0.1.0).

## Verification (no test layer — fixture matrix + independent spot-check)
- Implementer fixture matrix (bash): **7/7 green** — deny on `skills/**`; exit 0 on exempt / non-source / empty-stdin / no-config / override; driver-config fallback fires. Plus feeder-precedence + empty-key-fallthrough checks.
- Independent orchestrator spot-check (bash): source edit → exit 2 (correct stderr); non-source → exit 0; override → exit 0.
- File hygiene: `run-hook.cmd` mode 0755; all scripts LF, no BOM; `hooks.json` valid JSON; `bash -n` clean; `claude plugin validate .` ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
