### PR TITLE
docs: v0.1.0 architecture + consumer-setup + CHANGELOG + README align (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ desktop.ini
 
 # milestone-driver parallel-mode worktree fleet scratch dir (per-clone)
 .milestone-driver-worktrees/
+
+# milestone-feeder decompose preview plan-scratch (per-run, e.g.
+# .milestone-feeder/plan-<slug>.md) — reviewed and discarded, never committed.
+# NOTE: does not match .milestone-config/ (the committed feeder/driver profiles).
+/.milestone-feeder/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+Release notes for milestone-feeder. Each tagged release is also published on the
+[GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
+
+## v0.1.0 — Preview slice
+
+**Theme:** The first runnable slice of the feeder: a plugin scaffold with one
+mechanical gate, and a preview decompose pipeline that turns a feature brief into a
+reviewable milestone plan — small, well-formed issues with Wave-ordered dependencies
+— **without writing any GitHub state**. It reads code and the project substrate to
+ground its design calls, parks product calls it cannot ground, and authors no code.
+The self-check gate, `--apply`, and refine ship in v0.2.0.
+
+### ✨ Scaffold & safety spine
+
+| Issue | What |
+|---|---|
+| #1 | Plugin scaffold: `.claude-plugin/plugin.json` (the `superpowers` dependency, `0.1.0` version), `marketplace.json`, `LICENSE`, `.gitattributes` (LF enforcement for hook scripts), and the `.gitignore` hygiene baseline. |
+| #2 | Config schema (`.milestone-config/feeder.json`) + `docs/profile-schema.md`: the feeder's own keys (`substrateDir`, `selfCheck`, agent overrides, `issueSizeGuidance`, self-protection `sourceGlobs`), absent-means-default discipline, and the two resolution chains (the hook's `sourceGlobs` self-protection chain; the shared-keys chain read from the driver config). |
+| #3 | The `no-source-edit` gate: a `PreToolUse` hook (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`) via the bash-first/pwsh-fallback launcher, unconditionally denying edits to the resolved `sourceGlobs` (feeder.json → driver config → fail-open), with a `CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT` escape hatch. |
+| #4 | The `setup` skill: inference-first profile bootstrap, no required hard-stop key, label taxonomy provisioning aligned to the driver's (`ui`/`logic`/`risk:light`/`risk:heavy`), auto-invoked by `decompose` when the profile is absent. |
+
+### ✨ Decompose preview pipeline
+
+| Issue | What |
+|---|---|
+| #5 | The `decomposer` agent: architect lens, dispatched once — brief + substrate + repo → candidate issues + dependency edges + Wave order, local tags only, every design call grounded or parked as a product gap. |
+| #6 | The `issue-author` agent: per-candidate, authors one issue's full §4 spec (the five triage criteria — consistency, buildability, completeness, dependencies, UI/logic + risk) so it passes the driver's triage clean. |
+| #7 | The `decompose` skill: the preview orchestrator (Steps 0–5), brief ingestion (epic/file/inline), the product-gap park boundary, parallel issue authoring, the Wave-ordered milestone description, and the plan-file emit to `.milestone-feeder/plan-<slug>.md`. Preview only — no GitHub writes. |
+| #8 | This docs set: `docs/architecture.md` (internal design reference), `docs/consumer-setup.md` (adopter runbook), this CHANGELOG, and the README alignment to v0.1.0. |
+
+### Consumer notes
+
+- **`superpowers` is required** (declared in `plugin.json`); the decompose pipeline depends on it.
+- **`milestone-driver` is optional.** It powers the `selfCheck: "milestone-driver"` mode (a v0.2.0 capability) and supplies the shared keys the feeder reads. Absent → `selfCheck` degrades to `"internal"` and shared keys resolve to defaults; the pipeline still runs.
+- **Preview only this release.** `/milestone-feeder:decompose` writes no GitHub state — it emits a reviewable plan file (and a "needs product input" report when product gaps remain). The `--apply` token is recognized but unimplemented; real GitHub creation, the driver-backed self-check, and `refine` ship in **v0.2.0**.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin that turns a feature brief into a **GitHub milestone + smal
 
 Its quality bar is concrete — every issue it emits passes the driver's own triage clean (`GAPS: none`), because the feeder reuses the driver's actual reviewer agents as a pre-creation self-check.
 
-Status: **spec-stage, implementation starting.** The full design is in [SPEC.md](SPEC.md). Part of the [dev-tools](../dev-tools) suite.
+Status: **v0.1.0 (preview slice) shipped; v0.2.0 (self-check, `--apply`, refine) in progress.** The full design is in [SPEC.md](SPEC.md); the as-built design reference is in [docs/architecture.md](docs/architecture.md), and adopting the feeder is documented in [docs/consumer-setup.md](docs/consumer-setup.md). Part of the dev-tools suite.
 
 ## At a glance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,126 @@
+# Architecture
+
+A generic decompose engine ships in the plugin; each repo supplies a thin profile
+(`.milestone-config/feeder.json`) plus a substrate (the project-constitution docs
+under `substrateDir`). The engine turns a feature brief into a milestone of small,
+well-formed issues; the profile and substrate carry the stack, the conventions,
+and the design defaults the engine grounds its decomposition in.
+
+## Plugin contents
+
+The as-built v0.1.0 components. Components marked **planned (v0.2.0)** are specified
+in `SPEC.md` but not shipped in this release (see [The decompose procedure](#the-decompose-procedure)).
+
+| Component | Path | Purpose |
+|---|---|---|
+| Setup skill | `skills/setup/SKILL.md` | First-run profile bootstrap: infer keys from repo signals, write `.milestone-config/feeder.json`, provision the label taxonomy aligned to the driver's. Auto-invoked by `decompose` when the profile is absent. Mirrors `milestone-driver:setup`. |
+| Decompose skill | `skills/decompose/SKILL.md` | Orchestrator: brief → milestone + issues. Runs Steps 0–5 and emits a reviewable plan file. `/milestone-feeder:decompose <brief>` — **preview only** this release. |
+| Decomposer agent | `agents/decomposer.md` | Architect lens: brief + substrate + repo → candidate issue set + dependency edges + Wave order. One heavy reasoning step, dispatched once. Read-only. |
+| Issue-author agent | `agents/issue-author.md` | Per-issue subagent: authors one issue's full spec to the §4 output contract so it passes the driver's triage clean. Read-only; returns issue text, never opens the issue. |
+| Hook: `no-source-edit` | `hooks/` (`hooks.json`, `run-hook.cmd`, `.sh`, `.ps1`) | `PreToolUse` (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`): unconditionally deny edits to the feeder's own `sourceGlobs`. The only mechanical gate the feeder needs — it authors no code and opens no PRs. See [The mechanical gate](#the-mechanical-gate). |
+| Manifest + registration | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json` | Plugin metadata (incl. the `superpowers` dependency), marketplace registration, and Claude-side hook registration. |
+| Refine skill | `skills/refine/SKILL.md` | **Planned (v0.2.0).** Idempotent re-run against an existing milestone: re-triage, patch gapped issues, fill missing edges. |
+| Self-check gate | (in `decompose`, §5) | **Planned (v0.2.0).** Dispatches the driver's `triage-reviewer` / `design-reviewer` against each generated issue before any emit. |
+| `--apply` GitHub write path | (in `decompose`, Step 7) | **Planned (v0.2.0).** Creates the milestone + issues + labels. This release writes no GitHub state on any path. |
+
+**Reused, not rebuilt (composability):** the v0.2.0 self-check dispatches
+`milestone-driver:triage-reviewer` and `:design-reviewer` directly against the
+generated issue text (no `gh` call of their own), so the feeder's quality bar *is*
+the driver's entry gate — no second, drifting definition of "well-formed"
+(`SPEC.md` §3, §5).
+
+## Plugin version
+
+The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.1.0`)
+as the single source of truth. There is **no per-PR version machinery** — the
+feeder opens no PRs and touches no branches, so the driver's bump-rides-the-PR
+mechanism has nothing to ride. The version is bumped by hand when a release is cut.
+`.claude-plugin/marketplace.json` carries no `version` field (Claude Code resolves
+`plugin.json` first).
+
+## Pipeline position
+
+The feeder is the driver's direct predecessor: it produces the input the driver
+assumes already exists — a milestone whose issues each pass the driver's triage
+clean (`GAPS: none`). Product gaps are parked, never invented (`SPEC.md` §2).
+
+```
+feature brief (file / inline / GitHub epic issue)
+        │   reads substrate (.project/) + .milestone-config/driver.json (shared keys)
+        ▼
+   ┌───────────────┐   milestone + issues    ┌──────────────────┐
+   │ milestone-feeder │ ──────────────────────▶ │ milestone-driver │ ──▶ merged PRs
+   └───────────────┘  (pass triage clean)     └──────────────────┘
+        │
+        └── parks PRODUCT gaps → "needs product input" report (never invents scope)
+```
+
+The park boundary is the load-bearing constraint: the feeder makes *design and
+implementation* calls when the substrate or a stated repo convention supplies the
+answer, and parks *product* calls — what to build, or user-facing behavior with no
+conventional default — to a "needs product input" report rather than guessing them.
+
+## The mechanical gate
+
+One `PreToolUse` hook, registered in `hooks/hooks.json` and invoked via the
+bash-first / pwsh-fallback `run-hook.cmd` launcher (fail-open). The feeder reads
+code and authors issue text — it never writes source — so the deny is
+**unconditional** (no subagent carve-out, unlike the driver's `force-subagent`).
+
+| Gate | Matcher | Mechanism |
+|---|---|---|
+| `no-source-edit` | `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | Unconditionally denies edits to the resolved `sourceGlobs`. Resolution: `<repo>/.milestone-config/feeder.json` first (self-protection of the feeder's own repo), then the driver config (`.milestone-config/driver.json` → root `milestone-driver.json`), else **fail-open**. `docs/**`, `.claude/**`, and `Obsidian/**` are always exempt. Escape hatch: `CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1`. |
+
+The `sourceGlobs` this gate reads is **self-protection only** — the feeder guarding
+its own repo — and is semantically distinct from the *consumer's* shared
+`sourceGlobs` that the feeder reads from the driver config when decomposing a target
+repo (`SPEC.md` §7; `docs/profile-schema.md`).
+
+## The decompose procedure
+
+The `decompose` skill runs `SPEC.md` §6 Steps 0–5 and emits a preview plan file at
+Step 6. Steps 6 (self-check) and 7 (`--apply`) are **planned for v0.2.0** — the
+preview pipeline is complete and self-contained without them.
+
+| Step | Action |
+|---|---|
+| 0 | Read `.milestone-config/feeder.json` (absent → auto-invoke `setup`); read the substrate under `substrateDir` (best-effort); resolve the shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) from the driver config. |
+| 1 | Ingest the brief — a GitHub epic issue (`#<n>`), a file path, or inline text — and normalize it internally first. |
+| 2 | **Product-gap check (the park boundary):** separate product decisions (no conventional default) from design/implementation decisions (resolvable from substrate/convention). Product gaps are recorded, not guessed. |
+| 3 | Dispatch the `decomposer` **once**: candidate issue set + dependency edges + Wave order, with local tags (not GitHub numbers). |
+| 4 | Dispatch the `issue-author` **per candidate** (parallelizable) → each issue's full §4 spec. |
+| 5 | Assemble the dependency graph; render the milestone description to the §4 Wave template (local slugs). |
+| 6 | **Emit (preview):** write a reviewable plan file to `.milestone-feeder/plan-<slug>.md`, plus a "needs product input" report when product gaps remain. **No GitHub writes.** |
+
+> **Planned (v0.2.0).** Step 6 self-check — dispatch the driver's `triage-reviewer`
+> (and `design-reviewer` for UI issues) against each generated issue, iterate to
+> clean or park, bounded retry (at most 2) — and Step 7 `--apply` (real GitHub
+> milestone + issue + label creation) ship in v0.2.0 (`SPEC.md` §6, §9). This
+> release recognizes the `--apply` token but writes no GitHub state on any path;
+> the plan file's self-check line records the gate as **deferred**, not passed.
+
+## Modes & autonomy
+
+| Mode | Trigger | Behavior |
+|---|---|---|
+| Decompose (preview) | `/milestone-feeder:decompose <brief>` | Full procedure, Steps 0–5; stops at a reviewable plan file. **No GitHub writes.** Shipped. |
+| Decompose (apply) | `… --apply` | Same, then creates the milestone + issues + labels. **Planned (v0.2.0).** The token is recognized but unimplemented this release. |
+| Refine | `/milestone-feeder:refine <milestone>` | Re-triage an existing milestone, patch gapped issues, fill missing edges. Idempotent. **Planned (v0.2.0).** |
+
+**Authoring-autonomy boundary.** The feeder makes design/implementation calls
+grounded in the substrate or a stated repo convention — and cites the grounding
+(`.project/<doc>.md#<section>` or a sibling `file:line`). It parks product calls —
+decisions with no conventional default — to the "needs product input" report. It
+authors no code, opens no PRs, and never touches branches (`SPEC.md` §8).
+
+## Output style
+
+The skills and agents follow a concise, tabular output norm: status and outcomes
+are stated flatly, steps / gates / lists / options are presented as tables rather
+than inline prose, and any item that needs a human is marked with 🔴.
+
+---
+
+For the product overview, see the [README](../README.md). For the full profile
+reference, see [`profile-schema.md`](profile-schema.md). For adopting the feeder in
+a repository, see [`consumer-setup.md`](consumer-setup.md).

--- a/docs/consumer-setup.md
+++ b/docs/consumer-setup.md
@@ -1,0 +1,105 @@
+# milestone-feeder — consumer setup
+
+Adopt milestone-feeder in a repository in four steps. Most of this is one-time
+wiring; after that, `/milestone-feeder:decompose <brief>` turns a feature brief
+into a reviewable milestone plan.
+
+## 1. Install the plugin
+
+Install `milestone-feeder` in Claude Code (dev-install via `claude --plugin-dir`,
+or from a marketplace once published). Confirm it is enabled with `/plugin`.
+
+| Plugin | Status | Why |
+|---|---|---|
+| [`superpowers`](https://github.com/anthropics/claude-code) | **Required** | A hard dependency, declared in `.claude-plugin/plugin.json`. The decompose pipeline depends on it. |
+| `milestone-driver` | **Optional** | Powers the `selfCheck: "milestone-driver"` mode — the feeder dispatches the driver's own `triage-reviewer` / `design-reviewer` as its pre-creation self-check (a v0.2.0 capability). |
+
+**The `milestone-driver` soft dependency.** When `milestone-driver` is installed,
+the self-check gate (v0.2.0) backs each generated issue with the driver's real
+reviewers, so the feeder's quality bar *is* the driver's entry gate. When it is
+**absent**, `selfCheck` degrades to `"internal"` — the feeder's own checklist
+mirroring the five triage criteria — and the pipeline still runs. The feeder also
+reads the driver's profile (`.milestone-config/driver.json`) for shared keys
+(`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`); these resolve to documented
+defaults when no driver profile is present, so a driver-less repo still works.
+
+## 2. Add the project profile
+
+The first time you run `/milestone-feeder:decompose`, the plugin **auto-invokes
+`/milestone-feeder:setup`** if `.milestone-config/feeder.json` is absent. The
+bootstrap infers every key it can from repo signals (the substrate directory, the
+resolvable driver profile, whether the driver's reviewers resolve) and presents
+detected defaults — you accept, edit, or skip. It writes the profile to
+`.milestone-config/feeder.json`, provisions the label taxonomy, and returns control
+so the original decompose continues immediately.
+
+Unlike the driver, the feeder has **no required hard-stop key** — it writes no
+branches and runs fully on bundled defaults, so an empty `{}` profile is valid (all
+defaults apply). Setup still writes the file even when every key defaults, so
+config-presence detection is unambiguous.
+
+You can also run `/milestone-feeder:setup` directly at any time to create or repair
+the profile.
+
+**Manual authoring (fallback).** Create `.milestone-config/feeder.json` by hand —
+see [`profile-schema.md`](profile-schema.md) for the full key reference. Every
+own-key has a bundled default, so omit any key you do not override (absent-means-
+default); a minimal profile carries only what diverges. Commit it so every clone
+and CI has the same `no-source-edit` behavior. Minimal example:
+
+```json
+{
+  "substrateDir": ".project/",
+  "selfCheck": "milestone-driver"
+}
+```
+
+## 3. Restart Claude Code
+
+The one mechanical gate — `no-source-edit` — is a plugin `PreToolUse` hook
+registered in `hooks/hooks.json`. It **loads at session start**, so restart Claude
+Code after installing or updating the plugin for the hook to take effect. No
+separate native-hook installation step is required.
+
+## 4. Provide the substrate
+
+The decompose pipeline grounds its issue authoring in the **substrate** — the
+project-constitution docs (vision, architecture, conventions) under the
+`substrateDir` (default `.project/`). The decomposer and issue-author read these
+to resolve design defaults: format conventions, naming, the existing patterns to
+mirror.
+
+The substrate is read **best-effort**: a missing directory is not an error, and a
+section that is absent or marked `[TBD]` is skipped, never grounded on. A **thin**
+substrate means more decisions have no conventional default — so more candidates
+get parked as product gaps rather than authored. Richer constitution docs → fewer
+parks, more issues authored clean.
+
+## What a preview run does
+
+`/milestone-feeder:decompose <brief>` runs the preview pipeline and writes a
+reviewable plan file. As a consumer, the shape that matters:
+
+| Stage | What happens |
+|---|---|
+| Read config + substrate | Loads `feeder.json` (auto-invokes `setup` if absent), reads the substrate best-effort, resolves shared keys from the driver config. |
+| Decompose | Dispatches the `decomposer` once → candidate issues + dependency edges + Wave order. |
+| Author | Dispatches the `issue-author` per candidate → each issue's full §4 spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared edges, UI/logic + risk). |
+| Emit (preview) | Writes a plan file to `.milestone-feeder/plan-<slug>.md` — the milestone description (Wave order) plus every authored issue body. Writes a "needs product input" report when product gaps remain. |
+
+**The park boundary.** A decision with no conventional default — what to build, or
+user-facing behavior the substrate and conventions do not answer — is **parked** to
+the "needs product input" report, never guessed. Decide each, record it, and re-run.
+
+**Preview only this release.** The decompose pipeline writes **no GitHub state** on
+any path: no milestone is created, no issue is opened, no label is applied, no
+comment is posted. The plan file is per-run scratch you review and discard (it is
+written under `.milestone-feeder/`, which the repo gitignores). Real GitHub creation
+(`--apply`) and the driver-backed self-check ship in **v0.2.0**; the `--apply` token
+is recognized this release but unimplemented, and the plan file's self-check line
+records the gate as **deferred**, not passed.
+
+---
+
+For the internal design reference, see [`architecture.md`](architecture.md). For
+the full profile reference, see [`profile-schema.md`](profile-schema.md).


### PR DESCRIPTION
## Summary
Documents the v0.1.0 preview slice as-built (issue #8): architecture reference, consumer runbook, genesis CHANGELOG, README alignment, and the plan-scratch `.gitignore` line. Final issue of v0.1.0.

Closes #8.

## Changes
- `docs/architecture.md` (new) — plugin-contents table (v0.2.0 components flagged "planned"), pipeline + park boundary, no-source-edit gate table, decompose Steps 0–5 table, modes & autonomy, version note, output style.
- `docs/consumer-setup.md` (new) — install (superpowers required, milestone-driver optional for self-check), profile, restart, substrate, "what a preview run does".
- `CHANGELOG.md` (new) — header + `## v0.1.0 — Preview slice` (theme + themed sections #1–#8 + consumer notes).
- `README.md` (edit) — status line → v0.1.0 shipped / v0.2.0 in progress; doc cross-links; dev-tools link → plain text (suite unpublished).
- `.gitignore` (edit) — `+/.milestone-feeder/` (anchored; ignores the decompose plan-scratch, NOT `.milestone-config/`).

## Decision Log
- Folded the `.gitignore` hygiene line here — the docs claim the plan file is gitignored scratch; this makes that true (pairs with `.milestone-driver-*`).
- Anchored `/.milestone-feeder/` so it can't match `.milestone-config/` (verified).
- Dropped the dev-tools markdown link to plain text (suite linkage deferred; relative link renders broken on GitHub).
- Marked self-check/--apply/refine "planned (v0.2.0)" throughout (as-built truth).

## Code Review
- /code-review run: yes (medium effort, light profile) — independent verification of as-built accuracy + gitignore scoping + CHANGELOG anchor.
- Findings: 0 — docs cross-checked against source (gate, resolution chain, plan-scratch path, version); `.gitignore` correctly scoped; `## v0.1.0` heading present; validate ✔; scope = the 5 named files.
  - none
- No park-triggering findings.
- Version: no bump.

## Verification (no test layer)
- `claude plugin validate .` → ✔
- `git check-ignore`: `.milestone-feeder/` ignored, `.milestone-config/` NOT
- CHANGELOG `## v0.1.0 — Preview slice` present; README status line updated; UTF-8 no BOM, LF
- scope: `docs/architecture.md`, `docs/consumer-setup.md`, `CHANGELOG.md` (new); `README.md`, `.gitignore` (edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
