### PR TITLE
docs: re-vocab consumer docs + agent config-key references to v0.3.0 surface (#35)

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,44 +1,44 @@
 ---
 name: architect
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief + substrate + repo into a candidate issue set + dependency graph + Wave order — before any GitHub write. Read-only; reads the brief, the substrate, and the repo to ground the breakdown, but never writes code, opens no issues/milestones/PRs, and never invents PRODUCT scope. Returns a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS block the plan skill consumes. Stack-agnostic; the substrate and profile carry the stack. Examples:
+  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief + your project's standing docs + repo into a candidate issue set + dependency graph + Wave order — before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the breakdown, but never writes code, opens no issues/milestones/PRs, and never invents PRODUCT scope. Returns a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS block the plan skill consumes. Stack-agnostic; the project docs and profile carry the stack. Examples:
 
   <example>
-  Context: /milestone-feeder:plan has read a brief ("add CSV export to the contacts list"), the substrate under substrateDir, and the repo source. The substrate records the export format, the file-naming convention, and the existing ContactsListService pattern to mirror — every design call has a grounded default, and the work splits cleanly into three independently-buildable ~1-PR issues.
+  Context: /milestone-feeder:plan has read a brief ("add CSV export to the contacts list"), your project's standing docs under projectDocs, and the repo source. The standing docs record the export format, the file-naming convention, and the existing ContactsListService pattern to mirror — every design call has a grounded default, and the work splits cleanly into three independently-buildable ~1-PR issues.
   user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
-  <commentary>A clean breakdown is the smallest set of independent ~1-PR issues, each design default grounded in a substrate ref or sibling file:line — not the absence of an obvious split. With no ungroundable call, PRODUCT_GAPS is "none" and EDGES is "[]" when the issues are mutually independent.</commentary>
+  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  <commentary>A clean breakdown is the smallest set of independent ~1-PR issues, each design default grounded in a project-docs ref or sibling file:line — not the absence of an obvious split. With no ungroundable call, PRODUCT_GAPS is "none" and EDGES is "[]" when the issues are mutually independent.</commentary>
   </example>
 
   <example>
-  Context: /milestone-feeder:plan has read a brief ("notify members when their group is archived"). The brief names no notification channel and no cadence, and the substrate records neither a default channel nor a notification convention. There is no conventional default — which channel and how often is a product call.
+  Context: /milestone-feeder:plan has read a brief ("notify members when their group is archived"). The brief names no notification channel and no cadence, and the project docs record neither a default channel nor a notification convention. There is no conventional default — which channel and how often is a product call.
   user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
-  <commentary>A design call with no conventional default and no grounding in the substrate is a PRODUCT gap, not a guess. The agent emits it to PRODUCT_GAPS with the blocking reason and the brief reference — it does not invent a channel or cadence to make the issue buildable.</commentary>
+  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  <commentary>A design call with no conventional default and no grounding in the project docs is a PRODUCT gap, not a guess. The agent emits it to PRODUCT_GAPS with the blocking reason and the brief reference — it does not invent a channel or cadence to make the issue buildable.</commentary>
   </example>
 
   <example>
   Context: /milestone-feeder:plan has read a brief ("add a sync-status badge to the home screen"). Candidate #B (render the badge) references a SyncStatusViewModel type that candidate #A (introduce the sync-status model) is the issue that introduces. #B cannot be built until #A lands.
   user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + substrate + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
   <commentary>A candidate that references a type or screen another candidate introduces is a hard dependency edge. The agent emits "#B depends_on #A" grounded in the exact artifact reference, and places #B in a later Wave than #A — the Wave order is the topological sort of the edges, not a guess.</commentary>
   </example>
 model: inherit
 color: blue
 ---
 
-You are a staff/architect-level planner who breaks down a feature brief into the smallest set of independently-buildable issues — each roughly one PR, each ready to enter the driver's triage clean. Your role is the architect lens of the feeder: turn a brief + substrate + repo into a candidate issue set, an explicit dependency graph, and a Wave order, *before* any GitHub write, so the downstream issue-author writes against a clean breakdown and the driver builds in the right order. You are stack-agnostic; the substrate and profile carry the stack.
+You are a staff/architect-level planner who breaks down a feature brief into the smallest set of independently-buildable issues — each roughly one PR, each ready to enter the driver's triage clean. Your role is the architect lens of the feeder: turn a brief + your project's standing docs + repo into a candidate issue set, an explicit dependency graph, and a Wave order, *before* any GitHub write, so the downstream issue-author writes against a clean breakdown and the driver builds in the right order. You are stack-agnostic; the project docs and profile carry the stack.
 
 ## What you receive
 
 The dispatching `plan` skill provides:
 
 - **The brief** — normalized: what to build and why, in product terms.
-- **The substrate** — the project-constitution docs under `substrateDir` (default `.project/`). This is the source of design defaults: format conventions, naming, the existing patterns to mirror. When a design call has an answer, the substrate is where it lives.
+- **Your project docs** — the standing/constitution docs under `projectDocs` (default `.project/`). This is the source of design defaults: format conventions, naming, the existing patterns to mirror. When a design call has an answer, the project docs are where it lives.
 - **The resolved shared profile keys** — the *values* (not a path) for `sourceGlobs`, `uiSurfaceGlobs`, and `integrationBranch`, resolved from the driver config.
-- **Sizing guidance** — `issueSizeGuidance` when the profile carries it; otherwise the default: ~1 PR each, independently buildable.
+- **Sizing guidance** — `issueSize` when the profile carries it; otherwise the default: ~1 PR each, independently buildable.
 
-You may read the repo source and substrate (read-only) to ground the breakdown. You never edit them.
+You may read the repo source and project docs (read-only) to ground the breakdown. You never edit them.
 
 ## What you produce
 
@@ -46,7 +46,7 @@ A candidate breakdown that satisfies this contract — every clause, not a subse
 
 **1. Smallest independent issues.** Split the brief into the smallest set of issues that are each roughly one PR and independently buildable. Prefer more small issues over fewer large ones — the breakdown-for-quality principle. Do not bundle unrelated work into one issue to reduce the count.
 
-**2. Design grounded, never invented.** Every design default cites its grounding — a substrate ref or a sibling `file:line` that supplies the answer. A call the substrate or an established repo convention answers is *resolved* and recorded. A call with **no conventional default** — an ungroundable product decision (what to build, user-facing behavior) — is a **PRODUCT gap**: parked to `PRODUCT_GAPS`, never guessed.
+**2. Design grounded, never invented.** Every design default cites its grounding — a project-docs ref or a sibling `file:line` that supplies the answer. A call your project docs or an established repo convention answers is *resolved* and recorded. A call with **no conventional default** — an ungroundable product decision (what to build, user-facing behavior) — is a **PRODUCT gap**: parked to `PRODUCT_GAPS`, never guessed.
 
 **3. Explicit dependency edges.** When a candidate references a type, file, contract, interface, or screen that another candidate introduces, emit an explicit edge grounded in the exact artifact reference: `#B depends_on #A — <reason / the reference>`. An edge you cannot ground in the artifact is not emitted.
 
@@ -66,7 +66,7 @@ CANDIDATES:
     title: <imperative one-line issue title>
     surface: ui | logic
     risk: light | heavy
-    sketch: <one or two lines: what this issue does, and the substrate ref / sibling file:line grounding its design>
+    sketch: <one or two lines: what this issue does, and the project-docs ref / sibling file:line grounding its design>
   - … (one per candidate)
 EDGES:
   - "#B depends_on #A — <reason / the exact artifact reference>"
@@ -77,7 +77,7 @@ WAVES:
   - …                       # topological sort of EDGES; Wave 1 = no unmet deps
 PRODUCT_GAPS:
   - gap: <the product decision with no conventional default>
-    why_blocked: <why it cannot be grounded in the substrate or a convention>
+    why_blocked: <why it cannot be grounded in the project docs or a convention>
     brief_ref: <the brief line / phrase that asks for it>
   - …                       # "none" when the brief is fully resolvable
 ```
@@ -86,19 +86,19 @@ PRODUCT_GAPS:
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 
-Every design default **cites its grounding**: a substrate ref, or `file:line` for a sibling pattern read in the repo. No exceptions.
+Every design default **cites its grounding**: a project-docs ref, or `file:line` for a sibling pattern read in the repo. No exceptions.
 
-- A design call you cannot ground in the substrate or an established repo convention, and for which there is **no conventional default**, is a `PRODUCT_GAP` — never invented, never silently resolved to a plausible-sounding guess.
-- Every dependency edge cites the **actual artifact reference** (the type, screen, or contract one candidate introduces and another consumes) at `file:line` or by the recorded brief/substrate line. An edge you cannot ground is not emitted.
+- A design call you cannot ground in your project docs or an established repo convention, and for which there is **no conventional default**, is a `PRODUCT_GAP` — never invented, never silently resolved to a plausible-sounding guess.
+- Every dependency edge cites the **actual artifact reference** (the type, screen, or contract one candidate introduces and another consumes) at `file:line` or by the recorded brief/project-docs line. An edge you cannot ground is not emitted.
 - A candidate is grounded or it is a gap. There is no third state where you proceed on an assumption.
-- **"Looks reasonable / probably / should be fine"** are contract violations. If you catch yourself writing one, stop: either ground the call in the substrate/convention, or park it to `PRODUCT_GAPS`.
+- **"Looks reasonable / probably / should be fine"** are contract violations. If you catch yourself writing one, stop: either ground the call in the project docs/convention, or park it to `PRODUCT_GAPS`.
 
 ## What you refuse
 
-- Writing code, configuration, or any artifact that changes the repository — you read the repo and substrate, you never edit them.
+- Writing code, configuration, or any artifact that changes the repository — you read the repo and project docs, you never edit them.
 - Opening issues, milestones, or PRs — the `plan` skill owns every GitHub write; you return a block to it.
 - Inventing PRODUCT scope — a decision with no conventional default is surfaced in `PRODUCT_GAPS`, never guessed to make an issue buildable.
-- Returning an ungrounded candidate or edge — a design default without a substrate ref or sibling `file:line` becomes a `PRODUCT_GAP`; an edge without an artifact reference is dropped, not asserted.
+- Returning an ungrounded candidate or edge — a design default without a project-docs ref or sibling `file:line` becomes a `PRODUCT_GAP`; an edge without an artifact reference is dropped, not asserted.
 
 ## Communication style
 

--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -1,17 +1,17 @@
 ---
 name: issue-author
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:plan skill once per candidate issue to author ONE issue's full specification to the §4 output contract — engineered so it passes the driver's triage clean (GAPS: none) with no human clarification. Read-only; reads the brief, the substrate, and the repo to ground the design it records, but never writes repo files, never opens the issue on GitHub, and never invents PRODUCT scope. Returns issue TEXT (a STATUS / ISSUE_TAG / TITLE / ISSUE_BODY / LABELS wrapper, or PRODUCT_GAP) to the orchestrator. Guarantees the five criteria the driver's triage checks: Consistency, Buildability, Completeness, Dependencies, and the UI-flag. Examples:
+  Dispatched by milestone-feeder's /milestone-feeder:plan skill once per candidate issue to author ONE issue's full specification to the §4 output contract — engineered so it passes the driver's triage clean (GAPS: none) with no human clarification. Read-only; reads the brief, your project docs, and the repo to ground the design it records, but never writes repo files, never opens the issue on GitHub, and never invents PRODUCT scope. Returns issue TEXT (a STATUS / ISSUE_TAG / TITLE / ISSUE_BODY / LABELS wrapper, or PRODUCT_GAP) to the orchestrator. Guarantees the five criteria the driver's triage checks: Consistency, Buildability, Completeness, Dependencies, and the UI-flag. Examples:
 
   <example>
-  Context: /milestone-feeder:plan dispatched the architect, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the substrate's export-format convention and the existing ContactsListService pattern. No edge touches #A.
+  Context: /milestone-feeder:plan dispatched the architect, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the project docs' export-format convention and the existing ContactsListService pattern. No edge touches #A.
   user: "Author issue #A to the §4 output contract."
-  assistant: "Dispatching issue-author for candidate #A to author its full §4 spec — recording the export-format convention from the substrate, enumerating happy/empty/error/disabled acceptance criteria, declaring no dependencies, classifying logic/light."
-  <commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the substrate or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the architect emitted none. STATUS: AUTHORED.</commentary>
+  assistant: "Dispatching issue-author for candidate #A to author its full §4 spec — recording the export-format convention from your project docs, enumerating happy/empty/error/disabled acceptance criteria, declaring no dependencies, classifying logic/light."
+  <commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the project docs or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the architect emitted none. STATUS: AUTHORED.</commentary>
   </example>
 
   <example>
-  Context: The architect flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and substrate point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
+  Context: The architect flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and your project docs point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
   user: "Author issue #B to the §4 output contract."
   assistant: "Dispatching issue-author for candidate #B to author its §4 spec — Design section names the existing pattern to mirror (ConfirmImportPage at file:line), the required states (empty/loading/error), the confirm affordance for the destructive delete, and accessibility labels for the interactive elements."
   <commentary>A UI issue carries exactly what the design-reviewer checks: a concrete existing pattern to mirror at file:line, the required states, the destructive-action confirm affordance, and accessibility labels — so it clears the design lens before any code is written. STATUS: AUTHORED, Surface: ui.</commentary>
@@ -27,18 +27,18 @@ model: inherit
 color: yellow
 ---
 
-You are a staff/architect-level issue author. You write ONE GitHub issue's full specification so it passes the milestone-driver triage gate clean (GAPS: none) without a human clarification. You author issue TEXT; you never touch the repository. You are stack-agnostic — the brief, the substrate, and the resolved profile keys carry the stack, the conventions, and the surfaces; you ground every recorded decision in them, you do not bring assumptions of your own.
+You are a staff/architect-level issue author. You write ONE GitHub issue's full specification so it passes the milestone-driver triage gate clean (GAPS: none) without a human clarification. You author issue TEXT; you never touch the repository. You are stack-agnostic — the brief, your project docs, and the resolved profile keys carry the stack, the conventions, and the surfaces; you ground every recorded decision in them, you do not bring assumptions of your own.
 
 ## What you receive
 
 The dispatching `plan` skill provides:
 
-- **The candidate** — from the architect: its local tag (`#A`), working title, the surface/risk hint, and the one-line sketch (what the issue does and the substrate ref / sibling `file:line` grounding its design).
+- **The candidate** — from the architect: its local tag (`#A`), working title, the surface/risk hint, and the one-line sketch (what the issue does and the project-docs ref / sibling `file:line` grounding its design).
 - **The architect's edges touching THIS candidate** — the declared dependencies to record verbatim. You transcribe these into the issue; you do not invent or augment them.
-- **The brief + substrate** — the grounding sources. The brief carries what to build and why, in product terms; the substrate (the project-constitution docs under `substrateDir`) carries the design defaults — format conventions, naming, the existing patterns to mirror.
+- **The brief + your project docs** — the grounding sources. The brief carries what to build and why, in product terms; your project docs (the standing/constitution docs under `projectDocs`) carry the design defaults — format conventions, naming, the existing patterns to mirror.
 - **The resolved shared keys** — the *values* for `sourceGlobs`, `uiSurfaceGlobs` (to classify the candidate's surface), and `integrationBranch`, resolved from the driver config.
 
-Read the implicated substrate and sibling source (read-only) to ground recorded design. You never edit them, and you never write the issue to GitHub — you return its text.
+Read the implicated project docs and sibling source (read-only) to ground recorded design. You never edit them, and you never write the issue to GitHub — you return its text.
 
 ## The contract (load-bearing — these are not optional)
 
@@ -46,7 +46,7 @@ You guarantee the five criteria the driver's triage checks, 1:1. Each clause bel
 
 1. **Consistency.** No two recorded design statements contradict each other. Two statements that cannot both be true simultaneously — e.g., "mirror ConfirmImportPage grouping" and "flat list, no collection picker" — are a contract violation. Re-read your Design section in full before returning to confirm it is internally consistent (satisfies `triage-reviewer.md:45`).
 
-2. **Buildability.** Every decision the acceptance criteria require is either *recorded* in the Design section or *resolved* by a STATED convention — a `Convention followed:` line citing the substrate or a sibling `file:line`. Nothing is left for the implementer to invent. A decision with **no conventional default** — an ungroundable product call (what to build, user-facing behavior) — is a PRODUCT gap: you return `STATUS: PRODUCT_GAP`, you do not guess (satisfies `triage-reviewer.md:47`).
+2. **Buildability.** Every decision the acceptance criteria require is either *recorded* in the Design section or *resolved* by a STATED convention — a `Convention followed:` line citing your project docs or a sibling `file:line`. Nothing is left for the implementer to invent. A decision with **no conventional default** — an ungroundable product call (what to build, user-facing behavior) — is a PRODUCT gap: you return `STATUS: PRODUCT_GAP`, you do not guess (satisfies `triage-reviewer.md:47`).
 
 3. **Completeness.** The acceptance criteria enumerate the happy path **and** the empty state **and** the error/failure path **and** the disabled/edge state — not just the happy path. A happy-path-only criteria list is a contract violation (satisfies `triage-reviewer.md:49`).
 
@@ -69,8 +69,8 @@ The `ISSUE_BODY` you author reproduces the §4 issue-body template verbatim:
 - [ ] <disabled / edge state>
 
 ## Design (recorded, consistent)
-<the decisions an implementer would otherwise have to invent — grounded in the
-substrate or a cited sibling pattern. No contradictions.>
+<the decisions an implementer would otherwise have to invent — grounded in your
+project docs or a cited sibling pattern. No contradictions.>
 - Convention followed: <conventions.md ref or file:line of the sibling pattern>
 
 ## Dependencies
@@ -90,15 +90,15 @@ TITLE: <final imperative title>
 ISSUE_BODY: |
   <the §4 body, verbatim from the template above>
 LABELS: [<ui|logic>, <risk:light|risk:heavy if confident>]
-PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with no conventional default>, why: <why it cannot be grounded in the substrate or a convention> }
+PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with no conventional default>, why: <why it cannot be grounded in the project docs or a convention> }
 ```
 
 `STATUS: AUTHORED` carries a complete `ISSUE_BODY` that clears all five criteria. `STATUS: PRODUCT_GAP` carries the `PRODUCT_GAP` object and no fabricated body — you park the gap, you never invent scope to fill it. `LABELS` omits the `risk:*` label when you are not confident of the risk level.
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 
-- Every `Convention followed:` line cites a REAL substrate ref or a `file:line` you verified to exist — grep before you cite. A `Convention followed:` line pointing at an artifact you did not confirm exists is a contract violation.
-- An acceptance-criteria bullet you cannot ground in the brief, the substrate, or a sibling pattern is a contract violation — do not assert it. If grounding it requires a product call with no conventional default, return `STATUS: PRODUCT_GAP`.
+- Every `Convention followed:` line cites a REAL project-docs ref or a `file:line` you verified to exist — grep before you cite. A `Convention followed:` line pointing at an artifact you did not confirm exists is a contract violation.
+- An acceptance-criteria bullet you cannot ground in the brief, your project docs, or a sibling pattern is a contract violation — do not assert it. If grounding it requires a product call with no conventional default, return `STATUS: PRODUCT_GAP`.
 - A happy-path-only criteria list — missing the empty, error/failure, or disabled/edge state — is a contract violation. Enumerate every state the surface must handle.
 - An edge you did not receive from the architect is not yours to add; a Wave order is not yours to change.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,39 +1,65 @@
 # Architecture
 
-A generic decompose engine ships in the plugin; each repo supplies a thin profile
-(`.milestone-config/feeder.json`) plus a substrate (the project-constitution docs
-under `substrateDir`). The engine turns a feature brief into a milestone of small,
-well-formed issues; the profile and substrate carry the stack, the conventions,
-and the design defaults the engine grounds its decomposition in.
+A generic planning engine ships in the plugin; each repo supplies a thin profile
+(`.milestone-config/feeder.json`) plus your project's standing docs (the
+constitution docs under `projectDocs`). The engine turns a feature brief into a
+milestone of small, well-formed issues; the profile and standing docs carry the
+stack, the conventions, and the design defaults the engine grounds the breakdown in.
 
 ## Plugin contents
 
-The as-built v0.2.0 components. The self-check gate, the `--apply` GitHub-write
-path, and the `refine` skill all shipped in v0.2.0 (see
-[The self-check gate](#the-self-check-gate) and [The decompose procedure](#the-decompose-procedure)).
+The as-built v0.3.0 components. `plan` previews to a plan file, `create` deploys the
+approved plan, and `update` reconciles a refreshed plan onto an existing milestone
+(see [The reviewer gate](#the-reviewer-gate) and [The plan procedure](#the-plan-procedure)).
+The plan file is the **build artifact** (see [The plan file as build artifact](#the-plan-file-as-build-artifact)).
 
 | Component | Path | Purpose |
 |---|---|---|
-| Setup skill | `skills/setup/SKILL.md` | First-run profile bootstrap: infer keys from repo signals, write `.milestone-config/feeder.json`, provision the label taxonomy aligned to the driver's. Auto-invoked by `decompose` when the profile is absent. Mirrors `milestone-driver:setup`. |
-| Decompose skill | `skills/decompose/SKILL.md` | Orchestrator: brief → milestone + issues. Runs Steps 0–6 (incl. the self-check gate) and emits at Step 7 — a reviewable plan file (preview, default) or the GitHub artifacts (`--apply`). `/milestone-feeder:decompose <brief>`. |
-| Decomposer agent | `agents/decomposer.md` | Architect lens: brief + substrate + repo → candidate issue set + dependency edges + Wave order. One heavy reasoning step, dispatched once. Read-only. |
+| Setup skill | `skills/setup/SKILL.md` | First-run profile bootstrap: infer keys from repo signals, write `.milestone-config/feeder.json`, provision the label taxonomy aligned to the driver's. Auto-invoked by `plan`/`create` when the profile is absent. Mirrors `milestone-driver:setup`. |
+| Plan skill | `skills/plan/SKILL.md` | Orchestrator preview: brief → a reviewable plan file. Runs Steps 0–6 (incl. the reviewer gate) and emits at Step 7 — the plan file at `.milestone-feeder/plan-<slug>.md`. **No GitHub writes.** `/milestone-feeder:plan <brief>`. |
+| Create skill | `skills/create/SKILL.md` | Deploys the approved plan: reads the plan file and performs the GitHub writes (labels, create-or-adopt milestone, issues, slug→`#n` rewrite, description PATCH). Runs `plan` first only if no plan file exists. `/milestone-feeder:create <brief>`. See [The create deploy / write order](#the-create-deploy--write-order). |
+| Architect agent | `agents/architect.md` | Architect lens: brief + standing docs + repo → candidate issue set + dependency edges + Wave order. One heavy reasoning step, dispatched once. Read-only. |
 | Issue-author agent | `agents/issue-author.md` | Per-issue subagent: authors one issue's full spec to the §4 output contract so it passes the driver's triage clean. Read-only; returns issue text, never opens the issue. |
 | Hook: `no-source-edit` | `hooks/` (`hooks.json`, `run-hook.cmd`, `.sh`, `.ps1`) | `PreToolUse` (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`): unconditionally deny edits to the feeder's own `sourceGlobs`. The only mechanical gate the feeder needs — it authors no code and opens no PRs. See [The mechanical gate](#the-mechanical-gate). |
 | Manifest + registration | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json` | Plugin metadata (incl. the `superpowers` dependency), marketplace registration, and Claude-side hook registration. |
-| Refine skill | `skills/refine/SKILL.md` | Idempotent re-run against an existing milestone: re-triage live issues through the self-check gate, patch gapped bodies, fill missing edges, re-render the Wave order. `/milestone-feeder:refine <milestone>`. Creates and deletes no issues; a clean milestone is a no-op. Reuses decompose's gate (Step 6) and `--apply` write-primitives (§7-apply) by reference. |
-| Self-check gate | (in `decompose`, Step 6 §6.1–§6.6; `SPEC.md` §5) | Dispatches the driver's `triage-reviewer` / `design-reviewer` against each generated issue before any emit; runs in preview too (it writes no GitHub state). Three backends — `"milestone-driver"`, `"internal"`, `false`. See [The self-check gate](#the-self-check-gate). |
-| `--apply` GitHub write path | (in `decompose`, Step 7 §7-apply) | Ensures the labels idempotently, creates-or-adopts the milestone by title, opens each gate-surviving issue, rewrites slug→`#n` references, PATCHes the Wave-encoded milestone description, and files the needs-product-input report (epic comment on apply / local file otherwise). Idempotent re-apply via adopt + match-by-title. |
+| Update skill | `skills/update/SKILL.md` | Plan-driven reconcile against an existing milestone: re-triage live issues through the reviewer gate, patch gapped bodies, fill missing edges, re-render the Wave order. `/milestone-feeder:update <brief>`. Creates and deletes no issues; a clean milestone is a no-op. Reuses the reviewer gate (Step 6) and `create`'s write-primitives by reference. |
+| Reviewer gate | (in `plan`, Step 6 §6.1–§6.6; `SPEC.md` §5) | Dispatches the driver's `triage-reviewer` / `design-reviewer` against each generated issue before any emit; it writes no GitHub state. Three backends — `"milestone-driver"`, `"internal"`, `false`. See [The reviewer gate](#the-reviewer-gate). |
+| `create` GitHub write path | (in `create`, §7-apply deploy sequence) | Ensures the labels idempotently, creates-or-adopts the milestone by title, opens each gate-surviving issue, rewrites slug→`#n` references, PATCHes the Wave-encoded milestone description, and files the needs-product-input report (epic comment for a GitHub-epic brief / local file otherwise). Idempotent re-run via adopt + match-by-title. |
 
-**Reused, not rebuilt (composability):** the self-check dispatches
+**Reused, not rebuilt (composability):** the reviewer gate dispatches
 `milestone-driver:triage-reviewer` and `:design-reviewer` directly against the
 generated issue text (no `gh` call of their own), so the feeder's quality bar *is*
 the driver's entry gate — no second, drifting definition of "well-formed"
-(`SPEC.md` §3, §5). `refine` reuses the same gate and the `--apply` write-primitives
+(`SPEC.md` §3, §5). `update` reuses the same gate and `create`'s write-primitives
 by reference rather than re-deriving a drifting copy.
+
+## The plan file as build artifact
+
+The plan file is the **build artifact** — the single source of truth `create` and
+`update` deploy (`SPEC.md`; spec §3). The mental model: **the plan file is the
+spec; GitHub is the deployment.** `plan` compiles it; `create` deploys it fresh;
+`update` re-deploys it onto an existing milestone.
+
+`plan` writes it to a gitignored scratch path, named by a **deterministic slug** of
+the milestone goal so `create`/`update` can find it from the same brief:
+
+```
+.milestone-feeder/plan-<slug>.md
+```
+
+The plan file carries, unambiguously: the exact milestone title + one-line goal;
+the wave-encoded milestone description (local slugs `#A`/`#B`); per surviving issue
+its slug, title, full §4 body, labels, and surface/risk; the parked and dropped
+issues (marked, never created); the reviewer-gate verdict line; and the source-brief
+reference. `create` reads it and deploys **exactly** it — no pipeline re-run, no
+re-vet (it trusts the recorded gate verdict). The slug→`#n` rewrite still happens at
+write time, because issue numbers do not exist until creation; what changed from
+v0.2.0 is **only** the source of the issue bodies/labels/waves — read from the plan
+file, not regenerated.
 
 ## Plugin version
 
-The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.2.0`)
+The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.3.0`)
 as the single source of truth. There is **no per-PR version machinery** — the
 feeder opens no PRs and touches no branches, so the driver's bump-rides-the-PR
 mechanism has nothing to ride. The version is bumped by hand when a release is cut.
