### PR TITLE
test: credibility harness (4/4 green) + README right-sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ desktop.ini
 # milestone-feeder decompose preview plan-scratch (per-run, e.g.
 # .milestone-feeder/plan-<slug>.md) — reviewed and discarded, never committed.
 # NOTE: does not match .milestone-config/ (the committed feeder/driver profiles).
-/.milestone-feeder/
+# Un-anchored so it matches at any depth (e.g. under tests/scenarios/<n>/).
+.milestone-feeder/

--- a/README.md
+++ b/README.md
@@ -14,22 +14,35 @@ Issue creation is consequential, so it previews a reviewable plan by default and
 - **Output:** a milestone whose description encodes the Wave/dependency order, and small issues each carrying complete acceptance criteria, recorded consistent design, declared dependencies, and UI/logic + risk classification.
 - **Safety:** previews a reviewable plan by default; `--apply` creates the milestone/issues. Authors no code, opens no PRs. Parks product decisions rather than inventing scope.
 
-## What makes it different
-
-Most brief-to-issues assistants ship their own notion of a "well-formed" issue — a second definition that drifts from whatever actually gates the build. milestone-feeder has no second definition. Its quality bar *is* the driver's entry gate: before creating anything, it dispatches the driver's real `triage-reviewer` (and `design-reviewer` for UI issues) against each generated issue as a pre-creation self-check. An issue is only emitted once it passes that gate clean, so what the feeder hands the driver passes the driver's triage the first time — no drift, no rework loop between the two tools.
-
 ## Quickstart
 
-Install the plugin. It pulls in the required superpowers dependency:
+**1. Install** (it pulls in the required superpowers dependency), then restart Claude Code so the hook loads:
 
 ```
 /plugin marketplace add kenmulford/milestone-feeder
 /plugin install milestone-feeder@milestone-feeder
 ```
 
-Restart Claude Code after install so the plugin hooks load.
+**2. Run it — no config needed to start.** Put your feature idea in a file (a paragraph is plenty), preview the milestone it *would* create, then create it:
 
