### PR TITLE
docs: rewrite README to the writing-for-humans standard (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,98 @@
 # milestone-feeder
 
-Turn a feature brief into a build-ready milestone.
+Turn a rough idea into a build-ready GitHub milestone — a tidy list of small, well-formed issues, in the order they should be built.
 
-milestone-feeder is a Claude Code plugin. Hand it a feature brief — a file, inline text, or a GitHub epic issue — and it produces a GitHub milestone of small, well-formed issues that [`milestone-driver`](https://github.com/kenmulford/milestone-driver) can build with no human clarification. It decomposes the brief into independently-buildable issues, writes each issue's full spec, encodes the dependency/Wave order in the milestone description, and self-checks every issue with the driver's own reviewers before anything is created — so what it hands the driver passes the driver's triage the first time.
+milestone-feeder is a Claude Code plugin. You hand it a brief — a file, a few lines of text, or a GitHub epic issue — and it writes a reviewable plan: each piece of work as its own issue, with a full spec, the decisions an engineer would otherwise have to invent, and a build order. You read the plan, then tell it to build the milestone on GitHub. Its sibling plugin, [`milestone-driver`](https://github.com/kenmulford/milestone-driver), can then pick the issues up and build them with no further clarification.
 
-It previews a reviewable plan by default and writes nothing to GitHub until you pass `--apply`. A decision with no conventional default parks to a report rather than being guessed. It authors no code, opens no PRs, and never touches branches.
-
-## At a glance
-
-- **Input:** a feature brief (file, inline, or a GitHub epic issue) + your project's standing docs (`.project/`).
-- **Output:** a milestone whose description encodes the Wave/dependency order, and small issues each with complete acceptance criteria, recorded design, declared dependencies, and a UI/logic + risk label.
-- **Safety:** preview by default; `--apply` creates the milestone/issues; authors no code, opens no PRs; parks product decisions instead of inventing them.
-
-## Quickstart
-
-**1. Install** (it pulls in the required superpowers dependency), then restart Claude Code so the hook loads:
+**Install it** — this also pulls in the required `superpowers` plugin. Restart Claude Code afterward so the plugin's hook loads:
 
 ```
 /plugin marketplace add kenmulford/milestone-feeder
 /plugin install milestone-feeder@milestone-feeder
 ```
 
-**2. Run it — no config needed to start.** Put your feature idea in a file (a paragraph is plenty), preview the milestone it *would* create, then create it:
+## Quick start
 
-```
-# A brief can be a file, inline text, or a GitHub epic issue (e.g. #42).
-/milestone-feeder:decompose myfeature.md
-#   → writes a reviewable plan file and creates NOTHING on GitHub. Read it first.
+The whole tool is three commands — `plan`, then `create`, and `update` when your idea changes later. The loop:
 
-/milestone-feeder:decompose myfeature.md --apply
-#   → now creates the milestone + issues + labels on GitHub.
-```
+1. **`plan` your idea.** Put your idea in a file (a paragraph is plenty), or paste it inline, or point at a GitHub epic issue (e.g. `#42`):
 
-That's the whole loop: **preview → read the plan → `--apply`**. No profile yet? The first run bootstraps one with you. To re-vet a milestone you already created — re-triage it, patch gappy issues, fill missing dependency edges — run `/milestone-feeder:refine "<milestone title>"`.
+   ```
+   /milestone-feeder:plan myidea.md
+   ```
 
-**3. Customize it (optional).** Configure the feeder in `.milestone-config/feeder.json`; every key has a default, so this is optional:
+   It reads your project's docs, breaks the idea into small issues, checks each one against your conventions, and writes a **plan file** you can read. It creates nothing on GitHub yet.
 
-- **`substrateDir`** (default `.project/`) — the folder of your project's *standing docs*: architecture notes, coding conventions, a design system. The feeder reads these and **grounds every issue in your actual conventions** — it records "reuse the shared `FormField` component" with a citation instead of inventing a design, and a cross-cutting rule there (e.g. "all tables paginate at 30 rows/page") propagates into every issue it touches. The richer this folder, the better the issues and the fewer decisions the feeder hands back to you.
-- **`selfCheck`** (default `"milestone-driver"`) — the quality gate that vets every issue *before* it's created: `"milestone-driver"` uses the driver's real reviewers, `"internal"` uses a built-in checklist, `false` turns it off. Leave it on.
-- The build-side keys (`uiSurfaceGlobs`, `integrationBranch`, your repo's `sourceGlobs`) are **read from your milestone-driver config** — you don't repeat them here.
+2. **Read the plan.** Open the plan file it points you to and check the issues, the design decisions it recorded, and the build order. This is your review — change your idea and re-run `plan` if anything's off.
 
-Full setup: [docs/consumer-setup.md](docs/consumer-setup.md). Every key explained: [docs/profile-schema.md](docs/profile-schema.md).
+3. **`create` it.** When the plan looks right, build it on GitHub:
+
+   ```
+   /milestone-feeder:create myidea.md
+   ```
+
+   It creates the milestone, opens every issue, applies the labels, and writes the build order into the milestone description — exactly the plan you read, nothing re-decided.
+
+4. **`update` when your idea changes.** Edit your brief, re-run `plan` to refresh the plan, then sync it onto the milestone you already have:
+
+   ```
+   /milestone-feeder:update myidea.md
+   ```
+
+   It creates any new issue, patches any issue whose spec drifted (showing you the diff first), adds any new dependency to the build order, and **flags** — never closes — any live issue your plan no longer mentions.
+
+The very first time you run `plan` in a repo with no config, it sets up a small profile for you and then carries on — you don't re-run anything.
+
+## Before you start
+
+For us to build your milestone and issues, a few things need to be in place. Each one below comes with what breaks if it's missing.
+
+- **`gh` (the GitHub CLI) installed and signed in**, and you're working in a directory connected to a GitHub repository — otherwise we won't be able to create your milestone or issues.
+- **Claude allowed to run the GitHub write commands** that `create`, `update`, and `setup` use, plus **Read access to your project docs**:
+  - `gh label create` — to provision the `ui` / `logic` / `risk:*` labels.
+  - `gh api .../milestones` (POST and PATCH) — to create or adopt the milestone and write the build order into its description.
+  - `gh issue create` / `edit` / `list` / `view` / `comment` — to open issues, fix their cross-references, find existing ones on a re-run, read an epic brief, and post a needs-input report.
+  - **Read** on your project's standing docs — so we can ground each issue in your real conventions.
+
+  Without these grants, `create` and `update` can't write to GitHub.
+- **git.**
+- **bash with `jq`** (or **PowerShell 7+**) — for the small hook that keeps the plugin from editing your source while it works.
+- **`milestone-driver` is optional.** It backs the default reviewer (`reviewer: "milestone-driver"`), which checks each issue with the driver's own reviewers. If it isn't installed, the check quietly falls back to a built-in checklist (`reviewer: "internal"`) — nothing fails.
+
+One thing worth knowing: **`plan` never writes to GitHub.** It only *reads* — and only when you hand it an epic issue as the brief (it runs `gh issue view` on that one issue). Everything `plan` produces is a local file you review. The GitHub writes above are what `create`, `update`, and `setup` need — not `plan`.
 
 ## How it works
 
-A pipeline of small, gated steps: **decompose** the brief into candidate issues + a dependency graph, **author** each issue's full spec, **self-check** every issue against the driver's real reviewers (re-author on a fixable gap, park a decision with no conventional default), then **emit** — a preview plan by default, or the milestone + issues on `--apply`. `refine` runs the same pipeline against an existing milestone (idempotent; creates and deletes nothing).
+You hand `plan` your idea. It reads your project's standing docs and breaks the idea into small, buildable issues — recording, for each one, the decisions an engineer would otherwise have to invent, and citing the house rule it followed. Before it finishes, it checks each issue against your conventions and fixes or flags anything that doesn't hold up. A decision with no conventional default it never guesses — it flags it for you to make. Then `create` builds exactly what you approved.
 
-The gate, the parking rules, and the `--apply` write order are documented in [docs/architecture.md](docs/architecture.md).
+That check is the guardrail. Two parts, in plain terms:
 
-## Requirements
+- **It grounds every issue in your real conventions.** Instead of inventing a design, it reads your project's standing docs and reuses what's already there — recording "reuse the shared `FormField` component", with a citation, rather than making something up. A rule that applies everywhere (say, "all tables paginate at 30 rows per page") flows into every issue it touches.
+- **It checks each issue before it's created, and fixes or flags — never guesses.** Every issue is reviewed against the same bar `milestone-driver` uses to start a build. A gap your conventions can answer, it fixes. A decision with no conventional default — a real product call only you can make — it sets aside and lists for you in a needs-input report, rather than guessing an answer to make the issue look finished.
 
-- The superpowers plugin — a hard dependency, auto-installed on install if you have the official marketplace added.
-- GitHub CLI (`gh`), authenticated, for milestone, issue, and label operations.
-- git.
-- bash (preferred) or PowerShell 7+ for the `no-source-edit` hook; `jq` for the bash path.
-- milestone-driver is **optional** — it backs the default `selfCheck: "milestone-driver"` gate; absent, the feeder degrades to the built-in `"internal"` checklist.
+The richer your project docs, the better the issues and the fewer decisions land back on your plate. Nothing here is new machinery — it's the grounding and the check, described in plain terms.
+
+## Config
+
+Configuration is **optional** — every setting has a sensible default, so the tool runs with no config at all. When you do want to tune it, the settings live in `.milestone-config/feeder.json` (the same folder `milestone-driver` keeps its `driver.json` in). The first `plan` run writes this file for you.
+
+- **`projectDocs`** (default `.project/`) — the folder where your project's standing docs live: architecture notes, coding conventions, a design system. This is what the feeder reads to ground every issue in your real conventions.
+- **`reviewer`** (default `"milestone-driver"`) — who checks each issue against your conventions before it's created. `"milestone-driver"` uses the driver's own reviewers; `"internal"` uses a built-in checklist; `false` turns the check off (you'll get a visible warning if you do).
+- **`issueSize`** (optional) — a natural-language sizing rule the breakdown should honor, e.g. `"≤1 PR, ≤1 new screen"`. Leave it out for no constraint beyond the defaults.
+
+The build-side settings — your UI-surface paths, your integration branch, your source paths — are **read from your `milestone-driver` config**, not repeated here.
+
+Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every setting explained: [docs/profile-schema.md](docs/profile-schema.md).
 
 ## Status
 
-v0.2.0 — the self-check gate, `--apply`, and `refine` are shipped (v0.1.0 was the preview slice). Self-hosted: the feeder was built as its own milestone, driven by milestone-driver.
-
-The preview pipeline and the self-check gate are exercised by a scenario harness ([`tests/`](tests/), scorecard in [`tests/RESULTS.md`](tests/RESULTS.md)) — all green, with the gate running milestone-driver's real reviewers. The `--apply` and `refine` write paths are covered by design and a sandbox follow-up, not yet exercised end-to-end.
+v0.3.0 — the surface speaks your language: `plan` to draft, `create` to build, `update` to sync. Self-hosted: the feeder was planned as its own milestone and built by milestone-driver.
 
 ## Docs
 
 - [docs/consumer-setup.md](docs/consumer-setup.md): setup and wiring.
-- [docs/profile-schema.md](docs/profile-schema.md): every profile key.
-- [docs/architecture.md](docs/architecture.md): the as-built design and the gates.
+- [docs/profile-schema.md](docs/profile-schema.md): every profile setting.
+- [docs/architecture.md](docs/architecture.md): the as-built design and the checks.
 - [SPEC.md](SPEC.md): the full design and spec.
 
 ## License


### PR DESCRIPTION
Closes #34.

Rewrites `README.md` to the writing-for-humans standard — the showcase of the v0.3.0 "humanize the surface" theme. Section order is locked: **Quick start → Before you start → How it works**, then Config, Status, Docs, License.

## What changed
- **Quick start** leads with the quick win: the `plan` → read the plan → `create` loop, plus `update` when the idea changes later. Zero flags anywhere.
- **Before you start** enumerates the REAL consumer permissions, derived from the skills' actual `gh` surface (not this repo's dogfood `settings.local.json`, which carries only Read globs): `gh` installed + authenticated in a GitHub-connected repo; `gh label create`; `gh api .../milestones` (POST/PATCH); `gh issue create`/`edit`/`list`/`view`/`comment`; Read for project docs; git; bash+`jq` or PowerShell 7+ for the no-source-edit hook; `milestone-driver` optional (backs the default `reviewer: "milestone-driver"`, degrades to `"internal"` if absent). Notes that `plan` is read-only on GitHub.
- **How it works** makes the grounding + self-check gate legible in plain English (issue #4 → legibility, not new machinery) using the design spec §8 blockquote as the model.
- **Config** adopts the v0.3.0 key names — `projectDocs` / `reviewer` / `issueSize`; the file stays `feeder.json`.
- No `decompose` / `refine` / `--apply` / `substrateDir` / `selfCheck` anywhere; vocabulary matches design spec §12.

## Decision Log
| Choice | Rationale | Citation | Alternative rejected |
|---|---|---|---|
| Describe the real implemented surface, not the spec's aspiration | The README must match what the skills actually do | `skills/plan|create|update|setup/SKILL.md` | Copying spec §8 verbatim (aspirational) |
| Permission list derived from the skills' `gh` calls, not `settings.local.json` | AC requires the *consumer* surface; dogfood settings carry only Read globs | spec §8; `skills/create/SKILL.md` passes a–e; `skills/setup/SKILL.md` Phase 4; `skills/plan/SKILL.md` | Listing the dogfood allowlist |
| Install block kept at the top (lead), Requirements folded into Before-you-start | Install + restart-for-hook + `superpowers` pull are the first thing a newcomer needs; one prereq list, not two | brief item 1; `.claude-plugin/plugin.json` dependencies | A separate Requirements section |
| "build order" / "standing docs" / "flag for your decision" throughout | Design spec §12 vocabulary table is the translation backbone | spec §12 | Internal jargon (Wave / substrate / park) |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope finding(s) at low effort
  - none
- No park-triggering findings.
- version-free — no version bump (plugin.json already at the milestone target 0.3.0; idempotent no-op)

This is a documentation-only change (`README.md` at repo root, outside `sourceGlobs`); `risk:light`, non-UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)