@@ -48,7 +74,7 @@ clean (`GAPS: none`). Product gaps are parked, never invented (`SPEC.md` §2).
 
 ```
 feature brief (file / inline / GitHub epic issue)
-        │   reads substrate (.project/) + .milestone-config/driver.json (shared keys)
+        │   reads your project's standing docs (.project/) + .milestone-config/driver.json (shared keys)
         ▼
    ┌───────────────┐   milestone + issues    ┌──────────────────┐
    │ milestone-feeder │ ──────────────────────▶ │ milestone-driver │ ──▶ merged PRs
@@ -58,9 +84,10 @@ feature brief (file / inline / GitHub epic issue)
 ```
 
 The park boundary is the load-bearing constraint: the feeder makes *design and
-implementation* calls when the substrate or a stated repo convention supplies the
-answer, and parks *product* calls — what to build, or user-facing behavior with no
-conventional default — to a "needs product input" report rather than guessing them.
+implementation* calls when your project's standing docs or a stated repo convention
+supplies the answer, and parks *product* calls — what to build, or user-facing
+behavior with no conventional default — to a "needs product input" report rather
+than guessing them.
 
 ## The mechanical gate
 
@@ -75,30 +102,31 @@ code and authors issue text — it never writes source — so the deny is
 
 The `sourceGlobs` this gate reads is **self-protection only** — the feeder guarding
 its own repo — and is semantically distinct from the *consumer's* shared
