### PR TITLE
docs(metadata): bump release metadata to v0.3.0 (#33)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,16 +6,16 @@
     "email": "ken@kenmulford.com"
   },
   "metadata": {
-    "description": "Brief-to-milestone feeder for Claude Code — the predecessor of milestone-driver"
+    "description": "Brief-to-milestone feeder for Claude Code — plan your idea into well-formed issues, then create the milestone that milestone-driver builds."
   },
   "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
   "plugins": [
     {
       "name": "milestone-feeder",
       "source": "./",
-      "description": "Decompose a feature brief into a GitHub milestone of small, well-formed issues that pass milestone-driver's triage clean — preview by default, create on --apply. Authors no code.",
+      "description": "Plan a feature brief into a GitHub milestone of small, well-formed issues that pass milestone-driver's triage clean — review the plan, then create it; update keeps a changed plan in sync. Authors no code.",
       "category": "development",
-      "tags": ["github", "milestones", "issues", "decomposition", "planning", "triage", "automation"]
+      "tags": ["github", "milestones", "issues", "planning", "triage", "automation"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "milestone-feeder",
   "version": "0.3.0",
-  "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification: it decomposes the brief into independently-buildable issues, authors each issue's full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification), encodes the Wave order in the milestone description, and self-checks every issue against the driver's own triage reviewers before any GitHub write — previewing a plan by default and creating issues only on --apply. Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
+  "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",
     "email": "ken@kenmulford.com"
@@ -15,7 +15,6 @@
     "github",
     "milestone",
     "issues",
-    "decomposition",
     "planning",
     "triage",
     "automation",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,75 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.3.0 — Humanize the surface
+
+**Theme:** v0.2.0 works, but everything a user typed or read spoke in
+implementation jargon. v0.3.0 is one focused pass that makes the surface speak the
+user's language — intent-named command verbs, no flags, human config keys, and an
+agent renamed to match what it does. **This release is breaking vs v0.2.0.** It is
+not a behavioral redesign: one behavioral change ships, and only because it makes
+the surface honest — `create` now builds exactly the plan you approved instead of
+re-running the pipeline and possibly diverging from the preview.
+
+### 💥 Breaking — the command surface (verbs, not flags)
+
+Three intent-named verbs replace two verbs plus a flag. Each verb *is* the
+explanation of what it does. There are no back-compat aliases — the old commands
+are gone.
+
+| v0.2.0 | v0.3.0 | What you mean |
+|---|---|---|
+| `decompose <brief>` (preview) | **`plan <brief>`** | "Turn my idea into a reviewable plan." |
+| `decompose <brief> --apply` | **`create <brief>`** | "Approve it — build the milestone + issues." |
+| `refine <milestone>` | **`update <brief>`** | "My plan changed — sync it to the milestone." |
+
+- **`create` is read-the-plan and faithful.** It resolves the plan file `plan`
+  wrote and deploys **exactly** it — no pipeline re-run, no re-vet. If no plan file
+  exists yet, it runs `plan` for you first, then deploys that. What you reviewed is
+  what gets built.
+- **`update` is safe.** It reconciles a refreshed plan onto the existing milestone:
+  creates missing issues, patches drifted bodies (showing the diff first), and adds
+  new dependency edges. It **never closes or deletes** a live issue — one absent
+  from your plan is flagged for your decision, not removed. Re-running on an
+  already-synced milestone writes nothing (idempotent).
+
+### 💥 Breaking — config keys renamed (the file stays the same)
+
+The config file is still `.milestone-config/feeder.json` (no rename — pairs with
+`driver.json`, avoids hook churn). The **keys inside** are humanized. There is no
+silent old-key fallback; an external consumer who set the old keys re-runs `setup`.
+
+| v0.2.0 key | v0.3.0 key | What it is |
+|---|---|---|
+| `substrateDir` | **`projectDocs`** | Where your project's standing docs live. |
+| `selfCheck` | **`reviewer`** | Who checks each issue before it's created (`"milestone-driver"` / `"internal"` / `false`). |
+| `issueSizeGuidance` | **`issueSize`** | Optional sizing rule. |
+| `decomposerAgent` | **`architectAgent`** | Tracks the agent rename below. |
+
+### ✨ Agent rename — `decomposer` → `architect`
+
+| Issue | What |
+|---|---|
+| #27 | The breakdown agent (brief → candidate issues + dependency graph + build order) is renamed `decomposer` → `architect` (`agents/decomposer.md` → `agents/architect.md`, id `milestone-feeder:decomposer` → `milestone-feeder:architect`). It pairs cleanly with the issue-author: the architect designs the breakdown, the issue-author writes each issue. Logic and contracts are unchanged — only the name and the prose around it. |
+
+### ✨ Release metadata & verification
+
+| Issue | What |
+|---|---|
+| #33 | Release metadata re-vocab'd to the final surface: `plugin.json` (`version` → `0.3.0`, description rewritten to the `plan`/`create`/`update` surface, the `decomposition` keyword dropped), `marketplace.json` (no `--apply`, no residual `decompose` prose), and this CHANGELOG entry. |
+| #36 | The credibility harness migrated to the v0.3.0 surface (new verbs, new keys, `feeder.json` kept) and **re-run** — fresh transcripts, so the **4/4 green** scorecard proves v0.3.0, not v0.2.0. The rename changed names, not behavior. |
+
+### Consumer notes
+
+- **This is a breaking release.** Use `plan` / `create` / `update` (not
+  `decompose` / `decompose --apply` / `refine`), and the new config keys
+  (`projectDocs` / `reviewer` / `issueSize` / `architectAgent`). The config file
+  name is unchanged. Re-run `setup` if you had set any of the old keys.
+- **`create` builds what you approved.** It deploys the recorded plan faithfully;
+  to change what gets built, change your brief and re-run `plan`.
+- **`update` never destroys.** It only creates and patches; an issue that left your
+  plan is flagged, never auto-closed.
+
 ## v0.2.0 — Gate & apply
 
 **Theme:** The feeder grows teeth and a write hand. The preview slice now runs the


### PR DESCRIPTION
Bumps the plugin's release metadata to the v0.3.0 `plan`/`create`/`update` surface and records the breaking migration in the CHANGELOG. Config/docs only — no source (`skills/**`, `agents/**`, `hooks/**`) touched, no test layer in this repo.

Closes #33.

## What changed

- **`.claude-plugin/plugin.json`** — `version` stays `0.3.0`; `description` rewritten to the `plan`/`create`/`update` surface (drops "decompose"/"--apply"); the `decomposition` keyword removed (`planning` retained).
- **`.claude-plugin/marketplace.json`** — both descriptions and the `tags` re-vocab'd to `plan`/`create`/`update`; the `--apply` reference, the residual "Decompose" prose, and the `decomposition` tag removed.
- **`CHANGELOG.md`** — new `## v0.3.0 — Humanize the surface` entry prepended before `v0.2.0`, recording: breaking command rename (plan/create/update), breaking config-key rename (`projectDocs`/`reviewer`/`issueSize`/`architectAgent`; `feeder.json` kept), read-the-plan `create`, safe never-close idempotent `update`, the `decomposer`→`architect` agent rename, and the 4/4 harness re-run. (The CHANGELOG legitimately names the old terms — it documents the migration; `docs/specs/` and `CHANGELOG.md` are excluded from #37's grep.)

## Verification (no automated test layer — greps + inspection)

- `grep -i 'decompos\|--apply' .claude-plugin/plugin.json .claude-plugin/marketplace.json` → **empty** ✓
- `jq . .claude-plugin/plugin.json` → valid JSON; `version` is `0.3.0`; `description` names plan/create/update ✓
- `jq . .claude-plugin/marketplace.json` → valid JSON ✓
- `CHANGELOG.md` carries the `## v0.3.0` entry, positioned before `## v0.2.0` ✓

## Decision Log

| Choice | Rationale | Alternatives rejected |
|---|---|---|
| Re-vocab `marketplace.json` `metadata.description` (was "the predecessor of milestone-driver") to the plan/create/update surface | AC requires the marketplace re-vocab'd to plan/create/update with no residual decompose prose; the stale "predecessor" framing didn't describe the current surface. | Leaving it as-is — it carried no decompose/--apply token but failed the "re-vocab to plan/create/update" intent. |
| Drop the `decomposition` keyword/tag entirely (keep `planning`) rather than renaming to "planning" | `planning` already present in both arrays; adding a second would duplicate. | Renaming `decomposition`→`planning` — would create a duplicate `planning` entry. |
| CHANGELOG follows the existing entry voice (theme paragraph + grouped tables + consumer notes) and cites the per-issue numbers (#27, #33, #36) | Matches the v0.2.0/v0.1.0 structure already in the file; grounds claims in the milestone's build order. | A terse bullet list — would break the established CHANGELOG format. |
| Version left at `0.3.0` (no bump) | Milestone-driven run; target version is 0.3.0 and `plugin.json` already holds it — idempotent no-op per step 6.4. | Patch-bumping — would diverge from the milestone target. |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 1 in-scope finding at medium effort
  - `marketplace.json` `metadata.description` read "the milestone milestone-driver builds" (a stutter, violating the writing-for-humans user-facing-text standard) → fixed directly ("the milestone **that** milestone-driver builds"); a doc-only fix to a non-`sourceGlobs` config file, re-validated (JSON valid, grep clean). → resolved
- No park-triggering findings.

Version-free annotation: version-bump only — no logic change (metadata/docs only; `version` already at the milestone target 0.3.0).