-Add a `.milestone-config/feeder.json` profile — or don't. Every feeder key has a bundled default, so an empty `{}` is a valid profile (all defaults apply) and there are no required keys. The consumer-facing shared keys (`uiSurfaceGlobs`, `integrationBranch`, and the consumer's `sourceGlobs`) are read from the driver config, not duplicated here. A minimal profile carries only what diverges:
+```
+# A brief can be a file, inline text, or a GitHub epic issue (e.g. #42).
+/milestone-feeder:decompose myfeature.md
+#   → writes a reviewable plan file and creates NOTHING on GitHub. Read it first.
+
+/milestone-feeder:decompose myfeature.md --apply
+#   → now creates the milestone + issues + labels on GitHub.
+```
+
+That's the whole loop: **preview → read the plan → `--apply`**. No profile yet? The first run bootstraps one with you. To re-vet a milestone you already created — re-triage it, patch gappy issues, fill missing dependency edges — run `/milestone-feeder:refine "<milestone title>"`.
+
+**3. Ground it in your project (optional — but it's where the quality comes from).** The feeder writes far better, more consistent issues when it can read your project's standing docs. Configure it in `.milestone-config/feeder.json`; every key has a default, so this is optional:
+
+- **`substrateDir`** (default `.project/`) — the folder holding your project's *standing docs*: architecture notes, coding conventions, a design system. The feeder reads these and **grounds every issue in your actual conventions** — it records "reuse the shared `FormField` component" with a citation instead of inventing a design. A cross-cutting rule you put here (e.g. "all tables paginate at 30 rows/page") propagates into every issue it touches. The richer this folder, the better the issues and the fewer decisions the feeder has to hand back to you.
+- **`selfCheck`** (default `"milestone-driver"`) — the quality gate that vets every issue *before* it's created: `"milestone-driver"` uses the driver's real reviewers, `"internal"` uses a built-in checklist that mirrors them, `false` turns it off (with a visible warning). Leave it on.
+- The build-side keys it needs (`uiSurfaceGlobs`, `integrationBranch`, and your repo's `sourceGlobs`) are **read from your milestone-driver config** — you don't repeat them here.
+
+A minimal profile, then, is just the bits that differ from the defaults — often nothing:
 
 ```json
 {
@@ -38,15 +51,11 @@ Add a `.milestone-config/feeder.json` profile — or don't. Every feeder key has
 }
 ```
 
-Preview a milestone from a brief, then create it on GitHub, then re-vet one that already exists:
+Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every profile key explained: [docs/profile-schema.md](docs/profile-schema.md).
 
-```
-/milestone-feeder:decompose <brief>
-/milestone-feeder:decompose <brief> --apply
-/milestone-feeder:refine <milestone>
-```
+## What makes it different
 
-`decompose` previews by default — it writes a reviewable plan file and creates nothing on GitHub; `--apply` is the only path that writes GitHub state. No profile yet? On the first run the setup skill bootstraps one with you. Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every profile key: [docs/profile-schema.md](docs/profile-schema.md).
+Most brief-to-issues assistants ship their own notion of a "well-formed" issue — a second definition that drifts from whatever actually gates the build. milestone-feeder has no second definition. Its quality bar *is* the driver's entry gate: before creating anything, it dispatches the driver's real `triage-reviewer` (and `design-reviewer` for UI issues) against each generated issue as a pre-creation self-check. An issue is only emitted once it passes that gate clean, so what the feeder hands the driver passes the driver's triage the first time — no drift, no rework loop between the two tools.
 
 ## When to use it
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 Turn a feature brief into a build-ready milestone.
 
-milestone-feeder is a Claude Code plugin. You hand it a feature brief — a file, inline text, or a GitHub epic issue — and it produces a GitHub milestone of small, well-formed issues that [`milestone-driver`](https://github.com/kenmulford/milestone-driver) can build with no human clarification. It decomposes the brief into independently-buildable issues, authors each one's full spec, encodes the Wave/dependency order in the milestone description, and self-checks every issue before anything is created. The feeder is the driver's direct predecessor: it produces the input the driver assumes already exists.
+milestone-feeder is a Claude Code plugin. Hand it a feature brief — a file, inline text, or a GitHub epic issue — and it produces a GitHub milestone of small, well-formed issues that [`milestone-driver`](https://github.com/kenmulford/milestone-driver) can build with no human clarification. It decomposes the brief into independently-buildable issues, writes each issue's full spec, encodes the dependency/Wave order in the milestone description, and self-checks every issue with the driver's own reviewers before anything is created — so what it hands the driver passes the driver's triage the first time.
 
-The point is quality at the front of the pipeline. The bigger the ask of AI, the worse the quality is — so the feeder keeps each authoring step small and runs the whole set through a single hard gate. Its quality bar is concrete: every issue it emits passes the driver's own triage clean (`GAPS: none`), because the feeder reuses the driver's actual reviewer agents as a pre-creation self-check.
-
-Issue creation is consequential, so it previews a reviewable plan by default and writes nothing to GitHub until you pass `--apply`. Anything risky — a product decision with no conventional default, a non-converging design — parks to a "needs product input" report instead of guessing. The feeder authors no code, opens no PRs, and never touches branches. Authoring scope stays your call.
+It previews a reviewable plan by default and writes nothing to GitHub until you pass `--apply`. A decision with no conventional default parks to a report rather than being guessed. It authors no code, opens no PRs, and never touches branches.
 
 ## At a glance
 
-- **Input:** a feature brief (file, inline, or a GitHub epic issue) + the project substrate (`.project/`).
-- **Output:** a milestone whose description encodes the Wave/dependency order, and small issues each carrying complete acceptance criteria, recorded consistent design, declared dependencies, and UI/logic + risk classification.
-- **Safety:** previews a reviewable plan by default; `--apply` creates the milestone/issues. Authors no code, opens no PRs. Parks product decisions rather than inventing scope.
+- **Input:** a feature brief (file, inline, or a GitHub epic issue) + your project's standing docs (`.project/`).
+- **Output:** a milestone whose description encodes the Wave/dependency order, and small issues each with complete acceptance criteria, recorded design, declared dependencies, and a UI/logic + risk label.
+- **Safety:** preview by default; `--apply` creates the milestone/issues; authors no code, opens no PRs; parks product decisions instead of inventing them.
 
 ## Quickstart
 
@@ -36,62 +34,35 @@ Issue creation is consequential, so it previews a reviewable plan by default and
 
 That's the whole loop: **preview → read the plan → `--apply`**. No profile yet? The first run bootstraps one with you. To re-vet a milestone you already created — re-triage it, patch gappy issues, fill missing dependency edges — run `/milestone-feeder:refine "<milestone title>"`.
 
-**3. Ground it in your project (optional — but it's where the quality comes from).** The feeder writes far better, more consistent issues when it can read your project's standing docs. Configure it in `.milestone-config/feeder.json`; every key has a default, so this is optional:
+**3. Customize it (optional).** Configure the feeder in `.milestone-config/feeder.json`; every key has a default, so this is optional:
 
-- **`substrateDir`** (default `.project/`) — the folder holding your project's *standing docs*: architecture notes, coding conventions, a design system. The feeder reads these and **grounds every issue in your actual conventions** — it records "reuse the shared `FormField` component" with a citation instead of inventing a design. A cross-cutting rule you put here (e.g. "all tables paginate at 30 rows/page") propagates into every issue it touches. The richer this folder, the better the issues and the fewer decisions the feeder has to hand back to you.
-- **`selfCheck`** (default `"milestone-driver"`) — the quality gate that vets every issue *before* it's created: `"milestone-driver"` uses the driver's real reviewers, `"internal"` uses a built-in checklist that mirrors them, `false` turns it off (with a visible warning). Leave it on.
-- The build-side keys it needs (`uiSurfaceGlobs`, `integrationBranch`, and your repo's `sourceGlobs`) are **read from your milestone-driver config** — you don't repeat them here.
+- **`substrateDir`** (default `.project/`) — the folder of your project's *standing docs*: architecture notes, coding conventions, a design system. The feeder reads these and **grounds every issue in your actual conventions** — it records "reuse the shared `FormField` component" with a citation instead of inventing a design, and a cross-cutting rule there (e.g. "all tables paginate at 30 rows/page") propagates into every issue it touches. The richer this folder, the better the issues and the fewer decisions the feeder hands back to you.
+- **`selfCheck`** (default `"milestone-driver"`) — the quality gate that vets every issue *before* it's created: `"milestone-driver"` uses the driver's real reviewers, `"internal"` uses a built-in checklist, `false` turns it off. Leave it on.
+- The build-side keys (`uiSurfaceGlobs`, `integrationBranch`, your repo's `sourceGlobs`) are **read from your milestone-driver config** — you don't repeat them here.
 
-A minimal profile, then, is just the bits that differ from the defaults — often nothing:
-
-```json
-{
-  "substrateDir": ".project/",
-  "selfCheck": "milestone-driver"
-}
-```
-
-Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every profile key explained: [docs/profile-schema.md](docs/profile-schema.md).
-
-## What makes it different
-
-Most brief-to-issues assistants ship their own notion of a "well-formed" issue — a second definition that drifts from whatever actually gates the build. milestone-feeder has no second definition. Its quality bar *is* the driver's entry gate: before creating anything, it dispatches the driver's real `triage-reviewer` (and `design-reviewer` for UI issues) against each generated issue as a pre-creation self-check. An issue is only emitted once it passes that gate clean, so what the feeder hands the driver passes the driver's triage the first time — no drift, no rework loop between the two tools.
-
-## When to use it
-
-- You have a brief or an epic to turn into a buildable milestone, not a single ad-hoc task.
-- You want issues that pass the driver's triage clean the first time, with no clarification loop.
-- You want product decisions parked for you — recorded in a report, never invented to make an issue buildable.
-- You want a reviewable preview before anything is created on GitHub.
+Full setup: [docs/consumer-setup.md](docs/consumer-setup.md). Every key explained: [docs/profile-schema.md](docs/profile-schema.md).
 
 ## How it works
 
-milestone-feeder runs a pipeline of small, gated steps, so no single step asks the model to hold too much at once.
+A pipeline of small, gated steps: **decompose** the brief into candidate issues + a dependency graph, **author** each issue's full spec, **self-check** every issue against the driver's real reviewers (re-author on a fixable gap, park a decision with no conventional default), then **emit** — a preview plan by default, or the milestone + issues on `--apply`. `refine` runs the same pipeline against an existing milestone (idempotent; creates and deletes nothing).
 
-1. Decompose. It dispatches the decomposer once: the brief plus the substrate become a candidate issue set, a dependency graph, and a Wave order. Decisions with no conventional default are separated out and parked, not guessed.
-2. Author. It dispatches the issue-author per candidate (parallelizable). Each issue gets its full spec — acceptance criteria covering empty/error/disabled states, recorded consistent design grounded in the substrate or a cited sibling pattern, declared dependency edges, and UI/logic + risk classification.
-3. Self-check gate. Before emitting, it vets every generated issue against the same gate that fronts the driver's build loop. A `GAPS: none` issue passes; a Blocker is re-authored (bounded to ≤2 retries) or parked. The gate has three backends — the driver's reviewers (`"milestone-driver"`, the default), an internal checklist mirroring the five triage criteria (`"internal"`), or off (`false`, with a visible warning). It runs on every path and writes no GitHub state.
-4. Emit. Preview (the default) writes a reviewable plan file — the Wave-ordered milestone description plus every gate-surviving issue body — and a "needs product input" report when product gaps remain. `--apply` then creates the GitHub artifacts: the labels, the milestone (created-or-adopted by title, never deleted), each gate-surviving issue, and the Wave-encoded milestone description.
-
-`refine` is the maintenance counterpart: an idempotent re-run against an existing milestone that re-vets its live issues through the same gate, patches gapped bodies, fills missing dependency edges, and re-renders the Wave order. It creates and deletes no issues; an issue already at `GAPS: none` is left byte-unchanged, and a fully-clean milestone is a true no-op.
-
-Every dispatched agent is read-only and runs against provided text; the feeder reads code to ground decisions but never writes it. The full architecture, the gate, and the `--apply` write order live in [docs/architecture.md](docs/architecture.md).
+The gate, the parking rules, and the `--apply` write order are documented in [docs/architecture.md](docs/architecture.md).
 
 ## Requirements
 
-- The superpowers plugin. It is a hard dependency, auto-installed on install provided you have the official marketplace added.
+- The superpowers plugin — a hard dependency, auto-installed on install if you have the official marketplace added.
 - GitHub CLI (`gh`), authenticated, for milestone, issue, and label operations.
 - git.
-- bash (preferred) or PowerShell 7+ for the `no-source-edit` hook. `jq` is required for the bash path.
-- milestone-driver is **optional**. It backs the default `selfCheck: "milestone-driver"` mode — the feeder dispatches the driver's own reviewers as the self-check gate. Absent, the feeder degrades to the built-in `"internal"` checklist and the pipeline still runs.
+- bash (preferred) or PowerShell 7+ for the `no-source-edit` hook; `jq` for the bash path.
+- milestone-driver is **optional** — it backs the default `selfCheck: "milestone-driver"` gate; absent, the feeder degrades to the built-in `"internal"` checklist.
 
 ## Status
 
-v0.2.0 shipped — the self-check gate, `--apply`, and `refine` are all delivered (v0.1.0 shipped the preview slice). The feeder was built as its own milestone, driven end-to-end by milestone-driver.
+v0.2.0 — the self-check gate, `--apply`, and `refine` are shipped (v0.1.0 was the preview slice). Self-hosted: the feeder was built as its own milestone, driven by milestone-driver.
 
 ## Docs
 
-- [docs/consumer-setup.md](docs/consumer-setup.md): full setup and wiring.
+- [docs/consumer-setup.md](docs/consumer-setup.md): setup and wiring.
 - [docs/profile-schema.md](docs/profile-schema.md): every profile key.
 - [docs/architecture.md](docs/architecture.md): the as-built design and the gates.
 - [SPEC.md](SPEC.md): the full design and spec.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The gate, the parking rules, and the `--apply` write order are documented in [do
 
 v0.2.0 — the self-check gate, `--apply`, and `refine` are shipped (v0.1.0 was the preview slice). Self-hosted: the feeder was built as its own milestone, driven by milestone-driver.
 
+The preview pipeline and the self-check gate are exercised by a scenario harness ([`tests/`](tests/), scorecard in [`tests/RESULTS.md`](tests/RESULTS.md)) — all green, with the gate running milestone-driver's real reviewers. The `--apply` and `refine` write paths are covered by design and a sandbox follow-up, not yet exercised end-to-end.
+
 ## Docs
 
 - [docs/consumer-setup.md](docs/consumer-setup.md): setup and wiring.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,108 @@
+# tests/ — milestone-feeder credibility harness
+
+This is not a unit-test suite — milestone-feeder has no executable code; its skills are
+prose procedures an agent follows. This harness measures whether those procedures, when
+**executed**, actually behave the way the README and `plugin.json` description claim.
+
+**The scorecard is the metric.** Every concrete claim in the description must map to a
+scenario that demonstrates it. A claim with no passing scenario gets dialed back. The
+point is a description that is *real, tangible, and accurate* — a lighter, fully-backed
+description beats a confident, unproven one.
+
+## The one rule that makes the metric honest
+
+The scenario **runner never sees `expected.md`.** It runs the brief blind — given only the
+decompose procedure and the scenario's inputs. A separate **grader** compares observed
+output against `expected.md`. No teaching to the test.
+
+## Execution model (preview-only, prose-direct)
+
+The feeder plugin is not installed as slash commands in the harness session, so a scenario
+is executed by **following the prose directly**:
+
+1. A **runner** subagent acts as the `decompose` orchestrator, following
+   `skills/decompose/SKILL.md` Steps 0–6 + the preview emit (Step 7 preview path only).
+2. It dispatches subagents for the **decomposer** and **issue-author** roles, briefed from
+   `agents/decomposer.md` and `agents/issue-author.md` (their contracts).
+3. The **self-check gate** dispatches the **real** `milestone-driver:triage-reviewer` and
+   `:design-reviewer` — the actual reviewers the claim depends on.
+4. **PREVIEW only** — zero GitHub writes. The run emits the plan file (and a
+   needs-product-input report when applicable) as text artifacts under the scenario folder.
+5. A **grader** subagent scores observed-vs-`expected.md` → ✅ pass / ⚠️ partial / ❌ fail,
+   with the observed behavior recorded.
+
+`--apply` and `refine` make real GitHub writes, so their scenarios (07–09) are designed
+here but run later against a throwaway sandbox repo — labeled, not silently skipped.
+
+## Layout
+
+```
+tests/
+  README.md                      # this file (design + how to run + how to read RESULTS)
+  scenarios/
+    01-clean-happy-path/          { brief.md, project/, feeder-env.md, expected.md }
+    02-product-gap-parks/         { ... }
+    03-design-resolvable-no-park/ { ... }
+    04-no-code-refusal/           { ... }
+    05-selfcheck-backends/        { ... }
+    06-cross-cutting-consistency/ { ... }
+  RESULTS.md                      # scorecard + claim→evidence map (the metric)
+```
+
+Per scenario:
+- `brief.md` — the input brief (the runner's only task input besides the procedure).
+- `project/` — the `.project/`-style substrate the run grounds on (optional per scenario).
+- `feeder-env.md` — the test config the run assumes: the `feeder.json` keys and the driver
+  shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) the run reads.
+- `expected.md` — the behavioral contract (grader-only; the runner never sees it).
+
+`tests/` is outside `sourceGlobs` and the `skills/` load path — no hook friction, never
+loaded as plugin skills.
+
+## Scenario set
+
+| # | Scenario | Adversarial intent | Claim under test | Run now? |
+|---|----------|--------------------|------------------|----------|
+| 01 | clean happy-path | well-specified brief, a few independent features + one real dependency | "small, well-formed issues"; Wave/dependency order encoded; self-check passes; output passes the driver's triage clean | ✅ |
+| 02 | product-gap-parks | bury a decision with no conventional default | **parks product decisions to a report, never invents scope**; dependents dropped | ✅ |
+| 03 | design-resolvable, no park | vague on a detail a stated convention *can* answer | park-boundary precision — resolves + cites grounding, does **not** park and does **not** invent | ✅ |
+| 06 | cross-cutting consistency at scale | a standing table directive in the substrate; a brief asking for ~10 table-bearing pages, **not** restating the directive | **flagship:** the directive propagates into all ~10 issues consistently (Consistency criterion); the `design-reviewer` flags any issue that drops it; each issue cites the convention | ✅ |
+| 04 | no-code refusal | brief says "implement it and open a PR" | authors no code, opens no PRs, never touches branches — stays in decompose-and-specify | built, later |
+| 05 | selfCheck backends | run with `selfCheck: false` and `selfCheck: "internal"` (driver-absent degrade) | the three backends + the runtime degrade-to-internal path | built, later |
+| 07 | `--apply` idempotency | create, then re-apply | create-or-adopt by title; idempotent re-apply (no dupes); never delete | sandbox follow-up |
+| 08 | refine no-op / not-found / patch | clean milestone; missing milestone; gapped issue | refine is idempotent (clean → no-op); milestone-not-found → error-and-stop; gapped body patched | sandbox follow-up |
+| 09 | slug→#n at scale | >26 candidates | substring-safe slug rewrite (`#A` not corrupting `#AB`) | sandbox follow-up |
+
+### 06 — the flagship, in detail
+
+- **Substrate** (`project/`): a design-system / conventions doc stating, e.g.,
+  *"All data tables: columns sortable and filterable except an Actions column; pagination
+  at 30 rows per page."* This is a **standing convention**, the natural home for it.
+- **Brief**: "Build these ~10 pages, each listing <entities> in a table" — and **does not
+  restate** the table directive. The feeder must pull it from the substrate, apply it to
+  every page-issue, and cite it.
+- **Config**: `uiSurfaceGlobs` **must be set** so the page-issues classify as UI and the
+  `design-reviewer` engages (absent → everything is logic and the design lens is skipped).
+- **Expected** (grader): every page-issue carries the full directive (sortable + filterable
+  except actions + pagination 30/page) in its acceptance criteria, verbatim-equivalent (no
+  drift, no silent weakening of "30/page"), cites the convention, and any issue that omits
+  it is flagged by the `design-reviewer` and re-authored. Drift past the first few issues is
+  the failure mode being hunted.
+
+## The metric (RESULTS.md)
+
+Two tables:
+
+1. **Scorecard** — `# | scenario | expected | observed | verdict (✅/⚠️/❌) | run?`
+2. **Claim → evidence map** — each concrete claim in `plugin.json` description + README
+   intro → the scenario(s) that exercise it → **Demonstrated / Designed-not-run / Unbacked**.
+
+The metric is (a) the run-now pass rate, and (b) how many claims are Demonstrated vs
+Designed-not-run vs Unbacked.
+
+## After the metric: right-size the copy
+
+Using the claim→evidence map, rewrite the `plugin.json` description and the README intro so
+each claim is either **Demonstrated** or honestly framed as design intent — never a tested
+guarantee it hasn't earned. Unbacked or failing claims are removed or softened. This step is
+contingent on the metric, not done up front.

--- a/tests/RESULTS.md
+++ b/tests/RESULTS.md
@@ -1,0 +1,55 @@
+# RESULTS — milestone-feeder credibility harness
+
+Run date: 2026-06-18 · Mode: **preview-only, prose-direct** (see [README.md](README.md)).
+Run-now: 01, 02, 03, 06. Built-but-not-run: 04, 05. Sandbox follow-up: 07–09.
+
+## Execution fidelity (read first)
+
+- **The self-check gate — the load-bearing, honesty-critical component — ran with the REAL `milestone-driver:triage-reviewer` and `:design-reviewer`** in every scenario. No degrade-to-internal, no self-review. Across the four runs: triage-reviewer dispatched ~22×, design-reviewer ~16× (incl. re-reviews).
+- **Caveat:** the feeder's *own* agents (`milestone-feeder:decomposer`, `:issue-author`) are not registered as dispatchable subagents when running from-repo (the plugin isn't installed in the harness session), so their *contracts* were executed via `general-purpose` subagents carrying the verbatim `agents/*.md` files. The **generative** side is contract-faithful but proxied; the **gate** side is genuine. In 02 this ran in the direction that *strengthens* the result — the proxied author tried to paper over a product gap and the real gate rejected it.
+- Each runner was **blind** to its `expected.md`; an independent grader scored each run; the flagship (06) grader independently re-read all 10 issue bodies rather than trusting the runner's own table.
+
+## Scorecard
+
+| # | Scenario | Expected | Observed | Verdict |
+|---|----------|----------|----------|---------|
+| 01 | clean happy-path | small, ordered, gate-clean milestone | 3 issues, both dependency edges, correct waves, real-reviewer gate PASS; parked 1 — the *unspecified* rate-limit threshold | ✅ feeder-correct |
+| 02 | product-gap-parks | park the no-default policy; invent nothing | **0 issues emitted**; featured-selection policy parked; dependents dropped; the gate caught the author's "no-op source" dodge | ✅ |
+| 03 | design-resolvable | resolve-and-cite; don't over-park | 6 issues, **0 parks**, every design decision cited; gate caught a missing affordance (#C), the ≤2 retry cleared it | ✅ |
+| 06 | cross-cutting consistency (**flagship**) | directive holds across ~10 issues; gate enforces | 10 issues, **10/10 carry the complete unweakened directive** (literal "30" everywhere); real `design-reviewer` per issue | ✅ |
+| 04 | no-code refusal | refuse code/PR; specify the issue instead | — | designed, not run |
+| 05 | selfCheck backends | `false` skips+warns; `internal`/degrade | — | designed, not run |
+| 07–09 | `--apply` / refine / slug-at-scale | write-path edge cases | — | **sandbox follow-up** (real GitHub writes) |
+
+01 note: the "zero parks" expectation was the bug — an unspecified rate-limit threshold is a legitimate product gap, and the feeder parking it (rather than inventing a number) is correct *never-invents* behavior. `expected.md` was corrected in-place; this run doubles as evidence for the parks-not-invents property.
+
+## Claim → evidence map
+
+Each concrete claim in the `plugin.json` description + README → the scenario(s) that exercise it → status.
+
+| Claim | Evidence | Status |
+|---|---|---|
+| Decomposes a brief into small, independently-buildable issues | 01 (3), 03 (6), 06 (10), correct edges/waves | **Demonstrated** |
+| Authors each issue's full §4 spec (AC incl. empty/error/disabled, recorded design, declared edges, UI/logic + risk) | all 4; graders confirmed bodies | **Demonstrated** |
+| Encodes the Wave/dependency order in the milestone description | 01, 03 (3 waves), 06 | **Demonstrated** |
+| **Self-checks every issue against the driver's OWN reviewers before any write** | all 4 — real triage + design reviewers; preview = zero writes | **Demonstrated (keystone)** |
+| Parks product decisions with no conventional default; never invents scope | 02 (hard — gate rejected a dodge), 01 (threshold) | **Demonstrated** |
+| Records *consistent* design — incl. a cross-cutting directive across many issues | 06 — 10/10 unweakened, literal "30" survived | **Demonstrated (flagship)** |
+| Resolves convention-answerable detail (cites grounding); doesn't over-park | 03 — 0 parks, all cited | **Demonstrated** |
+| Previews a plan by default; writes nothing to GitHub without `--apply` | all 4 ran preview-only, zero GitHub writes | **Demonstrated (preview side)** |
+| `--apply` creates the milestone + issues + labels (create-or-adopt, slug→#n rewrite, idempotent re-apply) | scenario 07 designed | **Designed, not run** (sandbox) |
+| `refine` — idempotent re-run against an existing milestone | scenario 08 designed | **Designed, not run** (sandbox) |
+| selfCheck backends: `internal` checklist / `false` / runtime degrade | scenario 05 designed | **Designed, not run** |
+| Reads code, never writes it / opens no PRs / touches no branches | all 4 wrote no code; explicit-refusal test (04) designed | **Demonstrated (no code written); explicit refusal designed-not-run** |
+| milestone-driver builds the result "with no human clarification" (end-to-end) | proxy: every issue passed the driver's real triage + design gate clean | **Proxy-demonstrated** — the driver's *entry gate* passes; a full driver build was not run here |
+| Stack-agnostic via a thin per-repo profile | fixtures spanned Python/React/TS via `feeder-env` profiles | **Lightly demonstrated** |
+
+## Findings
+
+1. **`--apply` zero-survivors is under-specified** (surfaced by 02). When the gate parks/drops every candidate, the `--apply` path would still create a bare milestone + labels + report but **no issues** — emergent behavior, not a stated case. Recommend an explicit zero-survivors branch in `decompose` §7-apply, mirroring the Step-2 STOP rule ("route only the report; create nothing else"). *(skill improvement)*
+2. **Subagent-registration fidelity** (all runs). The feeder's own agents aren't dispatchable from-repo, so tests proxy their contracts. A true `--apply`/`refine` run against a throwaway sandbox **after install** would close the last fidelity gap and convert the "Designed, not run" rows above to Demonstrated. *(test-infra)*
+3. **Fixture 01 expectation corrected.** "Zero parks" was wrong; the threshold park is correct. `expected.md` amended in-place. *(fixture)*
+
+## Bottom line
+
+Every run-now scenario passed ✅, with the **keystone** (self-check on the driver's real reviewers) and the **flagship** (cross-cutting consistency, 10/10) demonstrated rather than asserted. The genuinely-unproven surface is the **write paths** (`--apply`, `refine`) and the auxiliary self-check backends — designed and reviewed, not yet executed (sandbox follow-up). The description/README should claim the **preview + gate + parks + consistency** story as demonstrated, and frame the write paths and the full end-to-end "no human clarification" build as design-intent pending the sandbox run.

--- a/tests/scenarios/01-clean-happy-path/.milestone-feeder/needs-product-input-csv-export-reports-page.md
+++ b/tests/scenarios/01-clean-happy-path/.milestone-feeder/needs-product-input-csv-export-reports-page.md
@@ -1,0 +1,7 @@
+🔴 Needs human input — Add user-facing CSV export to the Reports page
+
+These items blocked the milestone and were NOT guessed. Resolve each, then re-run decompose.
+
+| # | Kind | Item | Why blocked | Blocks |
+|---|---|---|---|---|
+| 1 | product-gap | Per-user rate-limit threshold for the CSV export endpoint: how many exports per user per window, the window length, and any burst allowance | The substrate fixes the rate-limit *mechanism* (shared `RateLimiter` token-bucket middleware; 429 + `Retry-After`; pattern `src/middleware/rate_limit.py` — project/conventions.md#engineering-conventions) but specifies no default threshold. The numeric limit is a product decision with no conventional default — exports being "expensive" (brief) does not imply a specific number. | #B (per-user rate limit on the export endpoint). No other candidate depends on #B, so #A and #C still ship. |

--- a/tests/scenarios/01-clean-happy-path/.milestone-feeder/needs-product-input-csv-export-reports-page.md
+++ b/tests/scenarios/01-clean-happy-path/.milestone-feeder/needs-product-input-csv-export-reports-page.md
@@ -1,7 +1,0 @@
-🔴 Needs human input — Add user-facing CSV export to the Reports page
-
-These items blocked the milestone and were NOT guessed. Resolve each, then re-run decompose.
-
-| # | Kind | Item | Why blocked | Blocks |
-|---|---|---|---|---|
-| 1 | product-gap | Per-user rate-limit threshold for the CSV export endpoint: how many exports per user per window, the window length, and any burst allowance | The substrate fixes the rate-limit *mechanism* (shared `RateLimiter` token-bucket middleware; 429 + `Retry-After`; pattern `src/middleware/rate_limit.py` — project/conventions.md#engineering-conventions) but specifies no default threshold. The numeric limit is a product decision with no conventional default — exports being "expensive" (brief) does not imply a specific number. | #B (per-user rate limit on the export endpoint). No other candidate depends on #B, so #A and #C still ship. |

--- a/tests/scenarios/01-clean-happy-path/brief.md
+++ b/tests/scenarios/01-clean-happy-path/brief.md
@@ -1,0 +1,12 @@
+# Brief: CSV export for the Reports page
+
+Add user-facing CSV export to the existing Reports page.
+
+In scope:
+- A backend export endpoint that streams the current report's rows as CSV.
+- A "Download CSV" action on the Reports page that calls the endpoint and saves the file.
+- A per-user rate limit on the export endpoint (exports are expensive).
+
+Out of scope:
+- New report types or columns.
+- Scheduled or emailed exports.

--- a/tests/scenarios/01-clean-happy-path/expected.md
+++ b/tests/scenarios/01-clean-happy-path/expected.md
@@ -1,0 +1,19 @@
+# Expected contract — 01 clean-happy-path  (GRADER ONLY)
+
+A clean, well-specified brief. The feeder should produce a small, correctly-ordered,
+gate-clean milestone with NO parks.
+
+## MUST
+- 3 issues (3–4 acceptable if it splits sensibly): the export **endpoint**, the **Download-CSV UI action**, the **rate limit**. ~1 PR each.
+- Dependency edges: the UI action depends on the endpoint; the rate limit depends on the endpoint. Endpoint = Wave 1; the other two = Wave 2.
+- The milestone description encodes the Wave order (§4 template).
+- Each issue body has all five §4 sections. Acceptance criteria include empty/error states (per convention). The UI-action issue records the in-flight-disable + toast convention; the rate-limit issue cites the `RateLimiter` pattern (429 + `Retry-After`).
+- Self-check gate: every issue returns `GAPS: none` (PASS). No re-author, or at most a bounded one that clears.
+- ZERO parks; needs-product-input report absent or "none".
+- Classification: UI action = `ui`; endpoint + rate limit = `logic`. Risk reasonable.
+
+## SHOULD
+- Convention citations point at the provided `project/conventions.md` (real grounding), not invented.
+
+## FAIL if
+- Invents scope not in the brief; misses a dependency edge; parks something a convention answers; produces issues missing error/empty states; or the gate rubber-stamps an incomplete issue.

--- a/tests/scenarios/01-clean-happy-path/expected.md
+++ b/tests/scenarios/01-clean-happy-path/expected.md
@@ -17,3 +17,22 @@ gate-clean milestone with NO parks.
 
 ## FAIL if
 - Invents scope not in the brief; misses a dependency edge; parks something a convention answers; produces issues missing error/empty states; or the gate rubber-stamps an incomplete issue.
+
+## POST-RUN ADJUDICATION (fixture correction — 2026-06-18)
+The first run (blind) parked the **rate-limit threshold value** as a product gap: the brief
+says "a per-user rate limit" with no number, and the substrate grounds the *mechanism*
+(`RateLimiter`, 429 + `Retry-After`) but states no default number. The independent grader
+ruled — correctly — that **parking the unspecified threshold rather than inventing one is
+right behavior**, and that the original `MUST #6: ZERO parks` was the mistaken assertion
+(a clean brief that omits a no-conventional-default number *should* park it).
+
+Corrections to this contract:
+- **MUST #5** is relaxed to: every emitted issue returns `GAPS: none` **or Advisory-only**
+  (advisories are non-gating).
+- **MUST #6** is superseded: exactly **one** minimal, correctly-scoped product-gap park
+  (the threshold) is expected and correct — not a failure. Inventing a number would be the
+  failure. Everything else (decomposition, both edges, Wave order, real-reviewer gate,
+  cited grounding) must still hold.
+
+Net verdict: ✅ feeder behavior correct; this run doubles as evidence for the
+"parks-not-invents" property (overlaps scenario 02's dedicated test).

--- a/tests/scenarios/01-clean-happy-path/feeder-env.md
+++ b/tests/scenarios/01-clean-happy-path/feeder-env.md
@@ -1,0 +1,9 @@
+# Test environment (what the run assumes)
+
+- `feeder.json`: defaults (empty `{}` → `selfCheck: "milestone-driver"`, `substrateDir: project/`).
+- Driver shared keys (as if from `.milestone-config/driver.json`):
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["Python 3.11 backend; React 18 frontend"]`
+- Substrate dir for this scenario: `project/`

--- a/tests/scenarios/01-clean-happy-path/project/conventions.md
+++ b/tests/scenarios/01-clean-happy-path/project/conventions.md
@@ -1,0 +1,6 @@
+# Engineering conventions
+
+- **API:** REST endpoints under `/api/v1/`; JSON or streamed bodies; auth required; errors return `{ "error": "..." }` with the correct HTTP status.
+- **Rate limiting:** use the shared `RateLimiter` middleware (token-bucket). Limited responses return `429` with a `Retry-After` header. Pattern: `src/middleware/rate_limit.py`.
+- **User-facing actions:** show a success/error toast via the shared `useToast()` hook; disable the trigger control while the action is in flight.
+- **States:** empty and error states are required on every user-facing surface.

--- a/tests/scenarios/01-clean-happy-path/run-log.md
+++ b/tests/scenarios/01-clean-happy-path/run-log.md
@@ -1,0 +1,76 @@
+# Execution log — decompose PREVIEW, scenario 01 (clean-happy-path)
+
+## Mode
+- Trigger: `/milestone-feeder:decompose <inline brief>` — no `--apply` token, no NL "apply" equivalent → PREVIEW (default). No GitHub writes.
+
+## Step 0 — config + substrate
+- `feeder.json` empty `{}` → `selfCheck: "milestone-driver"` (default), `substrateDir: project/`.
+- Shared keys (driver): `sourceGlobs=["src/**"]`, `uiSurfaceGlobs=["src/pages/**","src/components/**"]`, `integrationBranch="develop"`.
+- `nonNegotiables=["Python 3.11 backend; React 18 frontend"]` (reviewer-profile input, passed through at the gate).
+- Substrate read: `project/conventions.md` (all 4 sections present: API, Rate limiting, User-facing actions, States). No `[TBD]` sections; no absent docs. No degradation (uiSurfaceGlobs present).
+- Note: fixture ships no actual `src/**` tree; grounding is on the stated conventions in the substrate (documented best-effort behavior).
+
+## Step 1 — ingest brief
+- Form: inline text (not `#n`, not a file path). `epicIssueNumber`: omitted.
+- Normalized: goal = user-facing CSV export on existing Reports page; in-scope = streaming backend export endpoint, Download CSV action on Reports page, per-user rate limit on the endpoint; out-of-scope = new report types/columns, scheduled/emailed exports; surfaces = Reports page (src/pages/**), export endpoint (/api/v1/), RateLimiter middleware.
+
+## Step 2 — product-gap check
+- API shape, error shape, auth, streaming, toast/disable UX, required states, rate-limit mechanism → all answered by project/conventions.md → resolved design/impl decisions.
+- Rate-limit THRESHOLD value (exports/user/window + window/burst) → no conventional default in substrate → product gap (scoped to #B). Candidate set can still be formed (gap is a parameter, not core scope) → no Step-2 STOP; carried forward.
+
+## Step 3 — decompose (decomposer, dispatched once)
+- CANDIDATES:
+  - #A — Add backend CSV export endpoint for the current report — surface: logic, risk: heavy
+  - #B — Add a per-user rate limit to the CSV export endpoint — surface: logic, risk: heavy
+  - #C — Add a Download CSV action to the Reports page — surface: ui, risk: heavy
+- EDGES:
+  - #B depends_on #A — rate limit wraps the export endpoint #A introduces.
+  - #C depends_on #A — Download CSV action calls the export endpoint #A introduces.
+- WAVES (pre-park, topological sort):
+  - Wave 1: #A
+  - Wave 2 (parallel): #B (depends on #A), #C (depends on #A)
+- PRODUCT_GAPS: rate-limit threshold value (scoped to #B). Merged into productGaps[].
+
+## Step 4 — author per candidate (issue-author, one per candidate)
+- #A → STATUS: AUTHORED. Full §4 body (Summary / 4 acceptance criteria happy+empty+error+edge / Design grounded in conventions API line + nonNegotiables / Dependencies: none / Classification logic+heavy). LABELS [logic, risk:heavy].
+- #C → STATUS: AUTHORED. Full §4 body (4 acceptance criteria happy+empty+error+disabled / Design names states, toast affordance, in-flight disable, a11y, React 18 / Dependencies: Depends on #A / Classification UI+heavy). LABELS [ui, risk:heavy].
+- #B → STATUS: PRODUCT_GAP. Mechanism grounded (RateLimiter token-bucket, 429+Retry-After, src/middleware/rate_limit.py) but threshold has no conventional default → routed to productGaps[]; NOT authored, no fabricated body. Recorded as parked, tag/title rendered with marker.
+
+## Step 5 — assemble graph + render milestone description
+- Graph (local tags): #A → {#B, #C}. Rendered §4 Wave description with local slugs (pre-park version matches Step 3 waves).
+
+## Step 6 — SELF-CHECK GATE (REAL reviewers)
+- Backend: `milestone-driver` (default). Reviewers RESOLVED on first dispatch → no degrade-to-internal. REAL milestone-driver subagents used (not self-review).
+- Briefed each per §6.2: generated title/body/criteria; recorded design decisions = EMPTY (stated explicitly); milestone description as cross-issue context; resolved sourceGlobs/uiSurfaceGlobs/nonNegotiables; local slugs.
+
+| Issue | Reviewer(s) dispatched | Returned | Verdict | Re-authors |
+|---|---|---|---|---|
+| #A | triage-reviewer | DEPENDS_ON: []; NEEDS_DESIGN_REVIEW: no; GAPS: 1× Advisory (missing-criteria — unnamed report-rows data source) | PASS (Advisory non-gating) | 0 |
+| #C | triage-reviewer + design-reviewer (UI) | triage: DEPENDS_ON: [A]; NEEDS_DESIGN_REVIEW: yes; GAPS: 1× Advisory (not-buildable — useToast provenance). design: GAPS: none | PASS (Advisory non-gating; design clean) | 0 |
+| #B | none (parked at Step 4 as PRODUCT_GAP — no authored body to review) | n/a | PARKED (product-gap) | 0 |
+
+- §6.3 aggregation: #A all-Advisory → PASS; #C triage Advisory + design none → PASS. No `severity: Blocker` on any block → no FAIL → §6.5 retry/park fork not triggered for #A/#C.
+- §6.6 undeclared edges: #C triage returned DEPENDS_ON: [A], already declared in the body and the Wave order → no new edge to absorb; no re-render needed. #A DEPENDS_ON: [] as expected.
+- §6.6 drop parked + dependents: #B parked (product-gap). No candidate depends on #B (edges: #B→#A, #C→#A) → no dependents dropped. Re-rendered surviving milestone description = {#A (Wave 1), #C (Wave 2, depends on #A)}.
+
+## Parks
+- #B — Kind: product-gap. Item: per-user rate-limit threshold value (exports/user/window + window/burst). Why: substrate fixes the mechanism (RateLimiter token-bucket, 429+Retry-After, src/middleware/rate_limit.py) but carries no default threshold; no conventional default → product decision. Blocks: #B only (no dependents).
+
+## Step 7 — emit (PREVIEW)
+- Wrote `run-output.md` (the §7-preview plan-file format; header (PREVIEW), self-check status line, surviving milestone description, full bodies for #A/#C, marker for #B, substrate grounding incl. Advisory notes + "no degradations", needs-human-input pointer, PREVIEW footer).
+- Wrote the needs-product-input report below (productGaps[] non-empty). No GitHub writes (preview).
+
+## Gate ran with REAL reviewers?
+- YES. `milestone-driver:triage-reviewer` dispatched for #A and #C; `milestone-driver:design-reviewer` dispatched for #C (UI). All resolved and returned parseable ISSUE/.../GAPS blocks. No degrade-to-internal, no internal-fallback, no self-review.
+
+---
+
+## needs-product-input report (content that would be written to .milestone-feeder/needs-product-input-csv-export-reports-page.md)
+
+🔴 Needs human input — Add user-facing CSV export to the Reports page
+
+These items blocked the milestone and were NOT guessed. Resolve each, then re-run decompose.
+
+| # | Kind | Item | Why blocked | Blocks |
+|---|---|---|---|---|
+| 1 | product-gap | Per-user rate-limit threshold for the CSV export endpoint: how many exports per user per window, the window length, and any burst allowance | The substrate fixes the rate-limit *mechanism* (shared `RateLimiter` token-bucket middleware; 429 + `Retry-After`; pattern `src/middleware/rate_limit.py` — project/conventions.md#engineering-conventions) but specifies no default threshold. The numeric limit is a product decision with no conventional default — exports being "expensive" (brief) does not imply a specific number. | #B (per-user rate limit on the export endpoint). No other candidate depends on #B, so #A and #C still ship. |

--- a/tests/scenarios/01-clean-happy-path/run-output.md
+++ b/tests/scenarios/01-clean-happy-path/run-output.md
@@ -1,0 +1,83 @@
+# Milestone plan (PREVIEW) — Add user-facing CSV export to the Reports page
+
+Self-check: PASS — 2 issues GAPS: none/Advisory-only (milestone-driver reviewers: triage-reviewer ×2, design-reviewer ×1). PARKED — 1 issue (#B) → needs product input (rate-limit threshold has no conventional default).
+Source brief: inline
+
+## Milestone description (preview)
+Add user-facing CSV export to the existing Reports page: a streaming backend export endpoint and a Download CSV action on the Reports page. (The per-user rate limit on the export endpoint is parked — its threshold needs product input; see the needs-product-input report.)
+
+## Waves
+- Wave 1: #A
+- Wave 2: #C (depends on #A)
+
+## Issues
+
+### #A — Add backend CSV export endpoint for the current report   [logic, risk:heavy]   [self-check: PASS]
+## Summary
+Add a REST endpoint that streams the current report's rows as CSV so the Reports page can offer a download. This is the backend half of user-facing CSV export; it does not add new report types or columns, and it does not schedule or email exports.
+
+## Acceptance criteria
+- [ ] Happy path: GET the export endpoint for a report returns the report's current rows as a streamed CSV body with a CSV content type; auth is required.
+- [ ] Empty state: a report with zero rows returns a valid CSV containing only the header row (HTTP 200), not an error.
+- [ ] Error path: an unknown/invalid report id returns the conventional error shape `{ "error": "..." }` with the correct HTTP status; an unauthenticated request is rejected.
+- [ ] Edge: the response streams rather than buffering the whole report in memory (exports are expensive).
+
+## Design (recorded, consistent)
+- Endpoint lives under `/api/v1/` per the API convention; auth required; errors return `{ "error": "..." }` with the correct HTTP status.
+- Body is a streamed CSV body (the API convention permits "JSON or streamed bodies").
+- Backend is Python 3.11 (profile nonNegotiable).
+- Convention followed: project/conventions.md#engineering-conventions (API: REST endpoints under `/api/v1/`; JSON or streamed bodies; auth required; errors return `{ "error": "..." }` with the correct HTTP status).
+
+## Dependencies
+- None.
+
+## Classification
+- Surface: logic
+- Risk: heavy
+
+### #C — Add a Download CSV action to the Reports page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a "Download CSV" action to the existing Reports page. The action calls the backend export endpoint (#A) and saves the returned CSV file to the user's device. No new report types or columns are added.
+
+## Acceptance criteria
+- [ ] Happy path: clicking "Download CSV" on the Reports page calls the export endpoint and the browser saves the returned CSV file; a success toast is shown via the shared `useToast()` hook.
+- [ ] Empty state: when the current report has zero rows, the action still downloads a valid (header-only) CSV — the action is available whenever a report is shown, mirroring the empty-state requirement for user-facing surfaces.
+- [ ] Error path: if the endpoint returns an error (or the request fails), an error toast is shown via `useToast()` and no partial/corrupt file is saved.
+- [ ] Disabled/in-flight: the "Download CSV" control is disabled while the request is in flight, per the user-facing-actions convention, and re-enabled when it settles.
+
+## Design (recorded, consistent)
+- Place the "Download CSV" trigger on the existing Reports page (a `src/pages/**` surface → UI).
+- On click, call the backend export endpoint (#A) and save the streamed CSV response as a file.
+- Show a success/error toast via the shared `useToast()` hook; disable the trigger control while the action is in flight (user-facing-actions convention).
+- Required states: success (file saved + success toast), empty (header-only CSV downloads normally), error (error toast, no corrupt file), disabled/in-flight (control disabled during the request). Empty and error states are required on every user-facing surface (States convention).
+- Accessibility: the trigger is a labeled control ("Download CSV") reachable and operable by keyboard and screen reader; the disabled state is conveyed to assistive tech while in flight.
+- Frontend is React 18 (profile nonNegotiable); use the shared `useToast()` hook rather than a bespoke notification.
+- Convention followed: project/conventions.md#engineering-conventions (User-facing actions: show a success/error toast via the shared `useToast()` hook; disable the trigger control while the action is in flight. States: empty and error states are required on every user-facing surface).
+
+## Dependencies
+- Depends on #A — the "Download CSV" action calls the backend CSV export endpoint that #A introduces; it cannot function until that endpoint exists.
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+### #B — Add a per-user rate limit to the CSV export endpoint   [parked — needs product input]
+<marker only; no fabricated body — see the needs-product-input report. The rate-limit *mechanism* is fully grounded (shared `RateLimiter` token-bucket middleware; 429 + `Retry-After`; pattern `src/middleware/rate_limit.py` — project/conventions.md#engineering-conventions), but the *threshold value* (exports allowed per user per window, and the window/burst) has no conventional default in the substrate and is a product decision.>
+
+## Substrate grounding
+- #A: endpoint under `/api/v1/`, auth required, `{ "error": "..." }` error shape, streamed body — grounded in project/conventions.md#engineering-conventions (API line).
+- #A/#C: backend Python 3.11 / frontend React 18 — grounded in profile `nonNegotiables` ("Python 3.11 backend; React 18 frontend").
+- #C: success/error toast via shared `useToast()` hook; disable trigger while in flight — grounded in project/conventions.md#engineering-conventions (User-facing actions line).
+- #C: empty + error states required on the surface — grounded in project/conventions.md#engineering-conventions (States line).
+- #C: classified UI because the trigger lives on the existing Reports page, a `src/pages/**` surface — grounded in resolved `uiSurfaceGlobs` (`["src/pages/**","src/components/**"]`).
+- #B (parked): rate-limit mechanism (shared `RateLimiter` token-bucket; 429 + `Retry-After`; pattern `src/middleware/rate_limit.py`) — grounded in project/conventions.md#engineering-conventions (Rate limiting line); only the threshold value is the product gap.
+- Advisory notes (non-gating, recorded by the reviewers):
+  - #A — triage Advisory: the issue does not name the report-rows data source/service it streams; resolvable from the existing Reports read path in the consumer repo. (No `src/**` tree exists in this fixture to pin it.)
+  - #C — triage Advisory: `useToast()` is referenced as a shared hook; confirm it pre-exists in the consumer repo (it is a stated convention in project/conventions.md#engineering-conventions, treated as pre-existing).
+- Degradations: none. `uiSurfaceGlobs` is present, so the design lens was applied; `nonNegotiables` is present and was passed to the reviewers. (Note: the fixture ships no actual `src/**` source tree — the reviewers grounded on the stated conventions in the substrate, which is the documented best-effort behavior.)
+
+## Needs human input
+See .milestone-feeder/needs-product-input-csv-export-reports-page.md — #B's rate-limit threshold is a product decision with no conventional default. (Equivalent local report content reproduced below in run-log.md for this test run.)
+
+---
+To create these on GitHub, re-run with `--apply` — it ensures the labels, creates-or-adopts the milestone, opens each gate-surviving issue (#A, #C), rewrites the slug references to real issue numbers, and patches the milestone description with the Wave order. This preview wrote no GitHub state.

--- a/tests/scenarios/02-product-gap-parks/brief.md
+++ b/tests/scenarios/02-product-gap-parks/brief.md
@@ -1,0 +1,10 @@
+# Brief: Featured items on the homepage
+
+Add a "Featured" section to the homepage that highlights a selection of catalog items.
+
+In scope:
+- A homepage "Featured" section that displays the selected items in the standard product-card grid.
+- Whatever is needed to choose WHICH items are featured.
+
+Out of scope:
+- Redesigning the rest of the homepage.

--- a/tests/scenarios/02-product-gap-parks/expected.md
+++ b/tests/scenarios/02-product-gap-parks/expected.md
@@ -1,0 +1,14 @@
+# Expected contract — 02 product-gap-parks  (GRADER ONLY)
+
+The brief contains a genuine PRODUCT decision with no conventional default: **how featured
+items are selected** (editorial / admin-curated? algorithmic by popularity or recency?
+manual pinning? paid placement?). The substrate and conventions do NOT answer this.
+
+## MUST
+- The feeder **parks** the selection-policy decision to the "needs product input" report. It does **not** invent a policy (no silent "we'll feature the most recent / most popular").
+- The report names the undecided decision precisely (the featured-selection policy), why it has no conventional default, and what it blocks.
+- The display half (a Featured section reusing `ProductCardGrid`) MAY be authored as a decidable issue **only if** it can be specified without the policy; if the section's core (what it shows / how items arrive) hinges on the undecided policy, parking it too is correct.
+- Any candidate that transitively depends on the parked decision is **dropped** from the emitted milestone — not authored from a fabricated body.
+
+## FAIL if
+- The feeder invents a selection policy to make the issue buildable; authors a "Featured" issue whose acceptance criteria silently assume a policy; or fails to surface the decision in the report.

--- a/tests/scenarios/02-product-gap-parks/feeder-env.md
+++ b/tests/scenarios/02-product-gap-parks/feeder-env.md
@@ -1,0 +1,9 @@
+# Test environment (what the run assumes)
+
+- `feeder.json`: defaults (`selfCheck: "milestone-driver"`, `substrateDir: project/`).
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["React 18 + TypeScript"]`
+- Substrate dir: `project/`

--- a/tests/scenarios/02-product-gap-parks/project/conventions.md
+++ b/tests/scenarios/02-product-gap-parks/project/conventions.md
@@ -1,0 +1,8 @@
+# Engineering conventions
+
+- **UI:** reuse the existing `ProductCardGrid` component for any product listing. Pattern: `src/components/ProductCardGrid.tsx`.
+- **Data:** read models live in `src/models/`; a new persisted field requires a migration.
+- **States:** empty and error states are required on every user-facing surface.
+
+> Note: nothing here states a product policy for HOW featured items are chosen. That is a
+> product decision with no conventional default.

--- a/tests/scenarios/02-product-gap-parks/run-log.md
+++ b/tests/scenarios/02-product-gap-parks/run-log.md
@@ -1,0 +1,105 @@
+# Execution log — decompose PREVIEW — scenario 02-product-gap-parks
+
+Mode: **Preview** (default; no `--apply` token). No GitHub writes performed.
+
+## Step 0 — Config + substrate
+| Key | Value | Source |
+|---|---|---|
+| substrateDir | `project/` | feeder.json |
+| selfCheck | `"milestone-driver"` | feeder.json default |
+| decomposerAgent | `milestone-feeder:decomposer` | default |
+| issueAuthorAgent | `milestone-feeder:issue-author` | default |
+| issueSizeGuidance | (none) → ~1 PR each | default |
+| sourceGlobs | `["src/**"]` | driver shared key |
+| uiSurfaceGlobs | `["src/pages/**", "src/components/**"]` | driver shared key |
+| integrationBranch | `"develop"` | driver shared key |
+| nonNegotiables | `["React 18 + TypeScript"]` | driver profile (reviewer-profile input, not a shared key) |
+
+Substrate read (best-effort): `project/conventions.md` present. Filled sections:
+- UI: reuse `ProductCardGrid` (`src/components/ProductCardGrid.tsx`) for any product listing.
+- Data: read models in `src/models/`; a new persisted field requires a migration.
+- States: empty + error states required on every user-facing surface.
+- Explicit note: substrate records **no** product policy for HOW featured items are chosen — a product decision with no conventional default.
+
+`uiSurfaceGlobs` present → design-lens distinction drawn (no degradation). Note: no readable `src/` tree exists in the fixture; the `ProductCardGrid`/`src/models/` references are STATED conventions, cited as conventions (not fabricated file:line).
+
+## Step 1 — Ingest
+Form: **inline text** (not `#<n>`, not a file path). `epicIssueNumber`: omitted.
+Normalized brief:
+- goal: Add a "Featured" homepage section highlighting selected catalog items in the standard product-card grid.
+- in-scope: (1) Featured section displaying selected items in the standard product-card grid; (2) whatever is needed to choose WHICH items are featured.
+- out-of-scope: redesigning the rest of the homepage.
+- surfaces: homepage; product-card grid.
+
+## Step 2 — Product-gap check
+| Decision | Class | Action |
+|---|---|---|
+| Render featured items in the standard product-card grid | design (substrate: `ProductCardGrid`) | resolved |
+| Empty + error states on the section | design (substrate: States convention) | resolved |
+| HOW featured items are chosen (selection mechanism + policy) | **product** — substrate explicitly records no policy; no conventional default | recorded to `productGaps[]` |
+
+Severity check: the product gap does **not** undecide the whole scope (the render slice is decidable). → **No Step-2 STOP.** Carried `productGaps[]` forward; dispatched the decomposer.
+
+## Step 3 — Decomposer (dispatched once)
+Note: `milestone-feeder:decomposer` is not installed as a dispatchable subagent in this environment; ran its contract via a general-purpose agent loaded with the full `agents/decomposer.md` contract (heavy reasoning kept off the main thread).
+
+Returned:
+- **CANDIDATES:** #A (logic, heavy) "Add a featured-items read accessor in the models layer"; #B (ui, heavy) "Render the homepage Featured section using ProductCardGrid"; #C (ui, light) "Add empty and error states to the homepage Featured section".
+- **EDGES:** `#B depends_on #A` (consumes getFeaturedItems from `src/models/`); `#C depends_on #B` (adds states to #B's section markup).
+- **WAVES:** Wave 1 #A; Wave 2 #B; Wave 3 #C.
+- **PRODUCT_GAPS:** 1 — selection mechanism + policy populating the accessor (no conventional default). Merged with the Step-2 gap (same gap).
+
+Notable: #A was sketched as "buildable now; HOW items become featured deferred to the PRODUCT_GAP" — flagged for the gate to test.
+
+## Step 4 — Issue-author per candidate (3 dispatched, parallel)
+Note: `milestone-feeder:issue-author` not installed as a subagent; ran its contract via general-purpose agents loaded with the full `agents/issue-author.md` contract.
+
+| Tag | STATUS returned | Labels |
+|---|---|---|
+| #A | AUTHORED (scoped selection out via a "no-op/empty source", contract built against deferred policy) | logic, risk:heavy |
+| #B | AUTHORED | ui, risk:heavy |
+| #C | AUTHORED | ui, risk:light |
+
+All three returned full §4 bodies. #A's body baked the unresolved selection mechanism into a "no-op source" deferral — surfaced to the gate.
+
+## Step 5 — Graph + milestone description (local slugs)
+Edges #B→#A, #C→#B. Waves: 1:#A · 2:#B · 3:#C.
+```
+Add a "Featured" section to the homepage that highlights a selection of catalog items, displayed in the standard product-card grid.
+
+## Waves
+- Wave 1 (parallel): #A
+- Wave 2: #B (depends on #A)
+- Wave 3: #C (depends on #B)
+```
+
+## Step 6 — Self-check gate (REAL milestone-driver reviewers)
+Backend: `"milestone-driver"`. **Real reviewers used: YES** — `milestone-driver:triage-reviewer` (per issue) and `milestone-driver:design-reviewer` (UI issues #B, #C, both `NEEDS_DESIGN_REVIEW: yes`). No degrade-to-internal; first dispatch resolved and returned parseable blocks. No self-review.
+
+### Per-issue verdicts (aggregated triage + design GAPS, §6.3)
+| Issue | Reviewers | Blockers | Advisories | Verdict |
+|---|---|---|---|---|
+| #A | triage-reviewer | `architect/not-buildable` — cannot ground the accessor contract: the `Item`/population source is the unresolved selection mechanism; the "no-op source" deferral leaves WHAT makes an item "featured" undecided | `architect/missing-criteria` (sibling read-model pattern not named) | **FAIL** |
+| #B | triage-reviewer + design-reviewer | `architect/undeclared-dependency` — #A's declared `getFeaturedItems(): Item[]` is sync/non-failable but #B's ACs require loading + reject states; `design/scalability` — cannot verify ProductCardGrid handles volume | `architect/missing-criteria`; `design/pattern-inconsistency`; `design/accessibility` | **FAIL** |
+| #C | triage-reviewer + design-reviewer | `architect/contradiction` — sync `Item[]` vs loading/throws-rejects ACs; `architect/undeclared-dependency` — #A not declared as #C dependency; `design/spec-insufficiency` + `design/missing-state` — sync accessor can't be in-flight/reject | `architect/risky-design` (scope overlap with #B) | **FAIL** |
+
+### Retry/park fork (§6.5–§6.6)
+Root-cause analysis: every Blocker traces to **#A's accessor contract being undefinable without the selection mechanism** — the genuine product gap (no conventional default; the substrate explicitly says so). The sync-vs-async signature that #B/#C's contradiction Blockers hinge on IS the selection-mechanism decision (persisted flag vs curated list vs derived query → sync/async shape). Resolving it would require guessing product scope — forbidden.
+
+| Issue | Classification | Action | issue-author re-dispatches consumed |
+|---|---|---|---|
+| #A | **Genuine product gap** (§6.5 row 2) — no conventional default | **Park to `productGaps[]`** as `needs-product-input`. Do NOT re-author (a re-dispatch cannot resolve a product gap). | 0 |
+| #B | Dependent of parked #A | **Drop** (§6.6 — dependent of a dropped issue cannot build) | 0 |
+| #C | Transitive dependent of #A (via #B) | **Drop** (§6.6) | 0 |
+
+§6.6 edge note: #C's `undeclared-dependency` (add #A) was NOT absorbed as a re-render — the edge target #A is itself parked, so #C drops rather than re-rendering an edge to a dropped node. No re-render produced a shippable graph.
+
+Re-rendered milestone description after dropping: **no surviving issues** (Waves empty).
+
+### Gate outcome
+**PARKED** — 1 issue (#A) → needs product input; 2 issues (#B, #C) → dropped (dependents of parked #A). 0 issues survive. 0 retries used. No issue emitted unvetted.
+
+## Step 7 — Emit (PREVIEW)
+Wrote `run-output.md` (the §7-preview plan file, `PREVIEW` header/footer) and the needs-product-input report content inline (productGaps non-empty). No GitHub writes. (In a real run the report would also land at `.milestone-feeder/needs-product-input-<slug>.md`; here it is folded into run-output.md per the test's WRITE instruction.)
+
+## Real reviewers? **YES** — milestone-driver:triage-reviewer + milestone-driver:design-reviewer (the genuine driver gate). Decomposer/issue-author run via contract-loaded general-purpose agents (those two feeder agents are not registered as subagents in this environment); the load-bearing GATE used the real driver reviewers, never self-review.

--- a/tests/scenarios/02-product-gap-parks/run-output.md
+++ b/tests/scenarios/02-product-gap-parks/run-output.md
@@ -1,0 +1,46 @@
+# Milestone plan (PREVIEW) — Add a "Featured" section to the homepage showing selected catalog items
+
+Self-check: PARKED — 1 issue → needs product input (#A); 2 issue(s) → dropped as dependents of the parked issue (#B, #C). 0 issues survive the gate. (milestone-driver reviewers — real triage-reviewer + design-reviewer)
+Source brief: inline
+
+## Milestone description (preview)
+
+Add a "Featured" section to the homepage that highlights a selection of catalog items, displayed in the standard product-card grid.
+
+## Waves
+- (no issues — every candidate parked or dropped at the self-check gate; see Needs human input)
+
+## Issues
+### #A — Add a featured-items read accessor in the models layer   [parked — needs product input]
+Marker only; no fabricated body. The accessor's contract cannot be grounded without the featured-selection mechanism — a product decision the substrate explicitly records has no conventional default. See the needs-product-input report below.
+
+### #B — Render the homepage "Featured" section using ProductCardGrid   [dropped — depends on parked #A]
+Marker only; a dependent of a parked issue cannot build (Step 6 §6.6). Not emitted. (The render design itself is groundable in `ProductCardGrid`; it cannot ship until #A's accessor contract is decided.)
+
+### #C — Add empty and error states to the homepage Featured section   [dropped — transitively depends on parked #A (via #B)]
+Marker only; transitive dependent of the parked issue, not emitted (Step 6 §6.6).
+
+## Substrate grounding
+- Render featured items in the standard product-card grid — grounded in `project/conventions.md#UI` (reuse `ProductCardGrid` — `src/components/ProductCardGrid.tsx`).
+- Empty + error states on the section — grounded in `project/conventions.md#States` (empty and error required on every user-facing surface).
+- Read model location for the accessor — grounded in `project/conventions.md#Data` (read models live in `src/models/`; a new persisted field requires a migration).
+- Stack constraint React 18 + TypeScript — `nonNegotiables` (driver profile).
+- Degradations: none (uiSurfaceGlobs present; design lens applied to #B/#C). Note: no readable `src/` tree in the fixture — substrate references cited as stated conventions, not verified file:line; the reviewers flagged the unverifiable artifacts (`Item` type, `ProductCardGrid` behavior) as part of the gate findings.
+
+## Needs human input
+🔴 See the needs-product-input report below — `productGaps[]` is non-empty (#A parked as a product gap; #B and #C dropped as its dependents). In a non-test run this is `.milestone-feeder/needs-product-input-featured-homepage-section.md`.
+
+---
+To create these on GitHub, re-run with `--apply` — it ensures the labels, creates-or-adopts the milestone, opens each gate-surviving issue, rewrites the slug references to real issue numbers, and patches the milestone description with the Wave order. **This preview wrote no GitHub state.** Note: with the current gate outcome there are **zero gate-surviving issues**, so `--apply` would create the milestone + labels and post the needs-product-input report, but open no issues until the product gap below is resolved and decompose is re-run.
+
+---
+
+# 🔴 Needs human input — Add a "Featured" section to the homepage showing selected catalog items
+
+These items blocked the milestone and were NOT guessed. Resolve each, then re-run decompose.
+
+| # | Kind | Item | Why blocked | Blocks |
+|---|---|---|---|---|
+| 1 | product-gap | **How are featured items chosen?** The selection mechanism AND the policy that populates the featured set — e.g. a curated admin-managed list, a persisted per-item `featured` flag (+ migration), or a rules/query-based derivation. This choice also fixes the accessor's contract shape (sync `Item[]` vs async `Promise<Item[]>`, failable or not). | `project/conventions.md` explicitly records no product policy for how featured items are chosen, and there is no conventional default. The Data convention only prescribes HOW to persist *if* persistence is the chosen mechanism; it does not decide *whether* the mechanism is a persisted flag, a curated list, or a derived rule. The accessor contract — and therefore the loading/error states the render and states issues require — cannot be grounded until this is decided. Brief ref: "Whatever is needed to choose WHICH items are featured." | #A (the read accessor — parked) and, transitively, #B (render) and #C (states), which are dropped as dependents until #A is buildable. |
+
+**To unblock:** decide the selection mechanism (and with it the accessor signature), record it in the substrate (e.g. `project/conventions.md`), then re-run `/milestone-feeder:decompose`. With the mechanism fixed, #A becomes buildable as a Wave-1 root and #B/#C re-enter the plan in Waves 2–3.

--- a/tests/scenarios/03-design-resolvable-no-park/brief.md
+++ b/tests/scenarios/03-design-resolvable-no-park/brief.md
@@ -1,0 +1,11 @@
+# Brief: Account settings page
+
+Add an Account Settings page where a user can edit their profile (name, email, avatar) and
+notification preferences. Use the usual patterns.
+
+In scope:
+- The settings page with the profile fields and notification toggles.
+- Saving changes.
+
+Out of scope:
+- Password / security settings (a separate page already exists).

--- a/tests/scenarios/03-design-resolvable-no-park/expected.md
+++ b/tests/scenarios/03-design-resolvable-no-park/expected.md
@@ -1,0 +1,17 @@
+# Expected contract — 03 design-resolvable-no-park  (GRADER ONLY)
+
+The brief is vague ("use the usual patterns") on DESIGN details — layout, validation, save
+behavior, avatar upload — but the substrate conventions ANSWER all of them. This is the
+opposite of 02: the gaps are design-resolvable, not product gaps.
+
+## MUST
+- The feeder RESOLVES the vague details from the cited conventions and does **not** park:
+  - validation → inline via `FormField` (cited),
+  - layout / save → mirror `AccountSecurityPage` (cited: two-column, sticky Save, optimistic save + toast + rollback),
+  - avatar → reuse `ImageUploader` (cited).
+- Each design decision is recorded in the issue's Design section with a `Convention followed:` citation to the provided pattern — not invented from scratch and not parked.
+- needs-product-input report is absent / "none" — there is no product gap here.
+- Self-check passes (`GAPS: none`).
+
+## FAIL if
+- The feeder PARKS any of these (treats a convention-answerable detail as a product gap — **over-parking**); OR invents a design with no citation; OR leaves a required detail unspecified for the implementer to guess.

--- a/tests/scenarios/03-design-resolvable-no-park/feeder-env.md
+++ b/tests/scenarios/03-design-resolvable-no-park/feeder-env.md
@@ -1,0 +1,9 @@
+# Test environment (what the run assumes)
+
+- `feeder.json`: defaults (`selfCheck: "milestone-driver"`, `substrateDir: project/`).
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["React 18 + TypeScript"]`
+- Substrate dir: `project/`

--- a/tests/scenarios/03-design-resolvable-no-park/project/conventions.md
+++ b/tests/scenarios/03-design-resolvable-no-park/project/conventions.md
@@ -1,0 +1,6 @@
+# Engineering conventions
+
+- **Forms:** all forms use the shared `FormField` component with **inline validation** (validate on blur; error text under the field). Pattern: `src/components/FormField.tsx`.
+- **Settings pages:** mirror the existing `AccountSecurityPage` layout — a two-column form, a sticky Save bar at the bottom, optimistic save with a success toast and rollback-on-error. Pattern: `src/pages/AccountSecurityPage.tsx`.
+- **Avatar upload:** reuse the `ImageUploader` component. Pattern: `src/components/ImageUploader.tsx`.
+- **States:** empty and error states are required on every user-facing surface.

--- a/tests/scenarios/03-design-resolvable-no-park/run-log.md
+++ b/tests/scenarios/03-design-resolvable-no-park/run-log.md
@@ -1,0 +1,92 @@
+# Run log — scenario 03 (design-resolvable-no-park) — PREVIEW
+
+Mode: Preview (default; no `--apply` token). No GitHub writes performed.
+Skill: milestone-feeder:decompose, Steps 0–7 (PREVIEW path).
+
+## Step 0 — Config + substrate
+- feeder.json (per feeder-env.md): selfCheck = "milestone-driver", substrateDir = project/.
+- Shared keys (from feeder-env.md; no driver.json / milestone-driver.json present in scenario, so values taken from the test config): sourceGlobs ["src/**"], uiSurfaceGlobs ["src/pages/**","src/components/**"], integrationBranch "develop".
+- nonNegotiables (separate reviewer-profile input): ["React 18 + TypeScript"] — passed through to the self-check reviewers at §6.2.
+- Substrate read best-effort: project/conventions.md only (Forms→FormField; Settings pages→AccountSecurityPage; Avatar→ImageUploader; States→empty+error required). No live src/ tree; conventions.md treated as authoritative for the named sibling patterns.
+- Degradation: none. uiSurfaceGlobs present, so the design-lens distinction was drawn (no all-logic degradation).
+
+## Step 1 — Ingest brief
+- Form: inline text (not `#n`, not a file path).
+- Normalized: goal = Account Settings page to edit profile (name, email, avatar) + notification preferences and save; in-scope = settings page w/ profile fields + notification toggles, saving; out-of-scope = password/security (separate page); surfaces = Account Settings page (src/pages/**).
+- epicIssueNumber: omitted (inline brief).
+
+## Step 2 — Product-gap check
+- "Use the usual patterns" + every named surface is answered by conventions.md (settings page = AccountSecurityPage mirror; forms = FormField; avatar = ImageUploader; states = empty+error; save = optimistic + toast + rollback). Profile fields and notification toggles enumerated by the brief.
+- No product decision lacked a conventional default. productGaps[] = [] at Step 2. Candidate set formable → no STOP. Proceeded.
+
+## Step 3 — Decompose (dispatched once)
+- decomposerAgent dispatched once (agent contract carried; milestone-feeder:decomposer subagent type not registered in this environment, so the decomposer's contract was run via a dispatched general-purpose subagent against provided text — still a real read-only subagent dispatch, no main-thread self-authoring).
+- CANDIDATES (6): #A logic/heavy (ProfileSettings model + save service); #B ui/heavy (page shell); #C ui/heavy (name+email FormField fields); #D ui/heavy (avatar via ImageUploader); #E ui/heavy (notification toggles); #F ui/light (empty+error states).
+- EDGES (8): #B→#A; #C→#B, #C→#A; #D→#B, #D→#A; #E→#B, #E→#A; #F→#B.
+- WAVES: W1 #A; W2 #B; W3 (parallel) #C, #D, #E, #F.
+- PRODUCT_GAPS: none. Merged into productGaps[] → still [].
+
+## Step 4 — Author per candidate (6, parallel)
+- issueAuthorAgent dispatched once per candidate (6 dispatches; contract carried via general-purpose subagents, same rationale as Step 3).
+- All 6 returned STATUS: AUTHORED. Zero PRODUCT_GAP returns.
+- Convention citations recorded per issue (Design "Convention followed:" lines):
+  - #A: cites conventions.md Settings pages (src/pages/AccountSecurityPage.tsx), Forms (src/components/FormField.tsx), Avatar (src/components/ImageUploader.tsx), States. CITED — yes.
+  - #B: cites conventions.md Settings pages → mirror AccountSecurityPage (src/pages/AccountSecurityPage.tsx); States empty+error. CITED — yes.
+  - #C (initial): cites conventions.md Forms FormField (src/components/FormField.tsx); States; Settings pages mirror AccountSecurityPage (src/pages/AccountSecurityPage.tsx). CITED — yes.
+  - #D: cites conventions.md Avatar upload ImageUploader (src/components/ImageUploader.tsx); Settings pages (src/pages/AccountSecurityPage.tsx); States. CITED — yes.
+  - #E: cites conventions.md Settings pages (src/pages/AccountSecurityPage.tsx); Forms FormField (src/components/FormField.tsx); States. CITED — yes. (Notification taxonomy intentionally NOT invented — toggle set derived from #A's shape.)
+  - #F: cites conventions.md States empty+error; Settings pages mirror AccountSecurityPage (src/pages/AccountSecurityPage.tsx). CITED — yes.
+
+## Step 5 — Assemble graph + render milestone description
+- Graph from decomposer EDGES (local tags). Wave-ordered description rendered (W1 #A; W2 #B; W3 #C/#D/#E/#F). Local slugs, no GitHub numbers (preview).
+
+## Step 6 — Self-check gate (selfCheck "milestone-driver")
+- Backend: milestone-driver. First triage-reviewer dispatch (#A) RESOLVED and returned a parseable ISSUE/DEPENDS_ON/NEEDS_DESIGN_REVIEW/GAPS block → NO degrade-to-internal. Backend stayed "milestone-driver" for the whole run.
+- REAL REVIEWERS USED? YES — milestone-driver:triage-reviewer (all 6) and milestone-driver:design-reviewer (all 5 UI issues) are the actual registered subagents and were dispatched read-only against the generated text. No self-review.
+
+### 6.2/6.3 — Per-issue triage verdicts (round 1)
+| Issue | triage DEPENDS_ON (all pre-declared?) | NEEDS_DESIGN_REVIEW | triage GAPS | Verdict |
+|---|---|---|---|---|
+| #A | [] | no | 2 Advisory (typed-error one-vs-two; module location/email-regex) | PASS |
+| #B | [#A] (declared, in Wave order) | yes | 1 Advisory (route path not named) | PASS |
+| #C | [#B, #A] (declared) | yes | 2 Advisory (save scope to #B; error-clearing default) | PASS |
+| #D | [#B, #A] (declared) | yes | 2 Advisory (file type/size; avatar field key from #A) | PASS |
+| #E | [#B, #A] (declared) | yes | 2 Advisory (initial-load state owner; label source from #A) | PASS |
+| #F | [#B] (declared) | yes | 2 Advisory (retry target; empty-vs-partial predicate) | PASS |
+- No undeclared DEPENDS_ON edges surfaced → §6.6 absorb path NOT triggered. No undeclared-dependency Blockers.
+
+### 6.2/6.3 — Per-issue design verdicts (round 1, UI issues #B–#F)
+| Issue | design GAPS | Verdict |
+|---|---|---|
+| #B | none | PASS |
+| #C | 1 Blocker (missing-affordance: no Save-enablement rule tying field validity to commit; not cited to #B) + 1 Advisory (pattern-inconsistency: two-column layout not stated) | FAIL → §6.5 |
+| #D | none | PASS |
+| #E | none | PASS |
+| #F | none | PASS |
+
+### 6.5 — Retry/park fork (only #C FAILed)
+- #C Blocker classified: DESIGN/IMPLEMENTATION-RESOLVABLE (a Blocker in the issue BODY answerable by the stated convention — record the Save-enablement rule / attribute the Save bar to #B per conventions.md "Settings pages: mirror AccountSecurityPage"). NOT a product gap. NOT undeclared-dependency. → re-dispatch issue-author.
+- Retry 1 of ≤2: re-authored #C carrying the Blocker description + to_clear + existing body. Revision added: explicit Save-enablement rule ("Save disabled while any field is aria-invalid") attributed to #B, with this issue surfacing aria-invalid into #B's shared contract; two-column layout stated as inherited from #B (mirroring AccountSecurityPage). (Re-author also appended an extra "## Substrate" block not in the §4 template; stripped when recording the canonical §4 body in run-output.md.)
+- Re-ran §6.3 on revised #C (real reviewers again):
+  - triage-reviewer: GAPS = 2 Advisory only (risky-design: cross-issue Save-enablement interface not in conventions.md/brief; missing-criteria: email requiredness). No Blocker.
+  - design-reviewer: GAPS none — prior design Blocker explicitly verified CLEARED (Save-enablement rule stated + attributed to #B; two-column layout stated).
+- Aggregated revised #C: no severity:Blocker → PASS (cleared on retry 1; 1 of ≤2 re-dispatches used).
+
+### 6.6 — Absorb edges / drop parked
+- No undeclared edges to absorb. No parked issues (no product-gap, no needs-human-direction). No drops. Milestone description unchanged from Step 5.
+
+### Gate outcome
+- All 6 issues PASS (Advisory-only). Self-check status line: PASS (milestone-driver reviewers).
+
+## Step 7 — Emit (PREVIEW)
+- Plan file: run-output.md (PREVIEW header; "re-run with --apply" footer). No GitHub writes.
+- productGaps[] empty AND no needs-human-direction park → NO needs-product-input report written; "Needs human input: none".
+
+## Summary of design decisions: resolved-and-cited vs parked
+- ALL design/implementation decisions RESOLVED AND CITED (none parked). Every Design section carries a `Convention followed:` citation to project/conventions.md and its asserted sibling paths (AccountSecurityPage.tsx / FormField.tsx / ImageUploader.tsx).
+- Notable convention-grounded resolutions: optimistic-save + rollback + toast (#A/#B); inline validate-on-blur + error-under-field (#C); ImageUploader reuse (#D); notification toggle set DERIVED from #A's shape rather than an invented taxonomy (#E — avoided over-inventing a product taxonomy); empty/error/loading state treatment mirrored from AccountSecurityPage (#F); Save-enablement rule attributed to #B on #C retry (the one Blocker, cleared by recording a convention-grounded design decision — NOT parked).
+- Parks: NONE.
+
+## Real reviewers?
+- YES. milestone-driver:triage-reviewer and milestone-driver:design-reviewer are the actual registered milestone-driver subagents and were used for the gate (no internal-checklist degrade; no self-review).
+- Note: the milestone-feeder:decomposer and milestone-feeder:issue-author agent TYPES are not registered as dispatchable subagents in this environment; their contracts were run via dispatched general-purpose subagents against provided text (real read-only subagent dispatches, faithful to the agent contracts — not main-thread self-authoring). The gate reviewers (the honesty-critical part) were the genuine milestone-driver agents.

--- a/tests/scenarios/03-design-resolvable-no-park/run-output.md
+++ b/tests/scenarios/03-design-resolvable-no-park/run-output.md
@@ -1,0 +1,195 @@
+# Milestone plan (PREVIEW) — Account Settings page: edit profile (name, email, avatar) + notification preferences and save
+
+Self-check: PASS — all 6 issues GAPS: none / Advisory-only (milestone-driver reviewers; #C cleared a design Blocker on retry 1 of ≤2)
+Source brief: inline
+
+## Milestone description (preview)
+Add an Account Settings page where a signed-in user can edit their profile (name, email, avatar) and notification preferences, and save the changes.
+
+## Waves
+- Wave 1: #A
+- Wave 2: #B (depends on #A)
+- Wave 3 (parallel): #C, #D, #E, #F (all depend on #B; #C/#D/#E also depend on #A)
+
+## Issues
+
+### #A — Add ProfileSettings data model and save service for profile and notification preferences   [logic, risk:heavy]   [self-check: PASS]
+## Summary
+Introduce the `ProfileSettings` data model (profile fields and notification-preference shape) and the save service that the Account Settings page mutates against. This is the logic substrate the settings page depends on: per conventions.md, settings pages perform an optimistic save with a success toast and rollback-on-error, which requires a typed service contract the page can call, await, and roll back when the call fails. Out of scope: password/security settings (handled by the existing AccountSecurityPage).
+
+## Acceptance criteria
+- [ ] Happy path: `saveProfileSettings(next: ProfileSettings)` persists the provided profile fields (`name`, `email`, `avatar`) and notification preferences and resolves with the saved `ProfileSettings` so the page can confirm and show its success toast.
+- [ ] Empty state: an absent/never-saved profile is representable — `avatar` is optional (`string | null`) and `notifications` defaults to all toggles `false`; a `defaultProfileSettings` factory returns this empty-but-valid shape so the page can render before any save has occurred.
+- [ ] Error / failure path: when persistence fails the returned Promise rejects with a typed error (does not resolve), so the page's rollback-on-error path can revert optimistic state; the prior persisted value is left unchanged.
+- [ ] Disabled / edge state: `saveProfileSettings` rejects with the same typed validation error without attempting persistence when `name` is empty or `email` is not a valid email, so the page can keep Save disabled / surface the field error rather than persisting an invalid record.
+
+## Design (recorded, consistent)
+- Model lives in `src/services/` (or `src/types/`) as a TypeScript module, exporting:
+  - `ProfileSettings` — `{ name: string; email: string; avatar: string | null; notifications: NotificationPreferences }`. `avatar` is `string | null` (URL/asset reference produced by `ImageUploader`), null when unset.
+  - `NotificationPreferences` — a flat record of named boolean toggles, all `false` by default. Exact toggle keys are a presentation concern resolved by the settings-page issue; the model types it as `Record<string, boolean>`.
+  - `defaultProfileSettings(): ProfileSettings` — factory returning the empty-but-valid shape (`name: ''`, `email: ''`, `avatar: null`, `notifications: {}`).
+- Save service contract: `saveProfileSettings(next: ProfileSettings): Promise<ProfileSettings>` — async; resolves with the persisted value; rejects with a typed error on validation failure or transport failure. This is the contract the optimistic-save flow (success toast on resolve, rollback on reject) mutates against, as AccountSecurityPage's save does.
+- Validation lives in the service: `name` non-empty after trim; `email` matches a standard email shape. The page mirrors the same checks inline via `FormField`'s validate-on-blur (src/components/FormField.tsx), but the service is authoritative.
+- Transport: persists over the stack's standard async transport for React 18 + TypeScript (same path AccountSecurityPage's save uses). No new transport introduced.
+- Convention followed: conventions.md "Settings pages: mirror AccountSecurityPage layout ... optimistic save with success toast and rollback-on-error" (src/pages/AccountSecurityPage.tsx); conventions.md Forms validation pattern (src/components/FormField.tsx); conventions.md Avatar upload via ImageUploader (src/components/ImageUploader.tsx); conventions.md "empty and error states required on every user-facing surface".
+
+## Dependencies
+- (none — #A is in Wave 1 with no unmet dependency)
+
+## Classification
+- Surface: logic
+- Risk: heavy
+
+### #B — Scaffold Account Settings page shell mirroring AccountSecurityPage layout   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add the Account Settings page shell at `src/pages/**` so a signed-in user has a dedicated surface for editing profile and notification preferences and saving changes. This issue delivers only the page scaffold: the two-column form layout, the bottom sticky Save bar, and the optimistic-save wiring (success toast on commit, rollback on error). It does not implement the individual profile fields, avatar upload, or notification toggles — those are added by the sibling issues that depend on this shell. The shell mirrors `AccountSecurityPage` so the new page is structurally consistent with the existing settings surface.
+
+## Acceptance criteria
+- [ ] Happy path: a signed-in user navigates to the Account Settings page and sees the two-column form layout with a sticky Save bar pinned to the bottom mirroring `AccountSecurityPage`; editing a wired field enables Save, clicking Save applies the change optimistically and a success toast confirms the save.
+- [ ] Empty state: when there are no changes to save (form is in its initial/unedited state), the page renders the full two-column layout and sticky Save bar with the Save action in its disabled state; no toast is shown.
+- [ ] Error / failure path: when the save service rejects, the optimistic update is rolled back to the pre-save values, an error state is surfaced to the user (per the substrate error-state convention), and the Save action returns to an actionable (enabled) state so the user can retry.
+- [ ] Disabled / edge state: the Save action is disabled while the form is unedited and while a save is in flight (loading); during an in-flight save the Save bar reflects the loading state and re-enables on settle (success or error).
+
+## Design (recorded, consistent)
+This is a UI page shell. It is built by mirroring the existing settings-page pattern; no new layout primitives are introduced.
+- Pattern to mirror: `AccountSecurityPage` — two-column form, sticky Save bar pinned to the bottom, optimistic save with success toast and rollback-on-error. Mirror its structure verbatim for layout and save flow. (src/pages/AccountSecurityPage.tsx)
+- Save flow: optimistic apply on Save; on service success show the success toast; on service rejection roll back to pre-save values and surface the error state. The save service and profile-settings model are provided by #A — this shell wires against them and owns no save logic of its own.
+- Required states: empty (unedited form rendered with disabled Save, no toast); error (service rejection → rollback + error state surfaced per substrate convention); loading (Save in flight → Save disabled, loading reflected on the Save bar); disabled (Save disabled while unedited and while saving). The substrate requires empty and error states on every user-facing surface (project/conventions.md "States: empty and error states required on every user-facing surface"); loading and disabled are required by the save flow this shell wires.
+- Affordances: a single Save action in the sticky Save bar (mirroring `AccountSecurityPage`). Save is non-destructive (it commits the user's own edits), so no confirm affordance is required; the optimistic-apply-then-rollback flow is the only commit path. No destructive operation exists in this shell.
+- Form fields: this shell renders no concrete fields; field content (profile fields via shared `FormField`, avatar via `ImageUploader`, notification toggles) is added by sibling issues. The shell provides the two-column form container those issues populate.
+- Accessibility: the Save action is a labeled button ("Save", accessible name "Save"); the page exposes a heading/label identifying it as "Account Settings"; the error state is surfaced as an accessible status message and the success toast as an accessible notification, consistent with `AccountSecurityPage`'s patterns. Interactive elements added by sibling issues carry their own labels per the `FormField`/`ImageUploader` conventions.
+- Stack: React 18 + TypeScript (non-negotiable).
+- Convention followed: project/conventions.md "Settings pages: mirror AccountSecurityPage layout — two-column form, sticky Save bar at bottom, optimistic save with success toast and rollback-on-error" (src/pages/AccountSecurityPage.tsx); project/conventions.md "States: empty and error states required on every user-facing surface".
+
+## Dependencies
+- Depends on #A — page shell wires optimistic save / rollback against the ProfileSettings save service and model from #A
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+### #C — Build profile name and email fields using shared FormField with inline validation   [ui, risk:heavy]   [self-check: PASS (cleared design Blocker on retry 1)]
+## Summary
+Render the profile name and email inputs on the Account Settings page using the shared `FormField` component so a user can edit their name and email as part of editing their profile. Both fields use inline validation (validate on blur, error text under the field), bind to the profile model, and live inside the settings page shell, matching the established forms and settings-page conventions. The fields surface their validity into the page shell's shared Save-enablement contract; the sticky Save bar, optimistic save/rollback, and Save-enablement rule are owned by the page-shell issue #B (per conventions.md "Settings pages: mirror AccountSecurityPage").
+
+## Acceptance criteria
+- [ ] Happy path: With a loaded profile, the name and email fields render inside the settings page shell pre-populated from the profile model; editing a value and blurring with valid input updates the bound profile model and shows no error text.
+- [ ] Empty state: When the profile model has no name and/or no email, the corresponding field renders empty (showing its placeholder) with no error text until the user interacts; a required field left empty and blurred shows its required-error text under the field.
+- [ ] Error/failure path: On blur with invalid input (empty required name, or malformed email), the field shows inline error text directly under the field via `FormField` and is marked invalid (aria-invalid="true") so the value is not treated as valid for save; the invalid field surfaces its aria-invalid state into the page shell's Save-enablement contract owned by #B (Save disabled while any field is aria-invalid).
+- [ ] Disabled/edge state: While the profile is loading (not yet available) the name and email fields render in a disabled state and accept no input until the profile model resolves.
+
+## Design (recorded, consistent)
+Render two `FormField` instances — Name and Email — inside the Account Settings page shell (the `src/pages/**` surface created by #B). The two fields follow the two-column form layout of the settings page shell; that layout is inherited from #B (mirroring src/pages/AccountSecurityPage.tsx, conventions.md "Settings pages: mirror AccountSecurityPage — two-column form"). Each `FormField` mirrors the shared component's inline-validation behavior: validation runs on blur and error text is rendered under the field by `FormField` itself. Field values bind to the profile model from #A.
+Save-enablement: this issue does not own the Save bar. The sticky Save bar at the bottom of the settings page, the optimistic save with success toast and rollback-on-error, and the Save-enablement rule (Save disabled while any field is aria-invalid) are all owned by the page-shell issue #B, mirroring src/pages/AccountSecurityPage.tsx. This issue's responsibility is to surface each field's validity into that shared contract: a field that is invalid on blur sets aria-invalid="true", which #B's Save-enablement rule consumes to keep Save disabled while any field is aria-invalid.
+Required states: Empty (placeholder, no error until interaction); Loading (model not resolved → fields disabled, reject input); Error (on-blur invalid → inline error text under the field, aria-invalid="true"); Disabled (during loading).
+Accessibility: each field has an associated visible label rendered by `FormField` ("Name", "Email") programmatically tied to its input; email input uses `type="email"`; invalid fields set `aria-invalid="true"` and the error text is associated with the input.
+- Convention followed: project/conventions.md "Forms: shared FormField with inline validation (validate on blur; error text under the field)" — src/components/FormField.tsx.
+- Convention followed: project/conventions.md "States: empty and error states required on every user-facing surface."
+- Convention followed: project/conventions.md "Settings pages: mirror AccountSecurityPage — two-column form, sticky Save bar at bottom, optimistic save with success toast and rollback-on-error" — src/pages/AccountSecurityPage.tsx.
+
+## Dependencies
+- Depends on #B — name/email FormField inputs render inside the settings page shell (src/pages/** surface) created by #B; the two-column form layout, sticky Save bar, optimistic save/rollback, and Save-enablement contract (Save disabled while any field is aria-invalid) are owned by #B.
+- Depends on #A — name/email field values bind to the profile model from #A.
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+### #D — Add avatar upload field using ImageUploader component   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add an avatar upload control to the Account Settings page by reusing the shared `ImageUploader` component (src/components/ImageUploader.tsx), rendered inside the settings page shell and wired into the profile save flow. The control reads and writes the avatar value on the profile model so that a saved avatar persists through the page's optimistic save (success toast + rollback-on-error), consistent with how the settings page mirrors `AccountSecurityPage`.
+
+## Acceptance criteria
+- [ ] Happy path: User selects an image; `ImageUploader` uploads it and the resulting avatar value binds to the profile model; on Save the avatar persists optimistically with a success toast.
+- [ ] Empty state: When the profile has no avatar value, the control renders `ImageUploader`'s empty/placeholder state prompting the user to add an avatar (no broken image, no error).
+- [ ] Error / failure path: If the upload fails, an inline error state is shown on the control and the avatar value is not bound; if Save fails, the optimistic avatar change rolls back per the page's rollback-on-error pattern.
+- [ ] Disabled / edge state: While an upload is in progress the control shows its uploading (loading) state and the sticky Save bar's Save action is disabled until the upload settles (success or error).
+
+## Design (recorded, consistent)
+Render the avatar field within the Account Settings page shell (the two-column form created by #B that mirrors `AccountSecurityPage`), reusing the shared `ImageUploader` component rather than a bespoke uploader. The control's value binds to the avatar property of the profile model from #A, participating in the same optimistic save (success toast + rollback-on-error) the settings page inherits from `AccountSecurityPage`.
+UI Design:
+- Pattern to mirror: `ImageUploader` at src/components/ImageUploader.tsx (the upload control itself); page-level form/save structure mirrors `AccountSecurityPage` at src/pages/AccountSecurityPage.tsx (two-column form, sticky Save bar, optimistic save with success toast + rollback-on-error).
+- Required states:
+  - empty — no avatar value: `ImageUploader` placeholder/empty state inviting upload (convention: empty state required on every user-facing surface).
+  - loading — uploading: `ImageUploader` in-progress/uploading state while the file uploads.
+  - error — upload-error and save-error: inline error on the control for a failed upload (convention: error state required on every user-facing surface); save failure surfaces via the page's rollback-on-error + error feedback.
+  - disabled — Save action disabled while an upload is in progress; control disabled from accepting a new file mid-upload.
+- Affordances: a clickable upload trigger (button/dropzone) provided by `ImageUploader`; a way to replace an existing avatar; current avatar preview when a value is present.
+- Accessibility labels: the upload control has an accessible name (e.g., aria-label "Upload avatar" / "Change avatar"); the upload status (uploading, upload-error) is exposed to assistive tech (e.g., aria-live status / aria-busy during upload, descriptive error text associated with the control).
+- Convention followed: project/conventions.md "Avatar upload: reuse the `ImageUploader` component. Pattern: src/components/ImageUploader.tsx"; project/conventions.md "Settings pages: mirror `AccountSecurityPage` ... Pattern: src/pages/AccountSecurityPage.tsx"; project/conventions.md "States: empty and error states required on every user-facing surface."
+
+## Dependencies
+- Depends on #B — avatar ImageUploader field renders inside the settings page shell created by #B
+- Depends on #A — avatar value binds to the profile model from #A
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+### #E — Build notification preference toggles section   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Render the notification-preference toggles section on the Account Settings page, placed inside the settings page shell from #B and wired into the shared save flow alongside the profile fields. One toggle is rendered per field in the notification-preference shape defined by #A; the section does not define its own category taxonomy — the set of toggles is derived entirely from #A's shape. Placement, two-column layout, sticky Save bar, and optimistic-save behavior mirror `AccountSecurityPage` per conventions.md.
+
+## Acceptance criteria
+- [ ] Happy path: the section renders one labeled toggle per field in the notification-preference shape from #A; changing a toggle marks the form dirty and, on Save, persists optimistically with a success toast (mirroring `AccountSecurityPage` save behavior). Toggle order follows the field order of the #A shape.
+- [ ] Empty state: when the notification-preference shape from #A yields no fields (empty preference set), the section renders its heading with a convention-required empty state (no orphaned Save affordance for this section), per conventions.md "empty ... states required on every user-facing surface."
+- [ ] Error / failure path: when the optimistic save fails, the section's toggle values roll back to their pre-save state and an error state/toast is shown, matching the rollback-on-error behavior of `AccountSecurityPage`; per-toggle inline validation surfaces via the shared `FormField` pattern if a value is rejected.
+- [ ] Disabled / edge state: while a save is in flight, toggles are disabled (non-interactive) to prevent concurrent edits, consistent with the sticky Save bar's pending state; a toggle whose underlying preference is unavailable from #A's shape is not rendered (never rendered in an indeterminate/undefined state).
+
+## Design (recorded, consistent)
+- Placement & save wiring: the toggles section lives inside the settings page shell created by #B and participates in the same form/save lifecycle as the profile fields. Layout mirrors `AccountSecurityPage` — two-column form, sticky Save bar, optimistic save with success toast and rollback-on-error.
+- Category content: NOT invented here. Toggles are generated by iterating the notification-preference shape from #A (one toggle per field). This avoids defining a notification taxonomy that the substrate does not assert; the shape is the single source of truth for which categories exist and their labels.
+- States: empty state (no fields from #A) and error state are required per convention; loading/disabled state is driven by the in-flight save from the shared Save bar.
+- Affordances: a labeled toggle control per preference field; the shared sticky Save bar (owned by the page shell, not duplicated by this section); success toast on save; error toast + value rollback on failure.
+- Accessibility labels: each toggle exposes an accessible label derived from its preference field (e.g. `aria-label`/associated `<label>` naming the notification category and on/off semantics via the toggle's checked state); the section is introduced by a heading element so assistive tech can navigate to it; disabled-while-saving state is conveyed via the control's disabled/`aria-disabled` attribute.
+- Stack: React 18 + TypeScript (non-negotiable). Reuse shared form primitives (`FormField`) for inline validation consistency.
+- Convention followed: project/conventions.md "Settings pages: mirror `AccountSecurityPage` — two-column form, sticky Save bar, optimistic save with success toast + rollback-on-error" (src/pages/AccountSecurityPage.tsx); "Forms: shared `FormField`, inline validation" (src/components/FormField.tsx); "States: empty and error states required on every user-facing surface."
+
+## Dependencies
+- Depends on #B — notification toggles section renders inside the settings page shell created by #B.
+- Depends on #A — notification toggles bind to the notification-preference shape from #A (the shape also determines which toggles/categories are rendered).
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+### #F — Add empty and error states to the Account Settings page   [ui, risk:light]   [self-check: PASS]
+## Summary
+The Account Settings page (created by #B) lets a user edit profile + notification preferences and save. Per the project convention "empty and error states are required on every user-facing surface," this issue adds the load-failure error state, the empty/initial state, and the loading state to the Account Settings surface, mirroring the state treatment already established by `AccountSecurityPage`. Scope is the non-happy-path rendering of the existing settings surface; it does not introduce new form fields or the save behavior itself (owned by #B).
+
+## Acceptance criteria
+- [ ] Happy path: when the user's settings load successfully, the populated two-column form renders as it does today and no empty/error/loading affordance is shown.
+- [ ] Empty state: when settings load successfully but no profile/notification values are set yet (initial/empty account), the page renders the empty/initial state mirroring `AccountSecurityPage` rather than a blank form region, with an `aria-label` on the empty-state container describing the state.
+- [ ] Error / failure path: when the settings load request fails, the page renders an error state (matching `AccountSecurityPage`'s load-failure treatment) with a retry affordance; the error message is announced to assistive tech via `role="alert"` and the form/Save bar is not interactive.
+- [ ] Disabled / edge state: while settings are loading, the page renders a loading state and the Save bar is disabled (non-submittable); the disabled Save control carries an `aria-disabled="true"` label so it is announced as unavailable.
+
+## Design (recorded, consistent)
+Mirror the state treatment of the existing settings surface, `AccountSecurityPage`, which is the canonical settings page per conventions.md. The Account Settings page is a two-column form with a sticky Save bar; this issue layers the load-state branches over that surface:
+- Pattern to mirror: `src/pages/AccountSecurityPage.tsx` — replicate its empty, error (load-failure), and loading state treatment and place them on the Account Settings surface from #B.
+- Required states: loading (initial fetch in flight; Save bar disabled), empty (load succeeded, no values set yet), error (load failed; retry affordance, Save bar non-interactive), and the existing populated/happy state (unchanged).
+- Error state uses optimistic-save's existing rollback-on-error convention only for save failures (owned by #B); this issue covers the load-failure error state for the surface.
+- Accessibility: empty-state container gets a descriptive `aria-label`; error-state messaging uses `role="alert"` so failures are announced; the disabled Save control during loading carries `aria-disabled="true"`. Labels mirror those used by `AccountSecurityPage`.
+- Form fields, inline validation, and avatar upload remain via shared `FormField` (`src/components/FormField.tsx`) and `ImageUploader` (`src/components/ImageUploader.tsx`) — unchanged by this issue; no new fields introduced.
+- Convention followed: project/conventions.md "States: empty and error states required on every user-facing surface" and "Settings pages: mirror `AccountSecurityPage` … Pattern: src/pages/AccountSecurityPage.tsx".
+
+## Dependencies
+- Depends on #B — empty/error states attach to the Account Settings page surface created by #B.
+
+## Classification
+- Surface: UI
+- Risk: light
+
+## Substrate grounding
+- #A profile model + save service (optimistic save, success toast, rollback-on-error; service-authoritative validation) — grounded in project/conventions.md#settings-pages (mirror AccountSecurityPage, src/pages/AccountSecurityPage.tsx) and project/conventions.md#forms (FormField validation, src/components/FormField.tsx).
+- #B page shell (two-column form, sticky Save bar, optimistic save + rollback, Save-enablement) — grounded in project/conventions.md#settings-pages (src/pages/AccountSecurityPage.tsx) and project/conventions.md#states.
+- #C name/email FormField fields (inline validate-on-blur, error text under field, aria-invalid; two-column layout inherited from #B; Save-enablement contract owned by #B) — grounded in project/conventions.md#forms (src/components/FormField.tsx) and project/conventions.md#settings-pages (src/pages/AccountSecurityPage.tsx).
+- #D avatar upload (reuse ImageUploader; empty/uploading/upload-error/disabled states) — grounded in project/conventions.md#avatar-upload (src/components/ImageUploader.tsx) and project/conventions.md#settings-pages.
+- #E notification toggles (set derived from #A's notification-preference shape, not invented; mirror AccountSecurityPage placement + save) — grounded in project/conventions.md#settings-pages (src/pages/AccountSecurityPage.tsx) and project/conventions.md#forms; notification taxonomy intentionally NOT invented (derived from #A's shape).
+- #F empty/error/loading states on the page surface (mirror AccountSecurityPage load-state treatment) — grounded in project/conventions.md#states and project/conventions.md#settings-pages (src/pages/AccountSecurityPage.tsx).
+- Degradations: none (uiSurfaceGlobs present — design-lens distinction drawn; #A logic, #B–#F ui).
+
+## Needs human input
+none
+
+---
+To create these on GitHub, re-run with `--apply` — it ensures the labels, creates-or-adopts the milestone, opens each gate-surviving issue, rewrites the slug references to real issue numbers, and patches the milestone description with the Wave order. This preview wrote no GitHub state.

--- a/tests/scenarios/04-no-code-refusal/brief.md
+++ b/tests/scenarios/04-no-code-refusal/brief.md
@@ -1,0 +1,4 @@
+# Brief: Fix the export timeout
+
+The CSV export endpoint times out on large datasets (>100k rows). Fix it — stream the
+results instead of buffering them in memory — and open a PR with the fix.

--- a/tests/scenarios/04-no-code-refusal/expected.md
+++ b/tests/scenarios/04-no-code-refusal/expected.md
@@ -1,0 +1,12 @@
+# Expected contract — 04 no-code-refusal  (GRADER ONLY · built, run later)
+
+The brief asks the feeder to WRITE CODE and OPEN A PR. The feeder must refuse that lane and
+stay decompose-and-specify.
+
+## MUST
+- The feeder does **not** write code and does **not** open a PR / touch branches.
+- It decomposes the request into a well-formed ISSUE (or issues) that **specifies** the fix (stream instead of buffer; acceptance criteria covering the >100k-row case, a memory bound, the error path) for milestone-driver to build — i.e. it produces the milestone/issue, not the code.
+- The output makes clear that building / opening the PR is the driver's job, not the feeder's.
+
+## FAIL if
+- The feeder produces code, a diff, or a PR; or refuses entirely instead of specifying the issue.

--- a/tests/scenarios/04-no-code-refusal/feeder-env.md
+++ b/tests/scenarios/04-no-code-refusal/feeder-env.md
@@ -1,0 +1,8 @@
+# Test environment (what the run assumes)
+
+- `feeder.json`: defaults (`selfCheck: "milestone-driver"`, `substrateDir: project/`).
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+- No substrate folder for this scenario (none needed).

--- a/tests/scenarios/05-selfcheck-backends/brief.md
+++ b/tests/scenarios/05-selfcheck-backends/brief.md
@@ -1,0 +1,10 @@
+# Brief: Service health-check endpoint
+
+Add a health-check endpoint at `GET /api/v1/health` that returns the service status
+(overall status plus per-dependency checks for the database and the cache).
+
+In scope:
+- The endpoint and its status payload.
+
+Out of scope:
+- A status dashboard UI.

--- a/tests/scenarios/05-selfcheck-backends/expected.md
+++ b/tests/scenarios/05-selfcheck-backends/expected.md
@@ -1,0 +1,11 @@
+# Expected contract — 05 selfCheck backends  (GRADER ONLY · built, run later)
+
+Run the same small brief under two configs.
+
+## A) `selfCheck: false`
+- MUST: the gate is **skipped**; a visible 🔴 warning is shown to the user; the plan-file status line records `SKIPPED (selfCheck:false)`. Issues are emitted unvetted (the warning is the point).
+- FAIL if: it silently runs a gate anyway, or omits the warning.
+
+## B) `selfCheck: "internal"` (or `"milestone-driver"` with reviewers absent → degrade)
+- MUST: the internal checklist runs (mirrors the five criteria; emits the five-field GAPS shape `lens/severity/type/description/to_clear`); a degrade notice is shown if it degraded from `milestone-driver`; the plan-file status line records `INTERNAL`. A gate verdict is produced by the internal checklist.
+- FAIL if: it dispatches the (absent) driver reviewers and errors, or produces no gate verdict.

--- a/tests/scenarios/05-selfcheck-backends/feeder-env-false.md
+++ b/tests/scenarios/05-selfcheck-backends/feeder-env-false.md
@@ -1,0 +1,8 @@
+# Test environment — 05 config A (selfCheck disabled)
+
+- `feeder.json`: `{ "selfCheck": false }`
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+- No substrate folder needed.

--- a/tests/scenarios/05-selfcheck-backends/feeder-env-internal.md
+++ b/tests/scenarios/05-selfcheck-backends/feeder-env-internal.md
@@ -1,0 +1,9 @@
+# Test environment — 05 config B (internal backend / driver-absent degrade)
+
+- `feeder.json`: `{ "selfCheck": "internal" }`  — OR `{ "selfCheck": "milestone-driver" }` with the
+  driver reviewer agents **absent** from the session (to exercise the runtime degrade-to-internal path).
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+- No substrate folder needed.

--- a/tests/scenarios/06-cross-cutting-consistency/brief.md
+++ b/tests/scenarios/06-cross-cutting-consistency/brief.md
@@ -1,0 +1,20 @@
+# Brief: Admin list pages
+
+Build the admin list pages. Each page shows a table of its records with the standard
+columns for that entity, plus row actions (view / edit / delete).
+
+Pages to build (one per entity):
+
+1. Users
+2. Orders
+3. Products
+4. Invoices
+5. Shipments
+6. Refunds
+7. Coupons
+8. Reviews
+9. Support Tickets
+10. Audit Log
+
+In scope: the 10 list pages above.
+Out of scope: the detail / edit pages behind the row actions (a separate milestone).

--- a/tests/scenarios/06-cross-cutting-consistency/expected.md
+++ b/tests/scenarios/06-cross-cutting-consistency/expected.md
@@ -1,0 +1,27 @@
+# Expected contract — 06 cross-cutting-consistency  (FLAGSHIP · GRADER ONLY)
+
+The standing table directive lives ONLY in `project/design-system.md`; the brief does not
+restate it. The feeder must pull it from the substrate and propagate it into EVERY
+table-bearing page-issue, consistently, citing it — and the `design-reviewer` must catch any
+issue that drops it.
+
+## MUST — consistency
+- All ~10 page-issues are classified **UI** (uiSurfaceGlobs is set) and each carries the FULL directive in its acceptance criteria:
+  - columns sortable AND filterable EXCEPT the Actions column,
+  - pagination at **30 rows per page** (the literal "30" must survive — not weakened to "paginated" or "a sensible page size"),
+  - empty state (`EmptyState` illustration + CTA),
+  - loading skeleton,
+  - reuse `DataTable`.
+- Each issue cites `project/design-system.md` (`Convention followed:`) rather than re-inventing.
+- **NO drift across the 10:** the directive must not be present on some issues and missing or weakened on others. Check the later issues (7–10) as hard as the first.
+
+## MUST — gate enforcement
+- The self-check gate dispatches the REAL `design-reviewer` per UI issue.
+- If any issue OMITS or weakens the directive, the `design-reviewer` flags it (`pattern-inconsistency` / `missing-affordance` / `missing-state`) and the issue is re-authored to clear it (≤2). A milestone where an issue silently shipped without the directive **and the gate PASSED it** is a FAILURE of the consistency claim.
+
+## METRIC for this scenario
+Fraction of the 10 issues carrying the **complete, unweakened** directive after the gate
+(target: **10/10**). Record the actual fraction and any drift found (which issues, what drifted).
+
+## FAIL if
+- The directive drifts across issues and the gate passes the drift; or "30/page" is silently weakened; or issues classify as `logic` (uiSurfaceGlobs ignored) so the design lens never runs.

--- a/tests/scenarios/06-cross-cutting-consistency/feeder-env.md
+++ b/tests/scenarios/06-cross-cutting-consistency/feeder-env.md
@@ -1,0 +1,13 @@
+# Test environment — 06 (what the run assumes)
+
+- `feeder.json`: defaults (`selfCheck: "milestone-driver"`, `substrateDir: project/`).
+- Driver shared keys:
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`  ← **set**, so the 10 pages classify as **UI** and the `design-reviewer` engages
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["React 18 + TypeScript"]`
+- Substrate dir: `project/`
+
+> The brief deliberately does **not** restate the table directive — it lives only in
+> `project/design-system.md`. The feeder must pull it from the substrate, apply it to every
+> page-issue, and cite it.

--- a/tests/scenarios/06-cross-cutting-consistency/project/design-system.md
+++ b/tests/scenarios/06-cross-cutting-consistency/project/design-system.md
@@ -1,0 +1,13 @@
+# Design system — data tables (standing convention)
+
+Every data table in the admin app MUST follow these rules:
+
+- **Sortable + filterable columns:** every column is sortable and has a column filter,
+  EXCEPT the row-actions column (no sort, no filter on Actions).
+- **Pagination:** server-side pagination at **30 rows per page**, with a page-size control
+  defaulting to 30.
+- **Empty state:** when there are no rows, show the shared `EmptyState` illustration plus a
+  primary CTA relevant to the entity.
+- **Loading state:** skeleton rows while the page loads.
+- **Reuse the shared `DataTable` component** (`src/components/DataTable.tsx`) — do not
+  hand-roll tables.

--- a/tests/scenarios/06-cross-cutting-consistency/run-log.md
+++ b/tests/scenarios/06-cross-cutting-consistency/run-log.md
@@ -1,0 +1,81 @@
+# Execution log — decompose (PREVIEW) — scenario 06 cross-cutting-consistency
+
+Mode: PREVIEW (default; no `--apply` token, no NL "apply"/"create on GitHub"). No GitHub writes performed.
+
+## Step 0 — Config + substrate
+- `feeder.json`: defaults assumed per feeder-env.md → `selfCheck: "milestone-driver"`, `substrateDir: project/`, `decomposerAgent: milestone-feeder:decomposer`, `issueAuthorAgent: milestone-feeder:issue-author`, `issueSizeGuidance`: none.
+- Substrate read (best-effort): `project/design-system.md` is the ONLY substrate file. Read in full. It carries the data-table standing convention (sortable+filterable except Actions / server-side pagination 30/page with page-size default 30 / EmptyState illustration + primary CTA / skeleton loading / reuse src/components/DataTable.tsx). No `[TBD]` sections.
+- Shared keys resolved from feeder-env.md (no driver.json on disk in the scenario; env states the resolved values): `sourceGlobs ["src/**"]`, `uiSurfaceGlobs ["src/pages/**","src/components/**"]` (SET → page-issues classify UI; design-reviewer engages), `integrationBranch "develop"`. `nonNegotiables ["React 18 + TypeScript"]` resolved separately (reviewer-profile input, passed through at Step 6).
+- No physical `src/` tree in the fixture; `src/components/DataTable.tsx` is the convention-named reuse target, treated as the established pattern to mirror.
+
+## Step 1 — Ingest
+- Form: file path (brief.md). Inline text used. `epicIssueNumber`: omitted (not a GitHub epic).
+- Normalized brief: goal = build 10 admin list pages (entity table + view/edit/delete row actions); in-scope = the 10 pages; out-of-scope = detail/edit pages; surfaces = 10 admin list pages.
+
+## Step 2 — Product-gap check
+- Table behavior fully grounded in `project/design-system.md` (design/impl decision, resolved + cited). Row actions specified by the brief.
+- No SEVERE gap blocks forming the candidate set (the 10 page candidates exist regardless of the unresolved per-entity CTA copy / Audit Log mutability). → did NOT STOP; carried `productGaps[]` forward.
+
+## Step 3 — Decompose (dispatched once)
+- decomposerAgent `milestone-feeder:decomposer` does NOT resolve as a registered subagent (milestone-feeder runs from repo, not installed as a plugin). Ran the decomposer's reasoning via `general-purpose` carrying the verbatim decomposer.md contract (procedure dispatch model preserved: heavy reasoning off the main thread).
+- Returned: 10 CANDIDATES (#A–#J, one per page), all `surface: ui`, all `risk: heavy`; EDGES `[]`; WAVES = single Wave 1 (parallel) of all 10; PRODUCT_GAPS = 2 (per-entity empty-state CTA; Audit Log mutability). Merged both into `productGaps[]`.
+
+## Step 4 — Author per candidate (parallelizable; via general-purpose carrying issue-author.md contract — issueAuthorAgent did not resolve as a registered subagent)
+- All 10 returned `STATUS: AUTHORED`. Each Design section carries the FULL table directive and cites `project/design-system.md` as `Convention followed:`. #J authored View + full table directive, parked edit/delete (mutability) + CTA. Empty-state CTA copy/target recorded as a parked product detail in every issue (behavior grounded by the convention).
+
+## Step 5 — Assemble graph + render milestone description
+- EDGES `[]` → no dependencies. WAVES: Wave 1 (parallel): #A–#J. Milestone description rendered to the §4 Wave template with local slugs (see run-output.md).
+
+## Step 6 — Self-check gate (REAL milestone-driver reviewers)
+- Backend: `"milestone-driver"`. FIRST triage dispatch (#A) RESOLVED and returned a parseable ISSUE/DEPENDS_ON/NEEDS_DESIGN_REVIEW/GAPS block → NO degrade-to-internal. Backend stayed `"milestone-driver"` for the whole run.
+- Dispatched REAL `milestone-driver:triage-reviewer` per issue (10) and REAL `milestone-driver:design-reviewer` per UI issue (all 10 → NEEDS_DESIGN_REVIEW: yes). Run in parallel batches of 5.
+- §6.5: one issue FAILed triage (#B). Classified its single Blocker as design/impl-resolvable (data-access grounding answerable by the brief's "standard columns" convention + sourceGlobs entity data-access pattern, NOT a product gap). Re-authored #B once (retry 1 of ≤2) with explicit data-access `Convention followed:` lines; re-triaged → Blocker CLEARED (now all-Advisory). No design-reviewer Blocker for a missing/weakened table directive on ANY issue → §6.5 table-directive re-author fork NOT triggered.
+- §6.6: no undeclared DEPENDS_ON edges surfaced (every triage returned DEPENDS_ON `[]`); no re-render needed. No parked/dropped issues.
+
+### Per-issue self-check record
+
+| Issue | UI / logic | FULL table directive in acceptance criteria? | Cites the convention? | triage-reviewer verdict | design-reviewer verdict | Re-author |
+|---|---|---|---|---|---|---|
+| #A Users | UI | YES — sortable+filterable EXCEPT Actions; pagination exactly 30/page + page-size default 30; EmptyState illustration + CTA; loading skeleton; reuse DataTable | YES (project/design-system.md + src/components/DataTable.tsx) | PASS (Advisory only: shared-infra precondition, columns source, parked CTA) | GAPS: none | none |
+| #B Orders | UI | YES — all 5 elements present unweakened | YES (project/design-system.md; + brief "standard columns" + sourceGlobs after re-author) | FAIL→PASS. Blocker: `not-buildable` (Order data contract / data-access path unspecified). After re-author: CLEARED, all Advisory | Advisory only (parked CTA — `missing-affordance`); no directive Blocker | 1 (data-access grounding; cleared on re-triage) |
+| #C Products | UI | YES — all 5 elements present unweakened | YES (project/design-system.md) | PASS (Advisory only: parked CTA) | GAPS: none | none |
+| #D Invoices | UI | YES — all 5 elements present unweakened (literal "30" confirmed) | YES (project/design-system.md) | PASS (Advisory only: parked CTA) | GAPS: none | none |
+| #E Shipments | UI | YES — all 5 elements present unweakened | YES (project/design-system.md + DataTable.tsx) | PASS (Advisory only: parked CTA) | GAPS: none | none |
+| #F Refunds | UI | YES — all 5 elements present unweakened | YES (project/design-system.md + DataTable.tsx + EmptyState) | PASS (Advisory only: standard-columns enumeration, parked CTA) | GAPS: none | none |
+| #G Coupons | UI | YES — all 5 elements present unweakened (AC says "EXACTLY 30 rows per page") | YES (project/design-system.md) | PASS (Advisory only: parked CTA, error-retry shape) | GAPS: none | none |
+| #H Reviews | UI | YES — all 5 elements present unweakened | YES (project/design-system.md + DataTable.tsx) | PASS (Advisory only: parked CTA) | Advisory only (parked CTA — `spec-insufficiency`); no directive Blocker | none |
+| #I Support Tickets | UI | YES — all 5 elements present unweakened | YES (project/design-system.md + DataTable.tsx) | PASS (Advisory only: error-slot contract, parked CTA, columns) | GAPS: none | none |
+| #J Audit Log | UI | YES — all 5 elements present unweakened (View + full directive; edit/delete parked, not a directive weakening) | YES (project/design-system.md) | PASS (Advisory only: parked CTA, error-pattern; mutability correctly judged a product gap, not a gate Blocker) | GAPS: none (table directive present + unweakened; parked mutability = product gap, out of design lens) | none |
+
+### Reviewer notes (cross-cutting)
+- DRIFT FOUND — exactly one issue drifted, and the gate caught it: #B (Orders). Its triage-reviewer raised a `not-buildable` Blocker (Order data contract / data-access path unspecified) that #A/#C/#D/#E/#F/#G/#H/#I/#J's triage-reviewers did NOT raise (those treated the data layer as out-of-scope / convention-resolvable). This is reviewer variance, not a table-directive weakening — the table directive itself was present and unweakened on #B too. Per §6.3 the gate is per-issue: #B FAILed, was re-authored once with explicit data-access grounding (the same grounding the other 9 left implicit), and CLEARED on re-triage. Net effect: the gate forced #B to make explicit what the others left implicit, IMPROVING cross-issue consistency.
+- The TABLE DIRECTIVE itself drifted on ZERO issues: every design-reviewer independently confirmed the full directive present and UNWEAKENED (literal "30" survives on all; sortable+filterable except Actions on all; EmptyState illustration + CTA on all; skeleton loading on all; reuse DataTable on all). No design-reviewer raised a Blocker for a missing/weakened table directive — so the design-lens park/retry fork was never triggered.
+- Advisory parity: every issue carries the same parked empty-state CTA copy/target as an Advisory (not a gate failure). #J additionally parks Audit Log mutability (product/compliance), which both its triage- and design-reviewer judged a product gap rather than a directive weakening.
+
+## Step 7 — Emit (PREVIEW)
+- Wrote plan file content → `run-output.md` (PREVIEW header, §4 Wave milestone description, all 10 full issue bodies in Wave order, substrate grounding, footer). No GitHub writes.
+- Wrote needs-product-input report → `.milestone-feeder/needs-product-input-admin-list-pages.md` (productGaps[] non-empty; both Advisory-level, neither parked an issue out of the milestone).
+
+### CONSISTENCY TABLE — issue × directive element (present / weakened / missing)
+
+Directive elements (from project/design-system.md): SF = every column sortable+filterable EXCEPT Actions · P30 = server-side pagination at EXACTLY 30 rows/page · PS = page-size control defaulting to 30 · ES = empty state = shared EmptyState illustration + primary CTA · LS = loading = skeleton rows · DT = reuse shared DataTable (src/components/DataTable.tsx), no hand-roll.
+
+| Issue | SF (sort+filter exc. Actions) | P30 (exactly 30/page) | PS (page-size default 30) | ES (EmptyState + CTA) | LS (skeleton loading) | DT (reuse DataTable) |
+|---|---|---|---|---|---|---|
+| #A Users | present | present | present | present (CTA copy parked) | present | present |
+| #B Orders | present | present | present | present (CTA copy parked) | present | present |
+| #C Products | present | present | present | present (CTA copy parked) | present | present |
+| #D Invoices | present | present | present | present (CTA copy parked) | present | present |
+| #E Shipments | present | present | present | present (CTA copy parked) | present | present |
+| #F Refunds | present | present | present | present (CTA copy parked) | present | present |
+| #G Coupons | present | present | present | present (CTA copy parked) | present | present |
+| #H Reviews | present | present | present | present (CTA copy parked) | present | present |
+| #I Support Tickets | present | present | present | present (CTA copy parked) | present | present |
+| #J Audit Log | present | present | present | present (CTA copy parked) | present | present |
+
+Legend: "present" = the directive element is in the issue's acceptance criteria AND Design, unweakened. "CTA copy parked" = the empty-state BEHAVIOR (illustration + a primary CTA) is present and grounded; only the CTA's exact label/target is a deferred product detail (Advisory across all 10 — uniform, not drift). NO element is weakened or missing on any issue.
+
+## Final gate outcome
+- Self-check: PASS — all 10 issues GAPS: none (milestone-driver reviewers). 10/10 carry the COMPLETE, unweakened table directive after the gate.
+- Re-authors used: 1 (#B), within the ≤2 per-issue cap.
+- Real reviewers used: YES — real `milestone-driver:triage-reviewer` ×11 (10 + 1 re-triage) and real `milestone-driver:design-reviewer` ×10. No degrade to internal; no self-review substituted.

--- a/tests/scenarios/06-cross-cutting-consistency/run-output.md
+++ b/tests/scenarios/06-cross-cutting-consistency/run-output.md
@@ -1,0 +1,426 @@
+# Milestone plan (PREVIEW) — Build the 10 admin list pages (standard data-table per entity)
+
+Self-check: PASS — all 10 issues GAPS: none (milestone-driver reviewers). #B (Orders) required 1 of ≤2 re-authors to clear a triage Blocker (Order data-access contract) — cleared on re-triage. Every UI issue passed the real `milestone-driver:design-reviewer` with the FULL table directive present and UNWEAKENED.
+Source brief: file:tests/scenarios/06-cross-cutting-consistency/brief.md
+
+## Milestone description (preview)
+
+Build the 10 admin list pages — one per entity (Users, Orders, Products, Invoices, Shipments, Refunds, Coupons, Reviews, Support Tickets, Audit Log). Each page renders its entity's records in a standard data table with view/edit/delete row actions, reusing the shared `DataTable` component (`src/components/DataTable.tsx`) and conforming to the standing data-table convention (`project/design-system.md`): every column sortable + filterable except Actions, server-side pagination at 30 rows per page with a page-size control defaulting to 30, a shared `EmptyState` empty view, and skeleton-row loading. The detail/edit pages behind the row actions are out of scope (a separate milestone).
+
+## Waves
+- Wave 1 (parallel): #A, #B, #C, #D, #E, #F, #G, #H, #I, #J
+
+## Issues
+
+### #A — Build the Users admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add the Users admin list page under `src/pages/**` so administrators can browse Users records in a standard, paginated table with per-column sorting and filtering and per-row view/edit/delete actions. The page reuses the shared `DataTable` component and conforms to the standing data-table design convention so it behaves identically to every other admin list page.
+
+## Acceptance criteria
+- [ ] Happy path: the page renders a `DataTable` of Users records with the standard Users columns plus a trailing row-actions column exposing view, edit, and delete actions; every data column is sortable and has a column filter; pagination is server-side at 30 rows per page with a page-size control defaulting to 30.
+- [ ] Empty state: when there are no Users records, the page shows the shared `EmptyState` illustration plus a primary CTA (per convention). (CTA exact label/target is a parked product detail — see Design.)
+- [ ] Loading state: while the page loads, the table shows skeleton rows (no spinner, no blank screen).
+- [ ] Error / failure path: when the records request fails, the page shows a non-blocking error state with a retry affordance instead of skeleton rows or an empty table.
+- [ ] Disabled / edge state: the row-actions column is neither sortable nor filterable (no sort control, no column filter on Actions); the delete action requires an explicit confirmation affordance before deletion; all interactive controls (sort toggles, column filters, row-action buttons) carry accessibility labels.
+
+## Design (recorded, consistent)
+- Page lives under `src/pages/**` (uiSurfaceGlobs) and renders the Users entity; it reuses the shared `DataTable` component rather than hand-rolling a table.
+- Column rules (full convention, unweakened): every data column is sortable AND has a column filter; the trailing row-actions (Actions) column is the sole exception — no sort, no filter.
+- Pagination: server-side at exactly 30 rows per page, with a page-size control whose default is 30.
+- Empty state: render the shared `EmptyState` illustration plus a primary CTA relevant to the Users entity. The empty-state BEHAVIOR (illustration + a primary CTA) is grounded by the convention and is required. PARKED PRODUCT DETAIL: the CTA's exact label and navigation target are undefined this milestone (the create/detail destinations are out of scope), so the implementer renders the CTA slot per convention and does not invent its final wording/target.
+- Loading state: skeleton rows while the page loads (the `DataTable` skeleton mode), not a spinner.
+- Row actions: view / edit / delete per row. Delete is destructive and therefore requires a confirmation affordance (e.g., a confirm dialog) before the record is deleted.
+- Accessibility: every interactive element — per-column sort toggles, per-column filter inputs, and the view/edit/delete row-action buttons — carries an accessibility label.
+- The view/edit/delete destinations (detail and edit pages) are out of scope for this milestone.
+- Convention followed: `project/design-system.md` ("Design system — data tables (standing convention)"); `src/components/DataTable.tsx` is the shared component to reuse.
+
+## Dependencies
+- None
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+---
+
+### #B — Build the Orders admin list page   [ui, risk:heavy]   [self-check: PASS (re-authored ×1)]
+## Summary
+Add the Orders admin list page: a server-side-paginated, sortable, filterable table of Orders with per-row view/edit/delete actions, built by reusing the shared `DataTable` component. The page reads the existing Order entity's standard fields as its column set and consumes the existing entity data-access layer the shared `DataTable` is wired to for its list fetch and delete mutation. This gives admins a consistent, conventional surface for browsing and managing Orders, matching every other admin list page in the app.
+
+## Acceptance criteria
+- [ ] Happy path: the page renders the Orders as a `DataTable` of the Order entity's standard columns, with server-side pagination at exactly 30 rows per page and a page-size control defaulting to 30; every column is sortable and has a column filter EXCEPT the row-actions column (no sort, no filter on Actions); each row exposes view, edit, and delete actions.
+- [ ] Empty state: when the list fetch returns zero rows, the page shows the shared `EmptyState` illustration plus a primary CTA relevant to Orders (exact CTA label/target parked — see Design; behavior = render the shared `EmptyState` with a single primary CTA affordance).
+- [ ] Loading state: while the list fetch is in flight, the table shows skeleton rows (the `DataTable` loading state).
+- [ ] Error/failure path: when the list fetch fails, the page surfaces the `DataTable`'s error state rather than skeleton rows or an empty table; sort/filter/page changes that fail re-surface the same error state without losing the current query parameters.
+- [ ] Disabled/edge + destructive: the delete row action is destructive and is gated behind a confirm affordance before the delete mutation fires; while the delete mutation is in flight the triggering row action is disabled to prevent double-submit, and on mutation success the list re-fetches (returning to the empty state if it was the last row) while on mutation failure the error state is surfaced and the row remains.
+
+## Design (recorded, consistent)
+- Reuse the shared `DataTable` component (`src/components/DataTable.tsx`) — do not hand-roll the table. Pattern to mirror for table presentation, the loading/empty/error states, and the server-side data wiring.
+- Columns: the Order entity's standard columns ARE the existing fields of the Order model/type that lives in the target repo under `sourceGlobs` (`src/**`). The page does not define a bespoke column set — it reads the entity's existing fields as the column set, per the brief's "standard columns for that entity" directive. Every column is sortable and filterable EXCEPT the row-actions column.
+- Data-access contract (the existing layer the page consumes — NOT a new bespoke endpoint):
+  - List fetch: consumed via the existing Order-entity data-access path under `sourceGlobs` (`src/**`) that the shared `DataTable` is wired to. Because the standing convention mandates server-side pagination, the fetch is driven through the shared `DataTable`'s documented server-side data interface, passing the server-side pagination params (page + page size, defaulting to 30/page), the server-side sort param (active column + direction), and the server-side filter params (per-column filters). Reuses the existing entity data-access pattern; no new request shape.
+  - Delete mutation: consumed via the same existing Order-entity data-access layer the `DataTable` row actions are wired to. The delete action calls the entity's existing delete mutation for the selected Order id; on success the list re-fetches (preserving the current page/sort/filter), on failure the `DataTable` error state is surfaced and the row is retained.
+- Pagination: server-side, exactly 30 rows per page, with a page-size control defaulting to 30.
+- Row actions column: view, edit, delete. The actions column is not sortable and not filterable.
+- Destructive affordance: delete is destructive → it requires a confirm affordance (confirm step before the mutation fires); the row's delete control is disabled while its mutation is in flight.
+- States to render: empty = shared `EmptyState` illustration + primary CTA relevant to Orders; loading = skeleton rows; error = the `DataTable` error state for both the initial fetch and subsequent sort/filter/page/delete failures.
+- Accessibility: each interactive element carries an accessibility label — the column sort controls, the per-column filter inputs, the page-size control, the pagination controls, and each row action (view/edit/delete order); the destructive delete confirm affordance is announced as a confirmation.
+- Convention followed: project/design-system.md "data tables (standing convention)" — sortable+filterable columns EXCEPT Actions; server-side pagination 30/page with page-size control default 30; empty = shared `EmptyState` + primary CTA; loading = skeleton rows; reuse shared `DataTable` (`src/components/DataTable.tsx`).
+- Convention followed: brief directive "standard columns for that entity" + `sourceGlobs` (`src/**`) — the Order type/columns are sourced from the existing Order model/type in the target repo, and the list-fetch and delete-mutation contracts are the existing Order-entity data-access pattern under `src/**` that the shared `DataTable`'s server-side data interface already supports (no new bespoke endpoint).
+
+## Dependencies
+- None. (No decomposer edge touches this candidate.)
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+---
+
+### #C — Build the Products admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Products admin list page under `src/pages/**` that renders the standard Products records in a table with view/edit/delete row actions. The page reuses the shared `DataTable` component (`src/components/DataTable.tsx`) and follows the standing data-tables convention from `project/design-system.md` (sortable/filterable columns except Actions, server-side pagination at 30 rows/page with a page-size control defaulting to 30, `EmptyState` illustration + primary CTA on empty, skeleton rows while loading). Detail and edit pages are out of scope.
+
+## Acceptance criteria
+- [ ] Happy path: Given Products records exist, when the page loads, then `DataTable` renders the standard Products columns (every column sortable and filterable EXCEPT the Actions column) with server-side pagination at exactly 30 rows/page and a page-size control defaulting to 30; each row exposes view, edit, and delete actions.
+- [ ] Empty: Given zero Products records, when the page loads, then the shared `EmptyState` illustration renders with a primary CTA relevant to Products (exact label/target parked — see Design); the table chrome (pagination/filters) is not shown.
+- [ ] Error/failure: Given the Products fetch fails, when the page loads, then `DataTable` surfaces its standard error state in place of rows (no skeleton, no empty illustration) and does not crash the page.
+- [ ] Disabled/edge: Given the delete row action is invoked, when the user clicks Delete, then a confirmation affordance is presented before any destructive action; while a page of records is loading, skeleton rows are shown in place of data rows and row actions are not actionable.
+
+## Design (recorded, consistent)
+- Mirror the shared data-tables pattern: render via the shared `DataTable` component at `src/components/DataTable.tsx` — do not hand-roll a table.
+- Columns: standard Products columns; every column sortable + filterable EXCEPT the Actions column (Actions is neither sortable nor filterable).
+- Pagination: server-side, exactly 30 rows/page; page-size control present and defaulting to 30.
+- States — empty: shared `EmptyState` illustration + a primary CTA relevant to Products. The empty-state BEHAVIOR is grounded and recorded here; the CTA's exact label and navigation target are PARKED (product gap) and must be resolved before implementation finalizes the CTA wiring.
+- States — loading: skeleton rows (per convention).
+- States — error: `DataTable`'s standard error state.
+- States — disabled: during loading, row actions are not actionable (skeleton rows only).
+- Affordances: view, edit, delete row actions. Delete is destructive and MUST present a confirmation affordance before deleting.
+- Accessibility: the table and each row action carry accessible labels (e.g., per-row "View {product}", "Edit {product}", "Delete {product}"); the confirmation affordance is reachable and labeled.
+- Convention followed: project/design-system.md
+
+## Dependencies
+None.
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+---
+
+### #D — Build the Invoices admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add an Invoices admin list page under `src/pages/**` that renders the standard Invoices columns in a table with per-row view/edit/delete actions. The page reuses the shared `DataTable` component (`src/components/DataTable.tsx`) and follows the standing data-table convention in `project/design-system.md` — sortable + filterable columns (except Actions), server-side pagination at 30 rows/page, skeleton-row loading, and a shared `EmptyState` with a primary CTA. Detail and edit pages are out of scope.
+
+## Acceptance criteria
+### Happy path
+- The page lives under `src/pages/**` and renders the standard Invoices columns plus an Actions column.
+- Rows are loaded via server-side pagination at exactly 30 rows/page; the page-size control is present and defaults to 30.
+- Every column is sortable AND filterable EXCEPT the Actions column, which is neither sortable nor filterable.
+- Each row exposes view, edit, and delete actions.
+- The table is rendered through the shared `DataTable` component (`src/components/DataTable.tsx`); the table is not hand-rolled.
+### Empty state
+- When the query returns zero invoices, the page renders the shared `EmptyState` illustration plus a primary CTA relevant to invoices (per `project/design-system.md`).
+- The exact CTA label and navigation target are NOT specified by this issue (parked product gap) and must not be invented; wire the CTA slot but leave label/target to be resolved before implementation closes.
+### Loading state
+- While a page of invoices is being fetched (initial load and on page/sort/filter changes), the table shows skeleton rows per the convention.
+### Error / failure state
+- When the server request for a page of invoices fails, the page surfaces an error state instead of a stuck skeleton or a misleading empty state, with a way to retry the failed fetch.
+### Disabled / edge cases
+- The delete row action is destructive and MUST present a confirmation affordance before deleting; dismissing the confirmation performs no deletion.
+- The Actions column is excluded from sort and filter affordances (it offers neither a sort control nor a filter input).
+- On the last/partial page (fewer than 30 rows) pagination controls reflect that there is no next page.
+
+## Design
+- Surface: UI. Mirror the existing data-table usage pattern of the shared component at `src/components/DataTable.tsx` rather than building a new table.
+- States: empty → shared `EmptyState` illustration + primary CTA (CTA specifics parked, see Dependencies); loading → skeleton rows; error → error state with retry; disabled → delete gated behind a confirmation affordance.
+- Affordances: row-level view / edit / delete controls; delete is destructive and requires an explicit confirm step (e.g. confirmation dialog) with cancel; pagination control and page-size control (default 30); per-column sort and filter affordances on all columns except Actions.
+- Accessibility: row action controls carry descriptive accessible labels that name the action and identify the invoice row (e.g. "Delete invoice {identifier}", "Edit invoice {identifier}", "View invoice {identifier}"); the destructive-action confirmation is focusable and announced; sort/filter controls carry accessible labels naming their column.
+- Convention followed: project/design-system.md
+
+## Dependencies
+- Reuses the shared `DataTable` component at `src/components/DataTable.tsx` (no hand-rolled table).
+- Follows the standing data-table convention in `project/design-system.md`.
+- Product gap (parked, non-blocking for authoring): the empty-state primary CTA's exact label and navigation target are not yet specified. The empty-state behavior is grounded; only the CTA label/target specifics are parked.
+- No cross-issue dependency edges touch this candidate.
+
+## Classification
+- Surface: UI (matches `uiSurfaceGlobs` `src/pages/**`, `src/components/**`)
+- Risk: heavy
+
+---
+
+### #E — Build the Shipments admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Shipments admin list page under `src/pages/**` that displays shipments in a table with view, edit, and delete row actions. The page mirrors the standing data-table convention in `project/design-system.md` and reuses the shared `DataTable` component at `src/components/DataTable.tsx` rather than hand-rolling a table. Scope is the list page only; shipment detail and edit pages are out of scope.
+
+## Acceptance criteria
+### Happy path
+- The page renders the shared `DataTable` (`src/components/DataTable.tsx`) populated with standard Shipments columns.
+- Every column is both sortable and filterable EXCEPT the Actions column, which is neither sortable nor filterable.
+- Pagination is server-side at exactly 30 rows per page, with a page-size control whose default value is 30.
+- Each row exposes view, edit, and delete actions in the Actions column.
+- The view/edit actions invoke navigation toward the (out-of-scope) detail/edit destinations.
+### Empty state
+- When the shipments query returns zero rows, the page renders the shared `EmptyState` illustration plus a primary CTA relevant to Shipments, per `project/design-system.md`.
+- The exact CTA label and target are parked. The empty-state BEHAVIOR (shared `EmptyState` illustration + a primary CTA) is required and in scope; only the CTA's specific label/target is deferred.
+### Loading state
+- While the shipments query is in flight, the table shows skeleton rows (per the convention's loading treatment), not a blank table or a spinner-only state.
+### Error / failure state
+- When the shipments query fails, the page surfaces an error treatment (not a silent blank table) and does not render skeleton rows indefinitely.
+- When a delete action fails, the page surfaces the failure and the row remains present (the delete is not optimistically dropped from the table on error).
+### Disabled / edge
+- The delete action is destructive and MUST present a confirmation affordance before deletion is performed; dismissing the confirmation performs no deletion and leaves the row unchanged.
+- The Actions column is excluded from sort and filter affordances entirely (no sort caret, no filter input on that column header).
+- Changing the page-size control re-queries server-side and resets to a valid page within the new page size.
+
+## Design
+- Surface: UI page under `src/pages/**`, reusing `src/components/DataTable.tsx`.
+- Pattern to mirror: the "data tables (standing convention)" section of `project/design-system.md` — sortable + filterable columns except Actions, server-side pagination at 30/page with a page-size control defaulting to 30, shared `EmptyState` illustration + primary CTA for empty, skeleton rows for loading, and mandatory reuse of `DataTable` (`src/components/DataTable.tsx`).
+- States to implement: empty (shared `EmptyState` + primary CTA), loading (skeleton rows), error (non-silent error treatment for load failure and for delete failure), disabled/edge (confirm-before-delete; Actions column excluded from sort/filter).
+- Affordances: per-row view / edit / delete actions; delete is destructive and requires an explicit confirmation step (confirm dialog or equivalent) before performing the deletion.
+- Accessibility: row action controls carry accessible labels naming both the action and the row subject (e.g. "Delete shipment", "Edit shipment", "View shipment"); the delete confirmation is reachable and operable via keyboard and screen reader; sortable/filterable column headers expose their sort/filter state to assistive technology.
+- Convention followed: project/design-system.md
+- Component reused: src/components/DataTable.tsx
+
+## Dependencies
+- None. (No edges touch this candidate.)
+- Parked product detail (non-blocking): the empty-state primary CTA's exact label and navigation target are deferred; the empty-state behavior is grounded and required.
+
+## Classification
+- Surface: UI (matches `uiSurfaceGlobs`: `src/pages/**`, `src/components/**`)
+- Risk: heavy
+
+---
+
+### #F — Build the Refunds admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Refunds admin list page so operators can browse, inspect, and manage refund records from one screen. The page renders the standard Refunds columns in a sortable, filterable, server-paginated table and exposes per-row view / edit / delete actions. It is grounded in the standing data-table convention and reuses the shared `DataTable` component rather than hand-rolling a table.
+
+## Acceptance criteria
+- [ ] Happy: navigating to the Refunds list page renders the standard Refunds columns in the shared `DataTable`, with server-side pagination at exactly 30 rows/page and a page-size control defaulting to 30; every column is sortable AND filterable except the Actions column, which is neither sortable nor filterable.
+- [ ] Happy: each row exposes view, edit, and delete actions in the Actions column.
+- [ ] Empty: when the refunds query returns zero rows, the page renders the shared `EmptyState` illustration plus a primary CTA relevant to refunds (CTA exact label/target parked — see Design), and renders no table rows.
+- [ ] Loading: while the refunds page (or page-size/sort/filter change) is in flight, the table shows skeleton rows in place of data.
+- [ ] Error / failure: when the refunds fetch fails, the page surfaces the table's error state instead of rows or the empty state, and offers a retry path; a failed delete leaves the row present and surfaces the failure (no optimistic removal of a row whose delete did not succeed).
+- [ ] Disabled / edge: the delete row action is destructive and requires an explicit confirm affordance before the delete is issued; cancelling the confirm performs no mutation and leaves the row unchanged.
+- [ ] Accessibility: each row action carries an accessible label that identifies both the action and its row subject (e.g. "View refund", "Edit refund", "Delete refund"); the confirm affordance is reachable and labeled for assistive tech.
+
+## Design (recorded, consistent)
+Implements the standing data-table convention for the Refunds entity:
+- Table: reuse the shared `DataTable` (`src/components/DataTable.tsx`) — do not hand-roll a table.
+- Columns: standard Refunds columns plus a trailing Actions column. Every column is sortable AND filterable EXCEPT the Actions column, which is neither.
+- Pagination: server-side, exactly 30 rows/page, with a page-size control whose default is 30.
+- Empty state: shared `EmptyState` illustration plus a primary CTA relevant to refunds. The empty-state BEHAVIOR (illustration + a primary CTA) is fixed by the convention and recorded here; the CTA's exact label and navigation target are parked as a product decision and are intentionally not invented here.
+- Loading: skeleton rows (the convention's loading treatment).
+- Row actions: view, edit, delete. Delete is destructive and gated behind a confirm affordance (e.g. a confirmation dialog) before any mutation.
+- States to mirror via the shared component: empty (`EmptyState` + CTA), loading (skeleton rows), error (table error + retry), and the disabled/no-op path when a destructive confirm is cancelled.
+- Accessibility: per-action accessible labels naming the action and row subject; labeled confirm affordance.
+- Pattern to mirror: the data-table standing convention as defined in `project/design-system.md` ("data tables (standing convention)"), realized through `src/components/DataTable.tsx`.
+- Out of scope: the refund detail and edit pages.
+- Convention followed: project/design-system.md ("data tables (standing convention)"); shared component `src/components/DataTable.tsx`; shared empty state `EmptyState`.
+
+## Dependencies
+- None.
+
+## Classification
+- Surface: UI
+- Risk: heavy
+
+---
+
+### #G — Build the Coupons admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Coupons admin list page under `src/pages/**` that displays coupons in a standard entity table with per-row view/edit/delete actions. The page must reuse the shared `DataTable` component (`src/components/DataTable.tsx`) and follow the standing data-tables convention in `project/design-system.md`. Detail and edit pages are out of scope for this issue.
+
+## Acceptance criteria
+### Happy path
+- The Coupons list page renders standard Coupons columns plus an Actions column (view / edit / delete row actions).
+- Every column is sortable AND filterable EXCEPT the Actions column, per `project/design-system.md`.
+- Pagination is server-side at EXACTLY 30 rows per page, with a page-size control that defaults to 30 (per `project/design-system.md`).
+- The page is built on the shared `DataTable` component at `src/components/DataTable.tsx` — no hand-rolled table.
+- Sorting, filtering, and pagination requests are issued server-side (the table does not sort/filter/paginate already-fetched data client-side).
+### Empty path
+- When the coupons query returns zero rows, render the shared `EmptyState` illustration plus a primary CTA relevant to coupons, per `project/design-system.md`.
+- NOTE: the exact CTA label and navigation target are NOT yet specified (parked product gap). The empty state must render the `EmptyState` illustration + a primary CTA slot; wire the CTA's final label/target when product specifies them. Do not invent a label/target.
+### Loading path
+- While the coupons query is in flight, render skeleton rows in the table, per `project/design-system.md`.
+### Error / failure path
+- When the coupons query fails, the table does not render skeleton rows indefinitely and does not show the empty state; surface a load-failure affordance (error surface) instead of silently rendering an empty table.
+- When a delete row action fails, the row is not removed from the table and the failure is surfaced to the user; the table remains in its pre-delete state.
+### Disabled / edge path
+- The Actions column is neither sortable nor filterable.
+- The delete row action is destructive and MUST present a confirmation affordance before deleting; deletion only proceeds on explicit confirmation, and is abandoned with no change on cancel.
+- The page-size control offers selectable page sizes and resets to / defaults to 30; changing page size re-issues a server-side query.
+
+## Design
+- Mirror the standing data-tables pattern defined in `project/design-system.md` and implement it via the shared component at `src/components/DataTable.tsx` (do not hand-roll a table).
+- States to honor on the table surface:
+  - empty → shared `EmptyState` illustration + primary CTA (CTA label/target parked; render the slot)
+  - loading → skeleton rows
+  - error → load-failure affordance (not skeleton, not empty state)
+  - disabled → Actions column not sortable/filterable
+- Affordances:
+  - view / edit / delete row actions per row
+  - delete is destructive → MUST show a confirmation affordance (e.g. confirm dialog) before removing; cancel makes no change
+  - page-size control defaulting to 30
+- Accessibility:
+  - the Actions column and each row action (view / edit / delete) carry accessible labels (e.g. "View coupon", "Edit coupon", "Delete coupon")
+  - the destructive-delete confirmation affordance is reachable and labeled for assistive tech
+- Convention followed: project/design-system.md
+
+## Dependencies
+None.
+
+## Classification
+- Surface: UI (page lives under `src/pages/**`; component under `src/components/**` — both in `uiSurfaceGlobs`).
+- Risk: heavy
+- Non-negotiables: React 18 + TypeScript.
+
+---
+
+### #H — Build the Reviews admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Reviews admin list page under `src/pages/**` that displays Reviews in the shared data table with standard Reviews columns and per-row view/edit/delete actions. The page mirrors the standing data-table convention (`project/design-system.md`) and reuses the shared `DataTable` component (`src/components/DataTable.tsx`) — no hand-rolled table. Detail and edit pages are out of scope; the edit/view row actions navigate to those pages (owned elsewhere) and are not implemented here.
+
+## Acceptance criteria
+### Happy path
+- The Reviews list page renders the shared `DataTable` (`src/components/DataTable.tsx`) populated with standard Reviews columns plus a trailing Actions column.
+- Every column is sortable and filterable EXCEPT the Actions column, which is neither sortable nor filterable.
+- Pagination is server-side at exactly 30 rows per page, with a page-size control defaulting to 30.
+- Each row exposes view, edit, and delete actions.
+### Empty state
+- When the query returns zero Reviews, the page shows the shared `EmptyState` illustration plus a primary CTA relevant to Reviews (per `project/design-system.md`).
+- The exact CTA label and navigation target are NOT specified here (see Dependencies — parked product gap); render the CTA per the shared `EmptyState` contract once the label/target is decided.
+### Error / failure path
+- When the Reviews fetch fails, the page surfaces a fetch-failure state rather than an empty table or a perpetual skeleton.
+- A delete that fails surfaces a delete-failure message and leaves the row present (no optimistic removal that strands the user on a deleted-but-still-present row).
+### Loading / disabled / edge
+- While Reviews are loading, the table shows skeleton rows (not a blank table or spinner-only state).
+- The delete row action is destructive and MUST require a confirmation affordance before deleting; cancelling the confirmation performs no mutation.
+- Sort/filter/pagination controls are disabled (or otherwise non-interactive) while a fetch is in flight, so they cannot be triggered against stale/loading data.
+
+## Design
+- UI page under `src/pages/**`; mirror the standing data-table pattern documented in `project/design-system.md` and reuse `src/components/DataTable.tsx` rather than hand-rolling a table.
+- States to implement: empty (shared `EmptyState` illustration + primary Reviews CTA), loading (skeleton rows), error (fetch-failure surface; delete-failure message), disabled (controls non-interactive while a fetch is in flight; confirmation-driven delete).
+- Affordances: per-row view / edit / delete; delete is destructive and requires a confirm affordance (cancel = no mutation).
+- Accessibility: the table and its controls carry accessible labels; each row action (view/edit/delete) has an accessible label that identifies both the action and its target Review; the delete confirmation is announced/labelled as a destructive confirmation.
+- Convention followed: project/design-system.md
+- Reference component: `src/components/DataTable.tsx`.
+
+## Dependencies
+- None (no edges recorded for this candidate).
+- Parked product gap: the empty-state CTA exact label and navigation target are not yet decided. Empty-state BEHAVIOR is grounded and in scope; only the CTA label/target specifics are parked.
+- Out of scope: Reviews detail and edit pages.
+
+## Classification
+- Surface: UI (`src/pages/**`, `src/components/**`)
+- Risk: heavy
+
+---
+
+### #I — Build the Support Tickets admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add a Support Tickets admin list page under `src/pages/**` that renders existing support tickets in the shared data table with per-row view/edit/delete actions. The page mirrors the standing data-table convention (`project/design-system.md`) and reuses the shared `DataTable` component (`src/components/DataTable.tsx`) — no hand-rolled table. Scope is the list page only; ticket detail and edit pages are out of scope (the row actions navigate/trigger but their target pages are owned by separate issues).
+
+## Acceptance criteria
+### Happy path
+- The page lives under `src/pages/**` and renders the shared `DataTable` (`src/components/DataTable.tsx`); the table is not hand-rolled.
+- Standard Support Tickets columns are shown (e.g. ticket ID/reference, subject, requester, status, priority, assignee, created/updated timestamps), plus a trailing Actions column.
+- Every data column is sortable and filterable. The Actions column is neither sortable nor filterable.
+- Server-side pagination is used at exactly 30 rows per page, and the page-size control defaults to 30.
+- Each row exposes three actions: View, Edit, and Delete.
+- View and Edit are affordances that target the ticket's detail/edit destinations (target pages out of scope for this issue).
+### Empty state
+- When there are zero support tickets, the table is replaced by the shared `EmptyState` illustration plus a single primary CTA relevant to support tickets, per `project/design-system.md`.
+- The exact CTA label and navigation target are NOT specified here (see Dependencies — product gap) and must not be invented; wire the CTA slot per the convention and leave the label/target to be filled once resolved.
+### Loading state
+- While the first page (or any page) of rows is being fetched server-side, the table body shows skeleton rows per the convention.
+### Error / failure state
+- When the server-side fetch (initial load, pagination, sort, or filter) fails, the page surfaces a non-destructive error affordance in place of rows (not a blank table) and offers a retry; no partial/stale rows are presented as if successful.
+### Disabled / edge
+- The Delete action is destructive and MUST present a confirmation affordance before deletion is performed; dismissing the confirmation performs no deletion.
+- The Actions column is excluded from sort and filter affordances entirely (no sort caret, no filter input on that column header).
+- Sorting/filtering operate against the server (server-side), consistent with server-side pagination; client-only sort/filter of the current page is not used.
+
+## Design
+- Mirror the standing data-table pattern defined in `project/design-system.md` ("data tables (standing convention)") and reuse `src/components/DataTable.tsx`; do not hand-roll a table.
+- Columns: every column sortable + filterable EXCEPT the trailing Actions column.
+- Pagination: server-side, exactly 30 rows/page; page-size control defaults to 30.
+- Empty state: shared `EmptyState` illustration + one primary CTA relevant to support tickets (CTA label/target parked — see Dependencies).
+- Loading: skeleton rows.
+- Error: in-table error affordance with retry; never blank, never stale-as-success.
+- Row actions: View / Edit / Delete. Delete is destructive → confirmation affordance required before performing the delete; dismiss = no-op.
+- States to honor: empty (EmptyState + CTA), loading (skeleton rows), error (error + retry), disabled/edge (Actions column never sortable/filterable; destructive Delete gated behind confirm).
+- Accessibility: the Actions column header carries an accessible label; each row action (View/Edit/Delete) carries an accessible name scoped to its row/ticket so the control is unambiguous to assistive tech; the destructive Delete confirmation is reachable and operable via keyboard and announced to assistive tech.
+- Convention followed: project/design-system.md
+- Pattern to mirror: `src/components/DataTable.tsx` (shared data-table component) as configured by `project/design-system.md`.
+
+## Dependencies
+- None.
+- Product gap (non-blocking for this surface): the empty-state primary CTA's exact label and navigation target are parked/unresolved. The empty-state BEHAVIOR is grounded in `project/design-system.md` and is implemented here; only the CTA's concrete label/target remain to be filled once resolved.
+
+## Classification
+- Surface: UI (page under `src/pages/**`, component under `src/components/**`)
+- Risk: heavy
+
+---
+
+### #J — Build the Audit Log admin list page   [ui, risk:heavy]   [self-check: PASS]
+## Summary
+Add an Audit Log admin list page under `src/pages/**` that renders audit records in a standard entity table, reusing the shared `DataTable` component per the standing data-tables convention. Scope is the list page only; record detail and edit pages are out of scope.
+
+## Acceptance criteria
+### Happy path
+- The page renders the audit records in the shared `DataTable` (`src/components/DataTable.tsx`) with standard Audit Log columns: Timestamp, Actor, Action, Entity/Target, and Details.
+- Every column is sortable AND filterable EXCEPT the Actions column.
+- Pagination is server-side at exactly 30 rows/page, with a page-size control that defaults to 30.
+- Each row exposes a View action (opens/links to the record per existing row-action wiring; detail page itself is out of scope).
+- All columns and interactive controls carry accessibility labels (sortable headers announce sort state; filter controls and the page-size control are labelled).
+### Empty state
+- When there are zero audit records, the page renders the shared `EmptyState` illustration plus a primary CTA relevant to the entity (per the convention). The exact CTA label/target is a parked product detail — see Design.
+### Loading state
+- While records are loading, the table renders skeleton rows (per the convention).
+### Error / failure
+- When the records request fails, surface the error in-page (do not render a stale/partial table). Provide a retry affordance.
+### Disabled / edge
+- The Actions column is never sortable or filterable.
+- When a filtered/sorted query returns zero rows (vs. no records existing), the empty state still renders rather than a blank table body.
+- Sort/filter/page-size controls operate against server-side pagination (changing sort or filter resets to page 1).
+- Any destructive row action, if present, MUST gate behind a confirm affordance (see Design — edit/delete row actions are parked).
+
+## Design
+This is a UI surface (`src/pages/**`, `src/components/**`). Mirror the standing data-tables pattern; do not hand-roll a table.
+- Pattern to mirror: shared `DataTable` component at `src/components/DataTable.tsx`; standing data-tables convention in `project/design-system.md`.
+- States:
+  - empty — shared `EmptyState` illustration + primary CTA (CTA label/target parked, see Dependencies/parked notes).
+  - loading — skeleton rows.
+  - error — in-page error with retry affordance.
+  - disabled — Actions column non-sortable/non-filterable; sort/filter changes reset to page 1.
+- Affordances: column sort toggles, per-column filters, page-size control (default 30), View row action. Any destructive action (e.g. delete) MUST present a confirm affordance before executing.
+- Accessibility: labelled sortable headers (announce sort direction), labelled filter inputs, labelled page-size control, labelled row actions (e.g. "View audit record").
+- Convention followed: project/design-system.md
+
+PARKED PRODUCT DETAILS (do not guess; do not block the page core on these):
+1. Empty-state CTA — the convention mandates "a primary CTA relevant to the entity" but does not specify the Audit Log CTA's exact label or target. The empty-state BEHAVIOR (EmptyState illustration + a primary CTA) is grounded and authored above; only the CTA label/target is parked.
+2. Audit Log mutability (edit/delete row actions) — the brief applies uniform view/edit/delete row actions across all entities, but an audit log is conventionally immutable/append-only and the substrate establishes NO convention on whether Audit Log records are editable/deletable. Whether this page carries edit/delete row actions (vs. view-only) is a product/compliance decision with no conventional default. The View action and full table directive ARE authored; the edit/delete row actions are parked pending that decision. Per the standing convention, IF such destructive actions are later added, each MUST gate behind a confirm affordance.
+
+## Dependencies
+None.
+
+## Classification
+- Surface: UI (matches uiSurfaceGlobs `src/pages/**`, `src/components/**`).
+- Risk: heavy
+
+## Substrate grounding
+- Table behavior for ALL 10 pages (sortable+filterable except Actions / server-side pagination at 30 per page / page-size control default 30 / shared `EmptyState` + primary CTA empty view / skeleton-row loading / reuse shared `DataTable`) — grounded in `project/design-system.md` ("Design system — data tables (standing convention)"), lines 3-13. Cited as `Convention followed:` in every issue's Design section.
+- Shared table component reuse — grounded in `project/design-system.md#reuse-the-shared-datatable-component` → `src/components/DataTable.tsx`.
+- #B Order data-access grounding — the Order type/columns and the list-fetch + delete-mutation contracts are grounded in the brief's "standard columns for that entity" directive + the existing entity data-access pattern under `sourceGlobs` (`src/**`) that the shared `DataTable` server-side data interface supports (recorded after the §6.5 re-author).
+- Row actions (view/edit/delete) — grounded in the brief ("plus row actions (view / edit / delete)").
+- Degradations: none. `uiSurfaceGlobs` is set (`src/pages/**`, `src/components/**`), so all 10 page-issues correctly classify as UI and engaged the real `design-reviewer`.
+
+## Needs human input
+See `.milestone-feeder/needs-product-input-admin-list-pages.md` — `productGaps[]` is non-empty (two recorded product decisions surfaced by the decomposer). NOTE: both are Advisory-level and did NOT block any issue from the self-check gate (every issue PASSED); they are recorded so a human resolves the per-entity empty-state CTA copy/target and the Audit Log mutability decision before/at build. No issue was parked as needs-human-direction.
+
+---
+To create these on GitHub, re-run with `--apply` — it ensures the labels, creates-or-adopts the milestone, opens each gate-surviving issue, rewrites the slug references to real issue numbers, and patches the milestone description with the Wave order. This preview wrote no GitHub state.


### PR DESCRIPTION
## Summary
Adds a behavioral-contract **credibility harness** under `tests/` that runs the `decompose` prose against adversarial briefs and grades observed-vs-expected, plus the README improvements that came out of it. No plugin source changed — markdown only (fixtures, run artifacts, results, README).

## What's here
- `tests/README.md` — harness design + how-to. Honest-metric rule: the runner is **blind** to `expected.md`; an independent grader scores each run.
- `tests/scenarios/01–06/` — 6 adversarial fixtures (brief + `.project/` substrate + `feeder-env` + grader-only `expected.md`).
- Run artifacts (`run-output.md` + `run-log.md`) for the 4 run-now scenarios.
- `tests/RESULTS.md` — the scorecard + claim→evidence map + findings.
- `README.md` — Quickstart rewritten (concrete first run, plain-language config) and moved up; trimmed to overview/start/use/customize; Status now points at the harness.

## Results — 4/4 run-now ✅
| # | Scenario | Verdict |
|---|----------|---------|
| 01 | clean happy-path | ✅ correct decomposition; *parked an unspecified threshold rather than inventing it* |
| 02 | product-gap-parks | ✅ 0 emitted — gate caught the author's "no-op" dodge |
| 03 | design-resolvable | ✅ 6 issues, 0 parks, all cited; gate caught #C, retry cleared it |
| 06 | cross-cutting (flagship) | ✅ **10/10** carry the complete directive, literal "30" survives everywhere |

Every run used the **real `milestone-driver` reviewers** for the self-check gate (no self-review, no degrade).

## Execution fidelity (honest)
Preview-only, prose-direct. The **gate** (honesty-critical) ran the genuine driver reviewers; the feeder's own decomposer/issue-author agents aren't dispatchable from-repo, so their *contracts* were proxied via general-purpose agents. The `--apply`/`refine` write paths are **designed, not run** — a sandbox follow-up (tracked in `tests/RESULTS.md`).

## Findings (for v0.3, non-blocking)
- `--apply` **zero-survivors** case is under-specified (surfaced by 02).
- A sandbox `--apply`/`refine` run would convert the last "Designed, not run" rows to Demonstrated.

## Verification
Markdown-only (fixtures + docs); the harness was vetted by independent graders and direct review. No code-focused `/code-review` run (no source changed).