-`sourceGlobs` that the feeder reads from the driver config when decomposing a target
+`sourceGlobs` that the feeder reads from the driver config when planning a target
 repo (`SPEC.md` §7; `docs/profile-schema.md`).
 
-## The decompose procedure
+## The plan procedure
 
-The `decompose` skill runs `SPEC.md` §6 Steps 0–6 (the self-check gate is Step 6)
-and emits at Step 7 — a preview plan file by default, or the GitHub artifacts on
-`--apply`. The self-check gate runs on **both** paths (it writes no GitHub state);
-only Step 7 `--apply` writes GitHub state.
+The `plan` skill runs `SPEC.md` §6 Steps 0–6 (the reviewer gate is Step 6) and
+emits the plan file at Step 7. It writes **no GitHub state** — the reviewer gate
+writes none either. `create` then deploys the emitted plan file (see
+[The create deploy / write order](#the-create-deploy--write-order)).
 
 | Step | Action |
 |---|---|
-| 0 | Read `.milestone-config/feeder.json` (absent → auto-invoke `setup`); read the substrate under `substrateDir` (best-effort); resolve the shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) from the driver config, plus `nonNegotiables` (the additional reviewer-profile input the gate passes through). |
+| 0 | Read `.milestone-config/feeder.json` (absent → auto-invoke `setup`); read your project's standing docs under `projectDocs` (best-effort); resolve the shared keys (`sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`) from the driver config, plus `nonNegotiables` (the additional reviewer-profile input the gate passes through). |
 | 1 | Ingest the brief — a GitHub epic issue (`#<n>`), a file path, or inline text — and normalize it internally first. |
-| 2 | **Product-gap check (the park boundary):** separate product decisions (no conventional default) from design/implementation decisions (resolvable from substrate/convention). Product gaps are recorded, not guessed. |
-| 3 | Dispatch the `decomposer` **once**: candidate issue set + dependency edges + Wave order, with local tags (not GitHub numbers). |
+| 2 | **Product-gap check (the park boundary):** separate product decisions (no conventional default) from design/implementation decisions (resolvable from the standing docs/convention). Product gaps are recorded, not guessed. |
+| 3 | Dispatch the architect (`architectAgent`) **once**: candidate issue set + dependency edges + Wave order, with local tags (not GitHub numbers). |
 | 4 | Dispatch the `issue-author` **per candidate** (parallelizable) → each issue's full §4 spec. |
 | 5 | Assemble the dependency graph; render the milestone description to the §4 Wave template (local slugs). |
-| 6 | **Self-check gate** (the keystone): vet every generated issue against the same gate that fronts the driver's build loop. Iterate each FAILed issue to clean (≤2 `issue-author` re-dispatches) or park it. Runs in preview too — **no GitHub writes.** See [The self-check gate](#the-self-check-gate). |
-| 7 | **Emit.** Preview (default) writes a reviewable plan file to `.milestone-feeder/plan-<slug>.md`, plus a "needs product input" report when product gaps remain — **no GitHub writes**. `--apply` runs the preview emit first (the local audit record), then creates the GitHub artifacts. |
+| 6 | **Reviewer gate** (the keystone): vet every generated issue against the same gate that fronts the driver's build loop. Iterate each FAILed issue to clean (≤2 `issue-author` re-dispatches) or park it. **No GitHub writes.** See [The reviewer gate](#the-reviewer-gate). |
+| 7 | **Emit the plan file.** Write the reviewable plan file to `.milestone-feeder/plan-<slug>.md` — the build artifact `create`/`update` deploy — plus a "needs product input" report when product gaps remain. **No GitHub writes.** |
 
-### The Step 7 `--apply` write order
+### The create deploy / write order
 
-On `--apply`, the skill itself (never a dispatched agent — the agent-read-only
+`create` reads the plan file (running `plan` first only when no plan file exists)
+and deploys it. The skill itself (never a dispatched agent — the agent-read-only
 invariant holds) performs the GitHub writes in a fixed order. Only the
 **gate-surviving** issues are created; parked and dropped issues are never created.
 
@@ -108,28 +136,28 @@ invariant holds) performs the GitHub writes in a fixed order. Only the
 | b | **Create-or-adopt the milestone by exact title** (quote-safe `env.t` resolve): no match → create; one match → adopt (reopen if closed); multiple → adopt the first and log. Never deletes. |
 | c | **Create each gate-surviving issue** in Wave order, applying its `ui`/`logic` + `risk:*` labels; build the slug→`#n` map. On adopt, title-matched open issues are reused (no duplicate) and their bodies left as-is. |
 | d | **Second pass — rewrite slug→`#n`** (substring-safe) in each newly-created issue body and in the milestone description, then `gh issue edit`/`gh api PATCH`. Two passes are required because numbers don't exist until pass (c). |
-| e | **File the needs-product-input report** — epic comment on `--apply` when the brief was a GitHub epic, else a local file. |
+| e | **File the needs-product-input report** — epic comment when the brief was a GitHub epic, else a local file. |
 
-Idempotent re-apply relies on stable, exact, open issue titles: the adopt +
+Idempotent re-run relies on stable, exact, open issue titles: the adopt +
 match-by-title path reuses existing issues rather than duplicating them, and pass
 (d) is a no-op against already-numeric bodies/descriptions.
 
-## The self-check gate
+## The reviewer gate
 
-Before emitting, `decompose` vets **every generated issue** with the same gate
+Before emitting, `plan` vets **every generated issue** with the same gate
 that fronts the driver's build loop, so what the feeder emits passes the driver's
 triage clean (`SPEC.md` §5; Step 6 §6.1–§6.6). Each reviewer is dispatched
-**read-only against the generated text** — no `gh` call of its own. `refine` runs
+**read-only against the generated text** — no `gh` call of its own. `update` runs
 the same gate against a milestone's **live** issues (real comments, the live
 description, real `#n`).
 
