### PR TITLE
docs: document the as-built v0.2.0 surface (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.2.0 — Gate & apply
+
+**Theme:** The feeder grows teeth and a write hand. The preview slice now runs the
+**same self-check gate that fronts the driver's build loop** against every generated
+issue before emit — so what the feeder ships passes the driver's triage clean — and
+gains an `--apply` path that turns the gate-surviving plan into a real GitHub
+milestone + issues + labels. A new `refine` skill re-vets and patches a milestone
+that already exists. Preview stays the default and still writes no GitHub state; the
+gate runs on every path; product calls are still parked, never invented; the feeder
+still authors no code.
+
+### ✨ The self-check gate
+
+| Issue | What |
+|---|---|
+| #9 | The self-check gate (decompose Step 6, §6.1–§6.6): dispatches the driver's `triage-reviewer` (and `design-reviewer` for UI issues) against each generated issue before emit, gating on the returned `GAPS` block. Three backends — `"milestone-driver"` (degrades to `"internal"` at runtime if the reviewers don't resolve, with a per-issue fallback), `"internal"` (built-in checklist mirroring the five triage criteria), and `false` (skip with a visible 🔴 warning). FAILed issues are re-authored (≤2 retries) or parked; undeclared edges are absorbed and the Wave order re-rendered. Runs in preview too — no GitHub writes. Also reads `nonNegotiables` from the driver profile as a reviewer input. |
+
+### ✨ The `--apply` GitHub-write path
+
+| Issue | What |
+|---|---|
+| #10 | The `--apply` path (decompose Step 7 §7-apply): preview stays the default; `--apply` ensures the four labels idempotently, creates-or-adopts the milestone by exact title (reopen-if-closed, never deletes), creates each gate-surviving issue, rewrites slug→`#n` references (substring-safe) in the issue bodies and the milestone description, PATCHes the Wave-encoded milestone description, and files the needs-product-input report (epic comment on apply / local file otherwise). Idempotent re-apply via adopt + match-by-title; a defined partial-failure resume path. All `gh` writes are performed by the skill itself — every dispatched agent stays read-only. |
+
+### ✨ The refine skill
+
+| Issue | What |
+|---|---|
+| #11 | The `refine` skill (`/milestone-feeder:refine <milestone>`): an idempotent re-run against an **existing** milestone. Re-triages its live issues (their real GitHub comments + live bodies) through the #9 gate, patches gapped bodies, fills missing dependency edges, and re-renders the Wave order. Preview (default) writes a diff-style patch plan; `--apply` edits the live issues. Creates and deletes no issues; an issue already at `GAPS: none` is left byte-unchanged; a clean milestone is a true no-op. Reuses decompose's gate (Step 6) and `--apply` write-primitives (§7-apply) by reference — no second, drifting definition. |
+
+### ✨ Docs
+
+| Issue | What |
+|---|---|
+| #12 | This docs update to the as-built v0.2.0 surface: `docs/architecture.md` (the self-check gate result→action table, the Step 7 `--apply` write order, the apply/refine modes — flipped from "Planned (v0.2.0)" to shipped), `docs/consumer-setup.md` (the optional `milestone-driver` self-check backend, the preview-then-apply flow, the refine flow), `docs/profile-schema.md` (the `nonNegotiables` reviewer input note), the README status alignment to the shipped v0.2.0 surface, and this CHANGELOG. |
+
+### Consumer notes
+
+- **`milestone-driver` is the optional self-check backend.** It powers `selfCheck: "milestone-driver"`; absent → the gate degrades to `"internal"` and the pipeline still runs. It also supplies the shared keys and `nonNegotiables` the feeder reads.
+- **Preview is still the default; `--apply` writes GitHub state.** Preview writes a reviewable plan file and no GitHub state on any path. `--apply` creates the milestone + issues + labels (and an epic comment for a GitHub-epic brief), idempotently on re-run.
+- **`refine` maintains an existing milestone.** It re-vets and patches live issues; it creates and deletes no issues, and a clean milestone is a no-op.
+
 ## v0.1.0 — Preview slice
 
 **Theme:** The first runnable slice of the feeder: a plugin scaffold with one

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin that turns a feature brief into a **GitHub milestone + smal
 
 Its quality bar is concrete — every issue it emits passes the driver's own triage clean (`GAPS: none`), because the feeder reuses the driver's actual reviewer agents as a pre-creation self-check.
 
-Status: **v0.1.0 (preview slice) shipped; v0.2.0 (self-check, `--apply`, refine) in progress.** The full design is in [SPEC.md](SPEC.md); the as-built design reference is in [docs/architecture.md](docs/architecture.md), and adopting the feeder is documented in [docs/consumer-setup.md](docs/consumer-setup.md). Part of the dev-tools suite.
+Status: **v0.2.0 shipped — the self-check gate, `--apply`, and `refine` are all delivered** (v0.1.0 shipped the preview slice). The full design is in [SPEC.md](SPEC.md); the as-built design reference is in [docs/architecture.md](docs/architecture.md), and adopting the feeder is documented in [docs/consumer-setup.md](docs/consumer-setup.md). Part of the dev-tools suite.
 
 ## At a glance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,30 +8,32 @@ and the design defaults the engine grounds its decomposition in.
 
 ## Plugin contents
 
-The as-built v0.1.0 components. Components marked **planned (v0.2.0)** are specified
-in `SPEC.md` but not shipped in this release (see [The decompose procedure](#the-decompose-procedure)).
+The as-built v0.2.0 components. The self-check gate, the `--apply` GitHub-write
+path, and the `refine` skill all shipped in v0.2.0 (see
+[The self-check gate](#the-self-check-gate) and [The decompose procedure](#the-decompose-procedure)).
 
 | Component | Path | Purpose |
 |---|---|---|
 | Setup skill | `skills/setup/SKILL.md` | First-run profile bootstrap: infer keys from repo signals, write `.milestone-config/feeder.json`, provision the label taxonomy aligned to the driver's. Auto-invoked by `decompose` when the profile is absent. Mirrors `milestone-driver:setup`. |
-| Decompose skill | `skills/decompose/SKILL.md` | Orchestrator: brief → milestone + issues. Runs Steps 0–5 and emits a reviewable plan file. `/milestone-feeder:decompose <brief>` — **preview only** this release. |
+| Decompose skill | `skills/decompose/SKILL.md` | Orchestrator: brief → milestone + issues. Runs Steps 0–6 (incl. the self-check gate) and emits at Step 7 — a reviewable plan file (preview, default) or the GitHub artifacts (`--apply`). `/milestone-feeder:decompose <brief>`. |
 | Decomposer agent | `agents/decomposer.md` | Architect lens: brief + substrate + repo → candidate issue set + dependency edges + Wave order. One heavy reasoning step, dispatched once. Read-only. |
 | Issue-author agent | `agents/issue-author.md` | Per-issue subagent: authors one issue's full spec to the §4 output contract so it passes the driver's triage clean. Read-only; returns issue text, never opens the issue. |
 | Hook: `no-source-edit` | `hooks/` (`hooks.json`, `run-hook.cmd`, `.sh`, `.ps1`) | `PreToolUse` (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`): unconditionally deny edits to the feeder's own `sourceGlobs`. The only mechanical gate the feeder needs — it authors no code and opens no PRs. See [The mechanical gate](#the-mechanical-gate). |
 | Manifest + registration | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json` | Plugin metadata (incl. the `superpowers` dependency), marketplace registration, and Claude-side hook registration. |
-| Refine skill | `skills/refine/SKILL.md` | **Planned (v0.2.0).** Idempotent re-run against an existing milestone: re-triage, patch gapped issues, fill missing edges. |
-| Self-check gate | (in `decompose`, §5) | **Planned (v0.2.0).** Dispatches the driver's `triage-reviewer` / `design-reviewer` against each generated issue before any emit. |
-| `--apply` GitHub write path | (in `decompose`, Step 7) | **Planned (v0.2.0).** Creates the milestone + issues + labels. This release writes no GitHub state on any path. |
+| Refine skill | `skills/refine/SKILL.md` | Idempotent re-run against an existing milestone: re-triage live issues through the self-check gate, patch gapped bodies, fill missing edges, re-render the Wave order. `/milestone-feeder:refine <milestone>`. Creates and deletes no issues; a clean milestone is a no-op. Reuses decompose's gate (Step 6) and `--apply` write-primitives (§7-apply) by reference. |
+| Self-check gate | (in `decompose`, Step 6 §6.1–§6.6; `SPEC.md` §5) | Dispatches the driver's `triage-reviewer` / `design-reviewer` against each generated issue before any emit; runs in preview too (it writes no GitHub state). Three backends — `"milestone-driver"`, `"internal"`, `false`. See [The self-check gate](#the-self-check-gate). |
+| `--apply` GitHub write path | (in `decompose`, Step 7 §7-apply) | Ensures the labels idempotently, creates-or-adopts the milestone by title, opens each gate-surviving issue, rewrites slug→`#n` references, PATCHes the Wave-encoded milestone description, and files the needs-product-input report (epic comment on apply / local file otherwise). Idempotent re-apply via adopt + match-by-title. |
 
-**Reused, not rebuilt (composability):** the v0.2.0 self-check dispatches
+**Reused, not rebuilt (composability):** the self-check dispatches
 `milestone-driver:triage-reviewer` and `:design-reviewer` directly against the
 generated issue text (no `gh` call of their own), so the feeder's quality bar *is*
 the driver's entry gate — no second, drifting definition of "well-formed"
-(`SPEC.md` §3, §5).
+(`SPEC.md` §3, §5). `refine` reuses the same gate and the `--apply` write-primitives
+by reference rather than re-deriving a drifting copy.
 
 ## Plugin version
 
-The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.1.0`)
+The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.2.0`)
 as the single source of truth. There is **no per-PR version machinery** — the
 feeder opens no PRs and touches no branches, so the driver's bump-rides-the-PR
 mechanism has nothing to ride. The version is bumped by hand when a release is cut.
@@ -78,34 +80,79 @@ repo (`SPEC.md` §7; `docs/profile-schema.md`).
 
 ## The decompose procedure
 
-The `decompose` skill runs `SPEC.md` §6 Steps 0–5 and emits a preview plan file at
-Step 6. Steps 6 (self-check) and 7 (`--apply`) are **planned for v0.2.0** — the
-preview pipeline is complete and self-contained without them.
+The `decompose` skill runs `SPEC.md` §6 Steps 0–6 (the self-check gate is Step 6)
+and emits at Step 7 — a preview plan file by default, or the GitHub artifacts on
+`--apply`. The self-check gate runs on **both** paths (it writes no GitHub state);
+only Step 7 `--apply` writes GitHub state.
 
 | Step | Action |
 |---|---|
-| 0 | Read `.milestone-config/feeder.json` (absent → auto-invoke `setup`); read the substrate under `substrateDir` (best-effort); resolve the shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) from the driver config. |
+| 0 | Read `.milestone-config/feeder.json` (absent → auto-invoke `setup`); read the substrate under `substrateDir` (best-effort); resolve the shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) from the driver config, plus `nonNegotiables` (the additional reviewer-profile input the gate passes through). |
 | 1 | Ingest the brief — a GitHub epic issue (`#<n>`), a file path, or inline text — and normalize it internally first. |
 | 2 | **Product-gap check (the park boundary):** separate product decisions (no conventional default) from design/implementation decisions (resolvable from substrate/convention). Product gaps are recorded, not guessed. |
 | 3 | Dispatch the `decomposer` **once**: candidate issue set + dependency edges + Wave order, with local tags (not GitHub numbers). |
 | 4 | Dispatch the `issue-author` **per candidate** (parallelizable) → each issue's full §4 spec. |
 | 5 | Assemble the dependency graph; render the milestone description to the §4 Wave template (local slugs). |
-| 6 | **Emit (preview):** write a reviewable plan file to `.milestone-feeder/plan-<slug>.md`, plus a "needs product input" report when product gaps remain. **No GitHub writes.** |
+| 6 | **Self-check gate** (the keystone): vet every generated issue against the same gate that fronts the driver's build loop. Iterate each FAILed issue to clean (≤2 `issue-author` re-dispatches) or park it. Runs in preview too — **no GitHub writes.** See [The self-check gate](#the-self-check-gate). |
+| 7 | **Emit.** Preview (default) writes a reviewable plan file to `.milestone-feeder/plan-<slug>.md`, plus a "needs product input" report when product gaps remain — **no GitHub writes**. `--apply` runs the preview emit first (the local audit record), then creates the GitHub artifacts. |
 
-> **Planned (v0.2.0).** Step 6 self-check — dispatch the driver's `triage-reviewer`
-> (and `design-reviewer` for UI issues) against each generated issue, iterate to
-> clean or park, bounded retry (at most 2) — and Step 7 `--apply` (real GitHub
-> milestone + issue + label creation) ship in v0.2.0 (`SPEC.md` §6, §9). This
-> release recognizes the `--apply` token but writes no GitHub state on any path;
-> the plan file's self-check line records the gate as **deferred**, not passed.
+### The Step 7 `--apply` write order
+
+On `--apply`, the skill itself (never a dispatched agent — the agent-read-only
+invariant holds) performs the GitHub writes in a fixed order. Only the
+**gate-surviving** issues are created; parked and dropped issues are never created.
+
+| Pass | Write |
+|---|---|
+| a | **Ensure labels idempotently** (`gh label create --force`) before any issue references them — the four-label taxonomy (`ui`/`logic`/`risk:light`/`risk:heavy`). |
+| b | **Create-or-adopt the milestone by exact title** (quote-safe `env.t` resolve): no match → create; one match → adopt (reopen if closed); multiple → adopt the first and log. Never deletes. |
+| c | **Create each gate-surviving issue** in Wave order, applying its `ui`/`logic` + `risk:*` labels; build the slug→`#n` map. On adopt, title-matched open issues are reused (no duplicate) and their bodies left as-is. |
+| d | **Second pass — rewrite slug→`#n`** (substring-safe) in each newly-created issue body and in the milestone description, then `gh issue edit`/`gh api PATCH`. Two passes are required because numbers don't exist until pass (c). |
+| e | **File the needs-product-input report** — epic comment on `--apply` when the brief was a GitHub epic, else a local file. |
+
+Idempotent re-apply relies on stable, exact, open issue titles: the adopt +
+match-by-title path reuses existing issues rather than duplicating them, and pass
+(d) is a no-op against already-numeric bodies/descriptions.
+
+## The self-check gate
+
+Before emitting, `decompose` vets **every generated issue** with the same gate
+that fronts the driver's build loop, so what the feeder emits passes the driver's
+triage clean (`SPEC.md` §5; Step 6 §6.1–§6.6). Each reviewer is dispatched
+**read-only against the generated text** — no `gh` call of its own. `refine` runs
+the same gate against a milestone's **live** issues (real comments, the live
+description, real `#n`).
+
+### Backends (`selfCheck`)
+
+| `selfCheck` | Backend |
+|---|---|
+| `"milestone-driver"` (default) | Dispatch `milestone-driver:triage-reviewer` per generated issue (and `:design-reviewer` when its triage returns `NEEDS_DESIGN_REVIEW: yes`). If the reviewers do not resolve at dispatch time, **degrade to `"internal"`** for the run (a notice, never a failure); a later single-issue non-resolution falls back to the internal checklist for that one issue. |
+| `"internal"` | Run the built-in checklist mirroring the five triage criteria (consistency, buildability, completeness, dependencies, UI flag). Same pass/Blocker verdict shape, so the gate logic is backend-agnostic. |
+| `false` | **Skip the gate** with a visible 🔴 warning to the user, recorded as `SKIPPED (selfCheck:false)` in the plan-file status line. Generated issues are NOT vetted. |
+
+### Result → action (`SPEC.md` §5)
+
+| Aggregated result | Action |
+|---|---|
+| `GAPS: none` for every dispatched block | **PASS** — the issue clears the gate; proceed to emit (Step 7). |
+| Blocker, design/implementation-resolvable | **Re-dispatch `issue-author`** to fix, bounded to **≤2** re-dispatches per issue (the same cap the driver uses on every gate), then re-run the gate. |
+| Blocker, genuine **product** gap | **Park** to the "needs product input" report; never invented. |
+| Still-Blocker after 2 retries | **Park as needs-human-direction** (the candidate's design is likely wrong). |
+
+`severity: Advisory` entries do **not** fail the gate — they are recorded as notes,
+not retried. An `undeclared-dependency` Blocker is absorbed into the graph and the
+Wave order re-rendered (§6.6), not routed through the re-author path. A parked issue
+and every issue that transitively depends on it are dropped from the emitted
+milestone.
 
 ## Modes & autonomy
 
 | Mode | Trigger | Behavior |
 |---|---|---|
-| Decompose (preview) | `/milestone-feeder:decompose <brief>` | Full procedure, Steps 0–5; stops at a reviewable plan file. **No GitHub writes.** Shipped. |
-| Decompose (apply) | `… --apply` | Same, then creates the milestone + issues + labels. **Planned (v0.2.0).** The token is recognized but unimplemented this release. |
-| Refine | `/milestone-feeder:refine <milestone>` | Re-triage an existing milestone, patch gapped issues, fill missing edges. Idempotent. **Planned (v0.2.0).** |
+| Decompose (preview) | `/milestone-feeder:decompose <brief>` | Full procedure, Steps 0–6 (incl. the self-check gate); stops at a reviewable plan file. **No GitHub writes.** Shipped (v0.2.0). |
+| Decompose (apply) | `… --apply` | Same, then creates the milestone + issues + labels (and an epic comment for a GitHub-epic brief). Shipped (v0.2.0). |
+| Refine | `/milestone-feeder:refine <milestone>` | Re-triage an **existing** milestone's live issues through the self-check gate, patch gapped bodies, fill missing edges, re-render the Wave order. Preview (default) writes a diff-style patch plan; `--apply` edits the live issues. Creates and deletes no issues; a clean milestone is a true no-op (writes nothing). Shipped (v0.2.0). |
 
 **Authoring-autonomy boundary.** The feeder makes design/implementation calls
 grounded in the substrate or a stated repo convention — and cites the grounding

--- a/docs/consumer-setup.md
+++ b/docs/consumer-setup.md
@@ -1,8 +1,9 @@
 # milestone-feeder — consumer setup
 
 Adopt milestone-feeder in a repository in four steps. Most of this is one-time
-wiring; after that, `/milestone-feeder:decompose <brief>` turns a feature brief
-into a reviewable milestone plan.
+wiring; after that, `/milestone-feeder:decompose <brief>` previews a milestone
+plan, `… --apply` creates it on GitHub, and `/milestone-feeder:refine <milestone>`
+re-vets and patches one that already exists.
 
 ## 1. Install the plugin
 
@@ -12,15 +13,19 @@ or from a marketplace once published). Confirm it is enabled with `/plugin`.
 | Plugin | Status | Why |
 |---|---|---|
 | [`superpowers`](https://github.com/anthropics/claude-code) | **Required** | A hard dependency, declared in `.claude-plugin/plugin.json`. The decompose pipeline depends on it. |
-| `milestone-driver` | **Optional** | Powers the `selfCheck: "milestone-driver"` mode — the feeder dispatches the driver's own `triage-reviewer` / `design-reviewer` as its pre-creation self-check (a v0.2.0 capability). |
+| `milestone-driver` | **Optional** | The backend for the `selfCheck: "milestone-driver"` self-check mode — the feeder dispatches the driver's own `triage-reviewer` / `design-reviewer` as its pre-emit self-check gate. **Absent → degrades to `"internal"`**, and the pipeline still runs. |
 
-**The `milestone-driver` soft dependency.** When `milestone-driver` is installed,
-the self-check gate (v0.2.0) backs each generated issue with the driver's real
-reviewers, so the feeder's quality bar *is* the driver's entry gate. When it is
-**absent**, `selfCheck` degrades to `"internal"` — the feeder's own checklist
-mirroring the five triage criteria — and the pipeline still runs. The feeder also
-reads the driver's profile (`.milestone-config/driver.json`) for shared keys
-(`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`); these resolve to documented
+**The `milestone-driver` soft dependency.** `milestone-driver` is the **optional
+backend** for the `"milestone-driver"` self-check mode. When it is installed, the
+self-check gate backs each generated (or, in `refine`, each live) issue with the
+driver's real reviewers, so the feeder's quality bar *is* the driver's entry gate.
+When it is **absent**, `selfCheck` degrades to `"internal"` at runtime — the
+feeder's own checklist mirroring the five triage criteria — and the pipeline still
+runs. (Setting `selfCheck: false` skips the gate entirely, with a visible 🔴
+warning that the issues were not vetted.) The feeder also reads the driver's
+profile (`.milestone-config/driver.json`) for shared keys (`sourceGlobs`,
+`uiSurfaceGlobs`, `integrationBranch`) and `nonNegotiables` (the version/platform
+constraints the gate's reviewer checks against); these resolve to documented
 defaults when no driver profile is present, so a driver-less repo still works.
 
 ## 2. Add the project profile
@@ -75,29 +80,55 @@ substrate means more decisions have no conventional default — so more candidat
 get parked as product gaps rather than authored. Richer constitution docs → fewer
 parks, more issues authored clean.
 
-## What a preview run does
+## What a decompose run does
 
-`/milestone-feeder:decompose <brief>` runs the preview pipeline and writes a
-reviewable plan file. As a consumer, the shape that matters:
+`/milestone-feeder:decompose <brief>` runs the full pipeline. As a consumer, the
+shape that matters:
 
 | Stage | What happens |
 |---|---|
-| Read config + substrate | Loads `feeder.json` (auto-invokes `setup` if absent), reads the substrate best-effort, resolves shared keys from the driver config. |
+| Read config + substrate | Loads `feeder.json` (auto-invokes `setup` if absent), reads the substrate best-effort, resolves shared keys (and `nonNegotiables`) from the driver config. |
 | Decompose | Dispatches the `decomposer` once → candidate issues + dependency edges + Wave order. |
 | Author | Dispatches the `issue-author` per candidate → each issue's full §4 spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared edges, UI/logic + risk). |
-| Emit (preview) | Writes a plan file to `.milestone-feeder/plan-<slug>.md` — the milestone description (Wave order) plus every authored issue body. Writes a "needs product input" report when product gaps remain. |
+| Self-check gate | Vets every generated issue against the same gate that fronts the driver's build loop (the driver's reviewers when `selfCheck: "milestone-driver"`, else the internal checklist). FAILed issues are re-authored (≤2 retries) or parked. Runs on every path — **no GitHub writes.** |
+| Emit | **Preview (default):** writes a plan file to `.milestone-feeder/plan-<slug>.md` — the milestone description (Wave order) plus every gate-surviving issue body — and a "needs product input" report when product gaps remain. **No GitHub writes.** **`--apply`:** writes the plan file as the local record, then creates the GitHub artifacts. |
 
 **The park boundary.** A decision with no conventional default — what to build, or
 user-facing behavior the substrate and conventions do not answer — is **parked** to
 the "needs product input" report, never guessed. Decide each, record it, and re-run.
 
-**Preview only this release.** The decompose pipeline writes **no GitHub state** on
-any path: no milestone is created, no issue is opened, no label is applied, no
-comment is posted. The plan file is per-run scratch you review and discard (it is
-written under `.milestone-feeder/`, which the repo gitignores). Real GitHub creation
-(`--apply`) and the driver-backed self-check ship in **v0.2.0**; the `--apply` token
-is recognized this release but unimplemented, and the plan file's self-check line
-records the gate as **deferred**, not passed.
+## The preview-then-apply flow
+
+Issue creation is consequential and the feeder is exactly the stage where human
+product input matters most, so the flow is **preview, review, then apply** — never
+fully autonomous creation. End to end:
+
+| Step | Command | What happens |
+|---|---|---|
+| 1. Preview | `/milestone-feeder:decompose <brief>` | Runs the full pipeline including the self-check gate and stops at a **plan file** (`.milestone-feeder/plan-<slug>.md`). **No GitHub state is written** — no milestone, no issue, no label, no comment. |
+| 2. Review | *(read the plan file)* | Read the milestone description (Wave order), every gate-surviving issue body, and the "needs product input" report. Resolve any parked product gaps and re-run the preview until the plan is right. |
+| 3. Apply | `/milestone-feeder:decompose <brief> --apply` | Re-runs the pipeline, then creates the GitHub artifacts: ensures the four labels, **creates-or-adopts the milestone by title** (reopening it if closed, never deleting), opens each gate-surviving issue, rewrites the slug references to real issue numbers in the issue bodies and the milestone description, and files the needs-product-input report (a comment on the epic for a GitHub-epic brief, else a local file). |
+
+`--apply` is **idempotent on re-run**: it adopts the existing milestone and matches
+issues by exact title, so re-applying reuses what exists rather than duplicating it.
+The plan file is per-run scratch you review and discard (it is written under
+`.milestone-feeder/`, which the repo gitignores).
+
+## Refining an existing milestone
+
+`/milestone-feeder:refine <milestone>` re-vets and repairs a milestone that
+**already exists** — the maintenance counterpart of `decompose`. Where `decompose`
+*creates* a milestone, `refine` *re-vets and patches* one, **creating and deleting
+no issues**:
+
+| Step | Command | What happens |
+|---|---|---|
+| 1. Preview | `/milestone-feeder:refine <milestone>` | Loads the milestone's live issues (bodies + their real GitHub comments), re-triages each through the self-check gate, and writes a **diff-style patch plan** (`.milestone-feeder/refine-plan-<slug>.md`) showing the proposed body patches, added labels, and added dependency edges. **No GitHub writes.** |
+| 2. Apply | `/milestone-feeder:refine <milestone> --apply` | Edits the gapped live issue bodies, adds the implied labels, fills missing edges, and re-renders the milestone description's Wave order. An issue already at `GAPS: none` is left **byte-unchanged**; a **fully-clean milestone is a true no-op** — refine writes nothing and says so. |
+
+Refine is **idempotent**: re-running it on a milestone it just patched is a no-op.
+If the named milestone does not exist, refine **stops** (it never creates one — run
+`decompose` first).
 
 ---
 

--- a/docs/profile-schema.md
+++ b/docs/profile-schema.md
@@ -112,6 +112,16 @@ wins. The consumer's shared `sourceGlobs` here is the path set the feeder uses
 when authoring issues for a target repo — distinct from the self-protection
 `sourceGlobs` of resolution chain 1.
 
+**`nonNegotiables` — the self-check gate's additional reviewer input.** Beyond the
+three shared keys above, the self-check gate (decompose Step 6) also reads
+`nonNegotiables` from the driver profile, resolved down the **same chain**
+(`.milestone-config/driver.json` → root `milestone-driver.json` → absent →
+**omitted**, never invented). It is **not** a fourth shared key — it is the
+additional reviewer-profile input the gate passes through to the driver's
+`triage-reviewer`: the framework / platform / version constraints the reviewer
+checks each issue against. Absent → the reviewer simply has no version/platform
+constraints to check.
+
 ### `.milestone-config/` migration note
 
 Adopting `.milestone-config/` suite-wide means the driver resolves its profile


### PR DESCRIPTION
Closes #12.

## Summary
Documents the fully-built v0.2.0 surface across the docs: `architecture.md` (self-check gate section with the SPEC §5 result→action table + the three backends; the `--apply` write-order table; decompose/`--apply`/refine in the modes table — all flipped from "Planned (v0.2.0)" to shipped), `consumer-setup.md` (milestone-driver as the optional self-check backend that degrades to `internal`; the preview-then-apply + refine flows end to end), `profile-schema.md` (notes `nonNegotiables` as the self-check reviewer input, shared-keys count stays 3), `CHANGELOG.md` (`## v0.2.0` entry covering #9–#12, matching the v0.1.0 format), and `README.md` (status → v0.2.0 shipped).

Doc-only, light profile, non-UI → auto-merge on green. **Note:** this PR authors the `## v0.2.0` CHANGELOG entry, so the milestone's CHANGELOG step is idempotent (it will detect the heading and skip).

## Code Review
- /code-review run: yes (medium effort, light profile)
- Findings: 2 finders. Accuracy finder → clean (all claims match the as-built skills; all ACs met; no stale markers; version consistent). Consistency finder → 1 real cross-doc contradiction + 2 minor, all resolved:
  - **README still said "v0.2.0 … in progress"** while every other doc declared it shipped → fixed (status line flipped). The README was outside #12's literal AC file-list, but a front-door doc contradicting the release is squarely the issue's "describe the complete plugin" intent (and the v0.1.0 #8 precedent aligned the README) — fixed-and-logged as an in-scope-by-spirit doc fix, not a park.
  - CHANGELOG #12 entry now lists README.md (matches the #8 precedent).
  - architecture.md 5th triage criterion renamed "UI/design" → "UI flag" (SPEC §4 canonical term).
- Doc-only fix → committed directly (no `/code-review` re-run required for `*.md` per the pipeline; `tests-green` no-ops on doc-only).
- No park-triggering findings.
- Version: already 0.2.0 — no bump.

## Verification (no test layer)
`claude plugin validate .` → ✔ Validation passed. Each doc edit re-read against the as-built skills (decompose §6/§7-apply, refine) for accuracy. Grep confirms no remaining "Planned (v0.2.0)"/"in progress"/"deferred" markers for shipped features. `git diff` touches only README.md, CHANGELOG.md, docs/architecture.md, docs/consumer-setup.md, docs/profile-schema.md.

### Build note (not blocking)
`claude plugin validate` validates only the marketplace manifest, **not** skill frontmatter or docs — discovered mid-build via a break-and-restore probe. Throughout this milestone, skill/doc well-formedness was therefore verified by direct re-read + AC trace + multi-pass review, not by the validator alone.