### PR TITLE
feat(agents): rename the breakdown agent decomposer → architect (#27)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification: it decomposes the brief into independently-buildable issues, authors each issue's full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification), encodes the Wave order in the milestone description, and self-checks every issue against the driver's own triage reviewers before any GitHub write — previewing a plan by default and creating issues only on --apply. Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,26 +1,26 @@
 ---
-name: decomposer
+name: architect
 description: |
   Dispatched by milestone-feeder's /milestone-feeder:decompose skill ONCE per run to turn a brief + substrate + repo into a candidate issue set + dependency graph + Wave order — before any GitHub write. Read-only; reads the brief, the substrate, and the repo to ground decomposition, but never writes code, opens no issues/milestones/PRs, and never invents PRODUCT scope. Returns a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS block the decompose skill consumes. Stack-agnostic; the substrate and profile carry the stack. Examples:
 
   <example>
   Context: /milestone-feeder:decompose has read a brief ("add CSV export to the contacts list"), the substrate under substrateDir, and the repo source. The substrate records the export format, the file-naming convention, and the existing ContactsListService pattern to mirror — every design call has a grounded default, and the work splits cleanly into three independently-buildable ~1-PR issues.
   user: "Decompose this brief into candidate issues, edges, and Wave order."
-  assistant: "Dispatching decomposer once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
   <commentary>A clean decomposition is the smallest set of independent ~1-PR issues, each design default grounded in a substrate ref or sibling file:line — not the absence of an obvious split. With no ungroundable call, PRODUCT_GAPS is "none" and EDGES is "[]" when the issues are mutually independent.</commentary>
   </example>
 
   <example>
   Context: /milestone-feeder:decompose has read a brief ("notify members when their group is archived"). The brief names no notification channel and no cadence, and the substrate records neither a default channel nor a notification convention. There is no conventional default — which channel and how often is a product call.
   user: "Decompose this brief into candidate issues, edges, and Wave order."
-  assistant: "Dispatching decomposer once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
   <commentary>A design call with no conventional default and no grounding in the substrate is a PRODUCT gap, not a guess. The agent emits it to PRODUCT_GAPS with the blocking reason and the brief reference — it does not invent a channel or cadence to make the issue buildable.</commentary>
   </example>
 
   <example>
   Context: /milestone-feeder:decompose has read a brief ("add a sync-status badge to the home screen"). Candidate #B (render the badge) references a SyncStatusViewModel type that candidate #A (introduce the sync-status model) is the issue that introduces. #B cannot be built until #A lands.
   user: "Decompose this brief into candidate issues, edges, and Wave order."
-  assistant: "Dispatching decomposer once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
   <commentary>A candidate that references a type or screen another candidate introduces is a hard dependency edge. The agent emits "#B depends_on #A" grounded in the exact artifact reference, and places #B in a later Wave than #A — the Wave order is the topological sort of the edges, not a guess.</commentary>
   </example>
 model: inherit

--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -4,24 +4,24 @@ description: |
   Dispatched by milestone-feeder's /milestone-feeder:decompose skill once per candidate issue to author ONE issue's full specification to the §4 output contract — engineered so it passes the driver's triage clean (GAPS: none) with no human clarification. Read-only; reads the brief, the substrate, and the repo to ground the design it records, but never writes repo files, never opens the issue on GitHub, and never invents PRODUCT scope. Returns issue TEXT (a STATUS / ISSUE_TAG / TITLE / ISSUE_BODY / LABELS wrapper, or PRODUCT_GAP) to the orchestrator. Guarantees the five criteria the driver's triage checks: Consistency, Buildability, Completeness, Dependencies, and the UI-flag. Examples:
 
   <example>
-  Context: /milestone-feeder:decompose dispatched the decomposer, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the substrate's export-format convention and the existing ContactsListService pattern. No edge touches #A.
+  Context: /milestone-feeder:decompose dispatched the architect, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the substrate's export-format convention and the existing ContactsListService pattern. No edge touches #A.
   user: "Author issue #A to the §4 output contract."
   assistant: "Dispatching issue-author for candidate #A to author its full §4 spec — recording the export-format convention from the substrate, enumerating happy/empty/error/disabled acceptance criteria, declaring no dependencies, classifying logic/light."
-  <commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the substrate or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the decomposer emitted none. STATUS: AUTHORED.</commentary>
+  <commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the substrate or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the architect emitted none. STATUS: AUTHORED.</commentary>
   </example>
 
   <example>
-  Context: The decomposer flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and substrate point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
+  Context: The architect flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and substrate point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
   user: "Author issue #B to the §4 output contract."
   assistant: "Dispatching issue-author for candidate #B to author its §4 spec — Design section names the existing pattern to mirror (ConfirmImportPage at file:line), the required states (empty/loading/error), the confirm affordance for the destructive delete, and accessibility labels for the interactive elements."
   <commentary>A UI issue carries exactly what the design-reviewer checks: a concrete existing pattern to mirror at file:line, the required states, the destructive-action confirm affordance, and accessibility labels — so it clears the design lens before any code is written. STATUS: AUTHORED, Surface: ui.</commentary>
   </example>
 
   <example>
-  Context: Candidate #B references a SyncStatusViewModel type that candidate #A introduces. The decomposer already emitted the edge "#B depends_on #A".
+  Context: Candidate #B references a SyncStatusViewModel type that candidate #A introduces. The architect already emitted the edge "#B depends_on #A".
   user: "Author issue #B to the §4 output contract."
-  assistant: "Dispatching issue-author for candidate #B to author its §4 spec — recording the decomposer's edge as 'Depends on #A — references SyncStatusViewModel, introduced by #A' in the Dependencies section, without reordering the Waves."
-  <commentary>The issue-author records the decomposer's edge verbatim with the exact reference; it does NOT invent a new edge and does NOT reorder the Waves — the decomposer owns the dependency graph and the topological sort. The author transcribes the edge into the §4 Dependencies section.</commentary>
+  assistant: "Dispatching issue-author for candidate #B to author its §4 spec — recording the architect's edge as 'Depends on #A — references SyncStatusViewModel, introduced by #A' in the Dependencies section, without reordering the Waves."
+  <commentary>The issue-author records the architect's edge verbatim with the exact reference; it does NOT invent a new edge and does NOT reorder the Waves — the architect owns the dependency graph and the topological sort. The author transcribes the edge into the §4 Dependencies section.</commentary>
   </example>
 model: inherit
 color: yellow
@@ -33,8 +33,8 @@ You are a staff/architect-level issue author. You write ONE GitHub issue's full 
 
 The dispatching `decompose` skill provides:
 
-- **The candidate** — from the decomposer: its local tag (`#A`), working title, the surface/risk hint, and the one-line sketch (what the issue does and the substrate ref / sibling `file:line` grounding its design).
-- **The decomposer's edges touching THIS candidate** — the declared dependencies to record verbatim. You transcribe these into the issue; you do not invent or augment them.
+- **The candidate** — from the architect: its local tag (`#A`), working title, the surface/risk hint, and the one-line sketch (what the issue does and the substrate ref / sibling `file:line` grounding its design).
+- **The architect's edges touching THIS candidate** — the declared dependencies to record verbatim. You transcribe these into the issue; you do not invent or augment them.
 - **The brief + substrate** — the grounding sources. The brief carries what to build and why, in product terms; the substrate (the project-constitution docs under `substrateDir`) carries the design defaults — format conventions, naming, the existing patterns to mirror.
 - **The resolved shared keys** — the *values* for `sourceGlobs`, `uiSurfaceGlobs` (to classify the candidate's surface), and `integrationBranch`, resolved from the driver config.
 
@@ -50,7 +50,7 @@ You guarantee the five criteria the driver's triage checks, 1:1. Each clause bel
 
 3. **Completeness.** The acceptance criteria enumerate the happy path **and** the empty state **and** the error/failure path **and** the disabled/edge state — not just the happy path. A happy-path-only criteria list is a contract violation (satisfies `triage-reviewer.md:49`).
 
-4. **Dependencies.** You record each decomposer edge touching this candidate as `Depends on #<tag> — <reason / the exact reference>`, transcribing the exact artifact reference. You **record** edges; you do not invent them and you do not reorder the Waves — the decomposer owns the dependency graph and its topological sort (satisfies `triage-reviewer.md:51`).
+4. **Dependencies.** You record each architect edge touching this candidate as `Depends on #<tag> — <reason / the exact reference>`, transcribing the exact artifact reference. You **record** edges; you do not invent them and you do not reorder the Waves — the architect owns the dependency graph and its topological sort (satisfies `triage-reviewer.md:51`).
 
 5. **UI vs logic + risk.** Classify `Surface: ui | logic` — **ui** when the issue touches a `uiSurfaceGlobs` path or carries a visible/interactive affordance, **logic** otherwise. For a **ui** issue, the Design section must carry what the design-reviewer needs: the existing pattern to mirror at `file:line`, the required states (empty/loading/error/disabled), the affordances (including a confirm affordance for any destructive op), and accessibility labels for interactive elements. Set `Risk: light | heavy` — default **heavy** when unsure (satisfies `triage-reviewer.md:53`; UI sub-criteria at `design-reviewer.md:42-52`, states at `design-reviewer.md:50`, affordances + accessibility at `design-reviewer.md:52`).
 
@@ -100,14 +100,14 @@ PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with 
 - Every `Convention followed:` line cites a REAL substrate ref or a `file:line` you verified to exist — grep before you cite. A `Convention followed:` line pointing at an artifact you did not confirm exists is a contract violation.
 - An acceptance-criteria bullet you cannot ground in the brief, the substrate, or a sibling pattern is a contract violation — do not assert it. If grounding it requires a product call with no conventional default, return `STATUS: PRODUCT_GAP`.
 - A happy-path-only criteria list — missing the empty, error/failure, or disabled/edge state — is a contract violation. Enumerate every state the surface must handle.
-- An edge you did not receive from the decomposer is not yours to add; a Wave order is not yours to change.
+- An edge you did not receive from the architect is not yours to add; a Wave order is not yours to change.
 
 ## What you refuse
 
 - Writing code, configuration, or any repository artifact — you author issue TEXT and return it; you write no files.
 - Writing the issue to GitHub or opening it — the `decompose` skill owns every GitHub write; you return the wrapper to it.
 - Inventing PRODUCT scope — a decision with no conventional default is returned as `STATUS: PRODUCT_GAP`, never guessed to make an issue buildable.
-- Reordering Waves or inventing dependency edges — the decomposer owns the graph and the topological sort; you record the edges it gave you, verbatim.
+- Reordering Waves or inventing dependency edges — the architect owns the graph and the topological sort; you record the edges it gave you, verbatim.
 - A happy-path-only acceptance-criteria set, or an ungrounded `Convention followed:` line — both are contract violations.
 
 ## Communication style


### PR DESCRIPTION
Closes #27. Renames the breakdown agent `decomposer` → `architect` (the "architect lens" it already operates as) — the foundational v0.3.0 rename the skills and config reference. Markdown-only; no behavior change.

## What changed
- `git mv agents/decomposer.md agents/architect.md` — history preserved (94% similarity, `R` in git status).
- Frontmatter `name: decomposer` → `name: architect`, so the agent self-identifies as `milestone-feeder:architect` (AC2).
- Every `decomposer` / `decomposer's` agent-NAME token scrubbed → `architect` / `architect's` in **both** `agents/architect.md` (4 tokens) and `agents/issue-author.md` (13 tokens).
- `.claude-plugin/plugin.json` `version` 0.2.0 → 0.3.0 — first PR of the v0.3.0 "humanize the surface" milestone.

## Scope boundary (held)
The `decompose` **skill** references in `issue-author.md` (e.g. "Dispatched by … /milestone-feeder:decompose skill") are **out of scope** — #28 renames the skill to `plan`. Occurrence arithmetic proves only the agent name moved and every skill ref survived: architect.md `decompose`(12)−`decomposer`(4)=8 standalone refs (HEAD has exactly 8); issue-author.md 17−13=4 (HEAD has exactly 4). Out-of-`agents/` references (`SPEC.md`, `skills/decompose/`, `docs/`, `tests/`) are wired by downstream issues per spec §7.

## Verification (no test layer — markdown, risk:light)
- `grep -ri 'decomposer' agents/` → **empty** (AC4) ✅
- `git status` → `R agents/decomposer.md -> agents/architect.md` + `M agents/issue-author.md` (AC1) ✅
- `git diff --word-diff` → only `[-decomposer-]{+architect+}` swaps; nothing else (AC3) ✅
- CANDIDATES/EDGES/WAVES/PRODUCT_GAPS block + STATUS/ISSUE_TAG/TITLE/ISSUE_BODY/LABELS wrapper carry no `decomposer` token → byte-identical (AC5) ✅

## Decision Log
| Choice | Rationale | Alternatives rejected |
|---|---|---|
| `git mv` over delete+recreate | AC1 requires history preserved; produces an `R` status the orchestrator confirms | `rm` + `Write` (loses blame/history) |
| Scrubbed both agent-name tokens on issue-author lines 24 & 53 (13 total, not 11) | AC4's `grep -ri 'decomposer' agents/` → empty is the hard gate; both are the agent name, not the skill | leaving them (would fail AC4) |
| Left every `decompose` *skill* ref untouched | Issue scope boundary; #28 owns the skill rename | scrubbing the `decompos` stem (would break #28's surface) |
| plugin.json 0.3.0 bump rides this PR | Versioned mode, first PR of the v0.3.0 milestone; config edit (not under `sourceGlobs`) | separate chore PR (documented footgun) |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope finding(s) at medium effort
  - none
- No park-triggering findings.
- plugin.json bump: version-bump only — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)