-### Backends (`selfCheck`)
+### Backends (`reviewer`)
 
-| `selfCheck` | Backend |
+| `reviewer` | Backend |
 |---|---|
 | `"milestone-driver"` (default) | Dispatch `milestone-driver:triage-reviewer` per generated issue (and `:design-reviewer` when its triage returns `NEEDS_DESIGN_REVIEW: yes`). If the reviewers do not resolve at dispatch time, **degrade to `"internal"`** for the run (a notice, never a failure); a later single-issue non-resolution falls back to the internal checklist for that one issue. |
 | `"internal"` | Run the built-in checklist mirroring the five triage criteria (consistency, buildability, completeness, dependencies, UI flag). Same pass/Blocker verdict shape, so the gate logic is backend-agnostic. |
-| `false` | **Skip the gate** with a visible 🔴 warning to the user, recorded as `SKIPPED (selfCheck:false)` in the plan-file status line. Generated issues are NOT vetted. |
+| `false` | **Skip the gate** with a visible 🔴 warning to the user, recorded as `SKIPPED (reviewer:false)` in the plan-file status line. Generated issues are NOT vetted. |
 
 ### Result → action (`SPEC.md` §5)
 
@@ -150,15 +178,16 @@ milestone.
 
 | Mode | Trigger | Behavior |
 |---|---|---|
-| Decompose (preview) | `/milestone-feeder:decompose <brief>` | Full procedure, Steps 0–6 (incl. the self-check gate); stops at a reviewable plan file. **No GitHub writes.** Shipped (v0.2.0). |
-| Decompose (apply) | `… --apply` | Same, then creates the milestone + issues + labels (and an epic comment for a GitHub-epic brief). Shipped (v0.2.0). |
-| Refine | `/milestone-feeder:refine <milestone>` | Re-triage an **existing** milestone's live issues through the self-check gate, patch gapped bodies, fill missing edges, re-render the Wave order. Preview (default) writes a diff-style patch plan; `--apply` edits the live issues. Creates and deletes no issues; a clean milestone is a true no-op (writes nothing). Shipped (v0.2.0). |
+| Plan | `/milestone-feeder:plan <brief>` | Full procedure, Steps 0–6 (incl. the reviewer gate); stops at the plan file. **No GitHub writes.** |
+| Create | `/milestone-feeder:create <brief>` | Deploys the approved plan: ensures the labels, creates the milestone + issues (and an epic comment for a GitHub-epic brief). Runs `plan` first only when no plan file exists. |
+| Update | `/milestone-feeder:update <brief>` | Reconcile a refreshed plan onto an **existing** milestone (matched by exact title) through the reviewer gate — patch gapped bodies, fill missing edges, re-render the Wave order, showing the diff before it writes. **Never closes/deletes**; a live issue absent from the plan is flagged for your decision; a clean milestone is a true no-op (writes nothing). |
 
 **Authoring-autonomy boundary.** The feeder makes design/implementation calls
-grounded in the substrate or a stated repo convention — and cites the grounding
-(`.project/<doc>.md#<section>` or a sibling `file:line`). It parks product calls —
-decisions with no conventional default — to the "needs product input" report. It
-authors no code, opens no PRs, and never touches branches (`SPEC.md` §8).
+grounded in your project's standing docs or a stated repo convention — and cites
+the grounding (`.project/<doc>.md#<section>` or a sibling `file:line`). It parks
+product calls — decisions with no conventional default — to the "needs product
+input" report. It authors no code, opens no PRs, and never touches branches
+(`SPEC.md` §8).
 
 ## Output style
 

--- a/docs/consumer-setup.md
+++ b/docs/consumer-setup.md
@@ -1,9 +1,10 @@
 # milestone-feeder — consumer setup
 
 Adopt milestone-feeder in a repository in four steps. Most of this is one-time
-wiring; after that, `/milestone-feeder:decompose <brief>` previews a milestone
-plan, `… --apply` creates it on GitHub, and `/milestone-feeder:refine <milestone>`
-re-vets and patches one that already exists.
+wiring; after that, `/milestone-feeder:plan <brief>` previews a milestone
+plan, `/milestone-feeder:create <brief>` builds it on GitHub, and
+`/milestone-feeder:update <brief>` reconciles a refreshed plan onto an existing
+milestone.
 
 ## 1. Install the plugin
 
@@ -12,16 +13,16 @@ or from a marketplace once published). Confirm it is enabled with `/plugin`.
 
 | Plugin | Status | Why |
 |---|---|---|
-| [`superpowers`](https://github.com/anthropics/claude-code) | **Required** | A hard dependency, declared in `.claude-plugin/plugin.json`. The decompose pipeline depends on it. |
-| `milestone-driver` | **Optional** | The backend for the `selfCheck: "milestone-driver"` self-check mode — the feeder dispatches the driver's own `triage-reviewer` / `design-reviewer` as its pre-emit self-check gate. **Absent → degrades to `"internal"`**, and the pipeline still runs. |
+| [`superpowers`](https://github.com/anthropics/claude-code) | **Required** | A hard dependency, declared in `.claude-plugin/plugin.json`. The plan pipeline depends on it. |
+| `milestone-driver` | **Optional** | The backend for the `reviewer: "milestone-driver"` mode — the feeder dispatches the driver's own `triage-reviewer` / `design-reviewer` as its pre-emit reviewer gate. **Absent → degrades to `"internal"`**, and the pipeline still runs. |
 
 **The `milestone-driver` soft dependency.** `milestone-driver` is the **optional
-backend** for the `"milestone-driver"` self-check mode. When it is installed, the
-self-check gate backs each generated (or, in `refine`, each live) issue with the
+backend** for the `"milestone-driver"` reviewer mode. When it is installed, the
+reviewer gate backs each generated (or, in `update`, each live) issue with the
 driver's real reviewers, so the feeder's quality bar *is* the driver's entry gate.
-When it is **absent**, `selfCheck` degrades to `"internal"` at runtime — the
+When it is **absent**, `reviewer` degrades to `"internal"` at runtime — the
 feeder's own checklist mirroring the five triage criteria — and the pipeline still
-runs. (Setting `selfCheck: false` skips the gate entirely, with a visible 🔴
+runs. (Setting `reviewer: false` skips the gate entirely, with a visible 🔴
 warning that the issues were not vetted.) The feeder also reads the driver's
 profile (`.milestone-config/driver.json`) for shared keys (`sourceGlobs`,
 `uiSurfaceGlobs`, `integrationBranch`) and `nonNegotiables` (the version/platform
@@ -30,13 +31,13 @@ defaults when no driver profile is present, so a driver-less repo still works.
 
 ## 2. Add the project profile
 
-The first time you run `/milestone-feeder:decompose`, the plugin **auto-invokes
-`/milestone-feeder:setup`** if `.milestone-config/feeder.json` is absent. The
-bootstrap infers every key it can from repo signals (the substrate directory, the
-resolvable driver profile, whether the driver's reviewers resolve) and presents
-detected defaults — you accept, edit, or skip. It writes the profile to
-`.milestone-config/feeder.json`, provisions the label taxonomy, and returns control
-so the original decompose continues immediately.
+The first time you run `/milestone-feeder:plan` (or `create`), the plugin
+**auto-invokes `/milestone-feeder:setup`** if `.milestone-config/feeder.json` is
+absent. The bootstrap infers every key it can from repo signals (the standing-docs
+directory (`projectDocs`), the resolvable driver profile, whether the driver's
+reviewers resolve) and presents detected defaults — you accept, edit, or skip. It
+writes the profile to `.milestone-config/feeder.json`, provisions the label
+taxonomy, and returns control so the original plan continues immediately.
 
 Unlike the driver, the feeder has **no required hard-stop key** — it writes no
 branches and runs fully on bundled defaults, so an empty `{}` profile is valid (all
@@ -54,8 +55,8 @@ and CI has the same `no-source-edit` behavior. Minimal example:
 
 ```json
 {
-  "substrateDir": ".project/",
-  "selfCheck": "milestone-driver"
+  "projectDocs": ".project/",
+  "reviewer": "milestone-driver"
 }
 ```
 
@@ -66,69 +67,73 @@ registered in `hooks/hooks.json`. It **loads at session start**, so restart Clau
 Code after installing or updating the plugin for the hook to take effect. No
 separate native-hook installation step is required.
 
-## 4. Provide the substrate
+## 4. Provide your project docs
 
-The decompose pipeline grounds its issue authoring in the **substrate** — the
-project-constitution docs (vision, architecture, conventions) under the
-`substrateDir` (default `.project/`). The decomposer and issue-author read these
-to resolve design defaults: format conventions, naming, the existing patterns to
-mirror.
+The plan pipeline grounds its issue authoring in your project's **standing docs** —
+the constitution docs (vision, architecture, conventions) under `projectDocs`
+(default `.project/`). The architect and issue-author read these to resolve design
+defaults: format conventions, naming, the existing patterns to mirror.
 
-The substrate is read **best-effort**: a missing directory is not an error, and a
-section that is absent or marked `[TBD]` is skipped, never grounded on. A **thin**
-substrate means more decisions have no conventional default — so more candidates
+The standing docs are read **best-effort**: a missing directory is not an error,
+and a section that is absent or marked `[TBD]` is skipped, never grounded on. Thin
+project docs mean more decisions have no conventional default — so more candidates
 get parked as product gaps rather than authored. Richer constitution docs → fewer
 parks, more issues authored clean.
 
-## What a decompose run does
+## What a plan run does
 
-`/milestone-feeder:decompose <brief>` runs the full pipeline. As a consumer, the
+`/milestone-feeder:plan <brief>` runs the full pipeline. As a consumer, the
 shape that matters:
 
 | Stage | What happens |
 |---|---|
-| Read config + substrate | Loads `feeder.json` (auto-invokes `setup` if absent), reads the substrate best-effort, resolves shared keys (and `nonNegotiables`) from the driver config. |
-| Decompose | Dispatches the `decomposer` once → candidate issues + dependency edges + Wave order. |
+| Read config + project docs | Loads `feeder.json` (auto-invokes `setup` if absent), reads the standing docs best-effort, resolves shared keys (and `nonNegotiables`) from the driver config. |
+| Plan | Dispatches the architect once → candidate issues + dependency edges + Wave order. |
 | Author | Dispatches the `issue-author` per candidate → each issue's full §4 spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared edges, UI/logic + risk). |
-| Self-check gate | Vets every generated issue against the same gate that fronts the driver's build loop (the driver's reviewers when `selfCheck: "milestone-driver"`, else the internal checklist). FAILed issues are re-authored (≤2 retries) or parked. Runs on every path — **no GitHub writes.** |
-| Emit | **Preview (default):** writes a plan file to `.milestone-feeder/plan-<slug>.md` — the milestone description (Wave order) plus every gate-surviving issue body — and a "needs product input" report when product gaps remain. **No GitHub writes.** **`--apply`:** writes the plan file as the local record, then creates the GitHub artifacts. |
+| Reviewer gate | Vets every generated issue against the same gate that fronts the driver's build loop (the driver's reviewers when `reviewer: "milestone-driver"`, else the internal checklist). FAILed issues are re-authored (≤2 retries) or parked. Runs on every path — **no GitHub writes.** |
+| Emit | Writes a plan file to `.milestone-feeder/plan-<slug>.md` — the milestone description (Wave order) plus every gate-surviving issue body — and a "needs product input" report when product gaps remain. **No GitHub writes** — the GitHub artifacts are built later by `create`. |
 
 **The park boundary.** A decision with no conventional default — what to build, or
-user-facing behavior the substrate and conventions do not answer — is **parked** to
-the "needs product input" report, never guessed. Decide each, record it, and re-run.
+user-facing behavior the standing docs and conventions do not answer — is **parked**
+to the "needs product input" report, never guessed. Decide each, record it, and
+re-run.
 
-## The preview-then-apply flow
+## The plan-then-create flow
 
 Issue creation is consequential and the feeder is exactly the stage where human
-product input matters most, so the flow is **preview, review, then apply** — never
+product input matters most, so the flow is **plan, review, then create** — never
 fully autonomous creation. End to end:
 
 | Step | Command | What happens |
 |---|---|---|
-| 1. Preview | `/milestone-feeder:decompose <brief>` | Runs the full pipeline including the self-check gate and stops at a **plan file** (`.milestone-feeder/plan-<slug>.md`). **No GitHub state is written** — no milestone, no issue, no label, no comment. |
-| 2. Review | *(read the plan file)* | Read the milestone description (Wave order), every gate-surviving issue body, and the "needs product input" report. Resolve any parked product gaps and re-run the preview until the plan is right. |
-| 3. Apply | `/milestone-feeder:decompose <brief> --apply` | Re-runs the pipeline, then creates the GitHub artifacts: ensures the four labels, **creates-or-adopts the milestone by title** (reopening it if closed, never deleting), opens each gate-surviving issue, rewrites the slug references to real issue numbers in the issue bodies and the milestone description, and files the needs-product-input report (a comment on the epic for a GitHub-epic brief, else a local file). |
+| 1. Plan | `/milestone-feeder:plan <brief>` | Runs the full pipeline including the reviewer gate and stops at a **plan file** (`.milestone-feeder/plan-<slug>.md`). **No GitHub state is written** — no milestone, no issue, no label, no comment. |
+| 2. Review | *(read the plan file)* | Read the milestone description (Wave order), every gate-surviving issue body, and the "needs product input" report. Resolve any parked product gaps and re-run the plan until it is right. |
+| 3. Create | `/milestone-feeder:create <brief>` | Deploys **exactly the plan you approved** — reads the plan file (running `plan` first only if none exists yet), then creates the GitHub artifacts: ensures the four labels, **creates-or-adopts the milestone by title** (reopening it if closed, never deleting), opens each gate-surviving issue, rewrites the slug references to real issue numbers in the issue bodies and the milestone description, and files the needs-product-input report (a comment on the epic for a GitHub-epic brief, else a local file). |
 
-`--apply` is **idempotent on re-run**: it adopts the existing milestone and matches
-issues by exact title, so re-applying reuses what exists rather than duplicating it.
-The plan file is per-run scratch you review and discard (it is written under
-`.milestone-feeder/`, which the repo gitignores).
+`create` is **idempotent on re-run**: it adopts the existing milestone and matches
+issues by exact title, so re-running reuses what exists rather than duplicating it.
+The plan file lives under `.milestone-feeder/` (which the repo gitignores) and is
+the build artifact `create` deploys — review it before you run `create`.
 
-## Refining an existing milestone
+## Updating an existing milestone
 
-`/milestone-feeder:refine <milestone>` re-vets and repairs a milestone that
-**already exists** — the maintenance counterpart of `decompose`. Where `decompose`
-*creates* a milestone, `refine` *re-vets and patches* one, **creating and deleting
-no issues**:
+`/milestone-feeder:update <brief>` reconciles a **refreshed plan** onto a milestone
+that **already exists** — the maintenance counterpart of `create`. Where `create`
+*builds* a milestone, `update` *reconciles* the plan against the live one,
+**creating and deleting no issues**. The flow: edit your brief, re-run `plan` to
+refresh the plan file, then `update` reconciles it against the live milestone —
+showing the diff before it writes:
 
 | Step | Command | What happens |
 |---|---|---|
-| 1. Preview | `/milestone-feeder:refine <milestone>` | Loads the milestone's live issues (bodies + their real GitHub comments), re-triages each through the self-check gate, and writes a **diff-style patch plan** (`.milestone-feeder/refine-plan-<slug>.md`) showing the proposed body patches, added labels, and added dependency edges. **No GitHub writes.** |
-| 2. Apply | `/milestone-feeder:refine <milestone> --apply` | Edits the gapped live issue bodies, adds the implied labels, fills missing edges, and re-renders the milestone description's Wave order. An issue already at `GAPS: none` is left **byte-unchanged**; a **fully-clean milestone is a true no-op** — refine writes nothing and says so. |
+| 1. Refresh the plan | `/milestone-feeder:plan <brief>` | Re-runs the pipeline on your edited brief and refreshes the plan file. Because the plan going in is always gate-clean, reconciling it inherently repairs any issue that drifted from spec. **No GitHub writes.** |
+| 2. Update | `/milestone-feeder:update <brief>` | Resolves the existing milestone by title, then reconciles the refreshed plan against its live issues (matched by exact title): creates an issue in the plan but not on GitHub, patches a live body whose plan differs (**showing the diff first**), adds new dependency edges and re-renders the Wave order. A live issue **not** in the refreshed plan is **flagged for your decision** — never auto-closed. Nothing differs → a **true no-op**. |
 
-Refine is **idempotent**: re-running it on a milestone it just patched is a no-op.
-If the named milestone does not exist, refine **stops** (it never creates one — run
-`decompose` first).
+`update` **never closes and never deletes** — a live issue absent from your
+refreshed plan is flagged in the report, not auto-closed (closing is your call). It
+is **idempotent**: re-running it on an already-synced milestone writes nothing. If
+the named milestone does not exist, `update` **stops** (it never creates one — run
+`/milestone-feeder:create` first).
 
 ---
 

--- a/docs/profile-schema.md
+++ b/docs/profile-schema.md
@@ -40,36 +40,37 @@ optional in the file (each has a bundled default).
 
 | Key | Type | Default | Purpose |
 |---|---|---|---|
-| `substrateDir` | string | `.project/` | Where the project-constitution docs live. |
-| `selfCheck` | `"milestone-driver" \| "internal" \| false` | `"milestone-driver"` | Which reviewer backs the self-check gate. |
-| `decomposerAgent` | string | `milestone-feeder:decomposer` | Override the breakdown agent (default-filled). |
+| `projectDocs` | string | `.project/` | Where your project's standing docs live. |
+| `reviewer` | `"milestone-driver" \| "internal" \| false` | `"milestone-driver"` | Which reviewer checks each issue before it's created; `false` = off. |
+| `architectAgent` | string | `milestone-feeder:architect` | Override the breakdown agent (default-filled). |
 | `issueAuthorAgent` | string | `milestone-feeder:issue-author` | Override the authoring agent (default-filled). |
-| `issueSizeGuidance` | string | *(none)* | Optional natural-language sizing rule (e.g. "≤1 PR, ≤1 new screen"). |
+| `issueSize` | string | *(none)* | Optional natural-language sizing rule (e.g. "≤1 PR, ≤1 new screen"). |
 | `sourceGlobs` | string[] | `["skills/**","agents/**","hooks/**"]` | **Self-protection only** — the paths the feeder's own `no-source-edit` hook guards in the feeder's *own* repo. Distinct from the consumer's shared `sourceGlobs`. Resolution chain below. |
 
 ### Per-key notes
 
-**`substrateDir`.** Points the decompose procedure at the project-constitution
-docs (vision, architecture, conventions) it grounds issue authoring in. Default
+**`projectDocs`.** Points the plan procedure at your project's standing docs
+(vision, architecture, conventions) it grounds issue authoring in. Default
 `.project/`.
 
-**`selfCheck`.** Selects the reviewer backing the self-check gate — the keystone
-that prevents the feeder from authoring issues it cannot itself substantiate.
-`"milestone-driver"` (default) backs the gate with the driver's review agents;
-`"internal"` uses the feeder's own reviewer; `false` disables the gate.
+**`reviewer`.** Selects the reviewer that checks each issue before it's created —
+the keystone that prevents the feeder from authoring issues it cannot itself
+substantiate. `"milestone-driver"` (default) backs the review with the driver's
+review agents; `"internal"` uses the feeder's own reviewer; `false` turns the
+review off.
 
-**`decomposerAgent` / `issueAuthorAgent`.** Default-filled agent identifiers
-(`milestone-feeder:decomposer`, `milestone-feeder:issue-author`). Auto-filled;
+**`architectAgent` / `issueAuthorAgent`.** Default-filled agent identifiers
+(`milestone-feeder:architect`, `milestone-feeder:issue-author`). Auto-filled;
 rarely overridden. Omit them from the profile unless pointing at a custom agent.
 
-**`issueSizeGuidance`.** Optional free-text sizing rule the author honours when
+**`issueSize`.** Optional free-text sizing rule the author honours when
 splitting work into issues. Absent → no sizing constraint beyond the procedure's
 defaults.
 
 **`sourceGlobs` (self-protection).** The paths the feeder's `no-source-edit` hook
 guards in the feeder's **own** repo. This is **semantically distinct** from the
 consumer's shared `sourceGlobs` (which the feeder reads from the driver config
-when decomposing a target repo). Its presence in `feeder.json` is justified by
+when planning a target repo). Its presence in `feeder.json` is justified by
 the dogfood consumer — the feeder protecting its own source — under the
 "new keys only when a real consumer needs them" rule. See its resolution chain in
 [Shared keys](#shared-keys-resolved-from-the-driver-profile).
@@ -99,7 +100,7 @@ declares its source paths only in `driver.json` is still guarded.
 
 The consumer-facing shared keys — `uiSurfaceGlobs`, `integrationBranch`, and the
 **consumer's** `sourceGlobs` — are **read from the driver config, not duplicated**
-into `feeder.json`. The feeder reads these from the driver config when decomposing
+into `feeder.json`. The feeder reads these from the driver config when planning
 a target repo. They resolve in this order:
 
 1. **`.milestone-config/driver.json`** (primary).
@@ -112,8 +113,8 @@ wins. The consumer's shared `sourceGlobs` here is the path set the feeder uses
 when authoring issues for a target repo — distinct from the self-protection
 `sourceGlobs` of resolution chain 1.
 
-**`nonNegotiables` — the self-check gate's additional reviewer input.** Beyond the
-three shared keys above, the self-check gate (decompose Step 6) also reads
+**`nonNegotiables` — the reviewer gate's additional reviewer input.** Beyond the
+three shared keys above, the reviewer gate (plan Step 6) also reads
 `nonNegotiables` from the driver profile, resolved down the **same chain**
 (`.milestone-config/driver.json` → root `milestone-driver.json` → absent →
 **omitted**, never invented). It is **not** a fourth shared key — it is the
@@ -146,8 +147,8 @@ The two most commonly-set own-keys, with everything else defaulted:
 
 ```json
 {
-  "substrateDir": ".project/",
-  "selfCheck": "milestone-driver"
+  "projectDocs": ".project/",
+  "reviewer": "milestone-driver"
 }
 ```
 
@@ -157,12 +158,12 @@ Adds an optional sizing rule and the self-protection `sourceGlobs`:
 
 ```json
 {
-  "substrateDir": ".project/",
-  "selfCheck": "milestone-driver",
-  "issueSizeGuidance": "≤1 PR, ≤1 new screen",
+  "projectDocs": ".project/",
+  "reviewer": "milestone-driver",
+  "issueSize": "≤1 PR, ≤1 new screen",
   "sourceGlobs": ["skills/**", "agents/**", "hooks/**"]
 }
 ```
 
-The default-filled agent keys (`decomposerAgent`, `issueAuthorAgent`) are omitted
+The default-filled agent keys (`architectAgent`, `issueAuthorAgent`) are omitted
 in both examples; their bundled defaults apply automatically.


### PR DESCRIPTION
Closes #35.

Re-vocabs the remaining reference surface (three consumer docs + two agent bodies) from the v0.2.0 vocabulary to the v0.3.0 surface, per the locked design spec `docs/specs/v0.3.0-humanize-the-surface.md` (§2/§3/§4/§5/§6/§7/§9/§12). Prose / config-key-name edits only — no logic, no contract, no behavior change.

## What changed
- **`docs/architecture.md`** — as-built v0.3.0 design: the `plan`/`create`/`update` flow, a new "The plan file as build artifact" section, the architect agent, the reviewer gate (backends `reviewer`), the plan procedure (Steps 0–7), the create deploy/write order, the Modes table. Version line `0.2.0`→`0.3.0`.
- **`docs/consumer-setup.md`** — the three verbs in the intro/install/flow sections, `reviewer` key, "Provide your project docs", "What a plan run does", "The plan-then-create flow", "Updating an existing milestone" (reconcile / never-close / show-diff per §5); both JSON examples re-keyed.
- **`docs/profile-schema.md`** — own-keys table → `projectDocs`/`reviewer`/`issueSize`/`architectAgent`; `issueAuthorAgent` + self-protection `sourceGlobs` retained; file stays `feeder.json`. Per-key notes + both JSON examples re-keyed.
- **`agents/architect.md`**, **`agents/issue-author.md`** — config-key references renamed (`substrateDir`→`projectDocs`, `issueSizeGuidance`→`issueSize`) and the surrounding "substrate" prose aligned to "your project's standing docs". **No change to either agent's contract, structured return block, or behavior** (architect `CANDIDATES/EDGES/WAVES/PRODUCT_GAPS`; issue-author `STATUS/ISSUE_TAG/TITLE/ISSUE_BODY/LABELS` — both intact). Key-name re-vocab only.

## Verification (no automated test layer — verified by greps + inspection)
- `grep -ri 'decompos\|refine\|--apply\|substrateDir\|selfCheck' docs/` (excluding `docs/specs/`) → **empty** ✅
- `grep -ri 'substrateDir\|selfCheck\|issueSizeGuidance\|decomposerAgent' agents/` → **empty** ✅
- Both agent return blocks / wrappers + contract clauses (architect 1–6, issue-author 1–5) structurally intact.
- All internal anchor links in `docs/architecture.md` resolve; cross-file links resolve.

## Decision Log
| Decision | Rationale | Spec citation | Alternatives rejected |
|---|---|---|---|
| Kept the `§7-apply` section-label citation in `architecture.md` | `§7-apply` is the locked spec's own canonical name for the GitHub write sequence (carried verbatim from v0.2.0 as the migration record) — a section reference, not an `--apply` flag remnant | §4 | Renaming it → the citation would no longer faithfully point at the spec section |
| Aligned the two return-block field *descriptions* ("…grounded in your project docs…") rather than leaving "substrate" | The issue permits "substrate" to remain in the return-block carve-out but doesn't require it; aligning reads naturally and yields a fully consistent reader surface. Field **names** (`sketch`, `why_blocked`, `PRODUCT_GAP`) untouched | issue §4/§5 carve-out + §12 | Leaving "substrate" — costs a residual-vocab inconsistency for no benefit |
| Added "## The plan file as build artifact" as a described concept | AC explicitly requires the plan-file build artifact be described | §3 | Omitting it — fails the AC |
| Re-framed "Updating an existing milestone" to reconcile-refreshed-plan / show-the-diff-then-write / never-close-or-delete / idempotent / error-and-stop-run-create-first | The §5 `update` semantics, not refine's preview/`--apply` two-step | §5 | Carrying refine's two-step framing — factually wrong for v0.3.0 |
| Reframed `create` as read-the-plan/faithful deploy (runs `plan` first only if absent), dropping the `--apply` re-run-the-pipeline framing | Spec §4 `create` is faithful (no pipeline re-run, no re-vet) | §4 | The `--apply` re-run framing — contradicts §4 |

Version-bump annotation: **version-bump only — no logic change.** `.claude-plugin/plugin.json` was already at the milestone target `0.3.0`, so the bump is an idempotent no-op (no edit).

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope finding(s) at medium effort
  - none
- No park-triggering findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)