### PR TITLE
Final verification: close the §11 vocabulary-purge gate (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ desktop.ini
 # milestone-driver parallel-mode worktree fleet scratch dir (per-clone)
 .milestone-driver-worktrees/
 
-# milestone-feeder decompose preview plan-scratch (per-run, e.g.
+# milestone-feeder plan preview plan-scratch (per-run, e.g.
 # .milestone-feeder/plan-<slug>.md) — reviewed and discarded, never committed.
 # NOTE: does not match .milestone-config/ (the committed feeder/driver profiles).
 # Un-anchored so it matches at any depth (e.g. under tests/scenarios/<n>/).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -27,20 +27,7 @@ Before asking anything, gather signals from the repo. Run these checks silently 
 | Project docs directory | `.project/` present at repo root? | `projectDocs` default `.project/`; if the standing docs live elsewhere, that path is the suggested value |
 | Resolvable driver profile | `.milestone-config/driver.json` present, else legacy root `milestone-driver.json` present? | Confirms the shared keys the feeder reads (`uiSurfaceGlobs`, `integrationBranch`, the consumer's `sourceGlobs`) are available from the driver config (`SPEC.md` §7) — informational, not written into `feeder.json` |
 | Reviewer availability | Does `milestone-driver:triage-reviewer` resolve in this session? | `reviewer` default `"milestone-driver"` when it resolves, else `"internal"` (degrade to the feeder's own checklist mirroring the five triage criteria, `SPEC.md` §5) |
-| Existing profile | Read `.milestone-config/feeder.json` if present | Pre-fill any already-set keys (re-run handling below). If the file carries old key names, offer the courtesy migration below before pre-filling |
-
-#### Courtesy migration — old key names → new (a notice, not a contract)
-
-Earlier feeder profiles used four older key names. The skills now read **only** the new names — there is **no silent old-key fallback** in any skill body: an old key is either migrated here (with the notice below) or ignored, never honoured in place. When Phase 1 reads an existing `.milestone-config/feeder.json` that still carries any of these old keys, present this old→new mapping and offer to rewrite them to the new names in place. This is a courtesy, not a contract.
-
-| Old key (in file) | New key (written) | Value handling |
-|---|---|---|
-| `substrateDir` | `projectDocs` | value carried over unchanged |
-| `selfCheck` | `reviewer` | value carried over unchanged (`"milestone-driver"` \| `"internal"` \| `false`) |
-| `issueSizeGuidance` | `issueSize` | value carried over unchanged |
-| `decomposerAgent` | `architectAgent` | value carried over; if it is the old bundled default `"milestone-feeder:decomposer"`, update it to `"milestone-feeder:architect"` |
-
-`issueAuthorAgent` and `sourceGlobs` are unchanged — leave them exactly as they are. Present the mapping as a simple accept/decline: on accept, rewrite the file with the new key names (preserving values per the table) and continue Phase 2 with the migrated values pre-filled; on decline, leave the file as-is and continue with the new-key defaults (the old keys are ignored, never silently honoured). No 🔴 — this is a plain accept-or-decline choice, not a blocking decision.
+| Existing profile | Read `.milestone-config/feeder.json` if present | Pre-fill any already-set keys (re-run handling below) |
 
 ### Phase 2 — Tier-by-tier confirmation
 
@@ -135,7 +122,7 @@ Return control to the caller (`plan`) immediately. Do **not** ask the user to re
 
 ## Re-run behavior (idempotency)
 
-- **Existing profile.** If `.milestone-config/feeder.json` already exists, Phase 1 pre-fills from it and Phase 2 re-confirms every key with the existing value shown as the default (accept, edit, or re-configure) — mirroring the driver setup's existing-profile handling. The full flow still runs, but with current values pre-filled. If the file carries old key names, Phase 1 first offers the courtesy migration (old→new mapping with a notice) before pre-filling; the skills read only the new keys, so any old key the user declines to migrate is ignored, never silently honoured.
+- **Existing profile.** If `.milestone-config/feeder.json` already exists, Phase 1 pre-fills from it and Phase 2 re-confirms every key with the existing value shown as the default (accept, edit, or re-configure) — mirroring the driver setup's existing-profile handling. The full flow still runs, but with current values pre-filled.
 - **Labels.** Provisioning is idempotent via `--force`: re-running when a label already exists upserts its color/description and creates no duplicates.
 
 ## Output style


### PR DESCRIPTION
Closes #37. The milestone's §11 close-out gate: prove `decompose` (and the other retired vocab) appears nowhere on the live surface, and that the new `plan`/`create`/`update` surface round-trips.

## What changed

Two surgical cleanups — the last two grep hit-sites — to make the v0.3.0 vocabulary purge byte-clean:

- **`.gitignore`** — the plan-scratch comment said "milestone-feeder **decompose** preview plan-scratch"; renamed the leftover verb to "plan".
- **`skills/setup/SKILL.md`** — removed the `#### Courtesy migration` subsection. It was the only thing in the file naming the old config keys (`substrateDir`, `selfCheck`, `issueSizeGuidance`, `decomposerAgent`). Per design spec §6 the migration is "a courtesy, not a contract," and it is redundant with the locked hard-break decision (an external user still on old keys simply re-runs `setup`, which reads only the new keys). Also trimmed two trailing cross-references to it (the Phase 1 "Existing profile" cell and the Re-run-behavior bullet). Setup otherwise unchanged — it already uses the new keys (`projectDocs`/`reviewer`/`issueSize`/`architectAgent`).

Net: 3 insertions, 16 deletions across 2 files. No code logic, no `plugin.json` bump (already `0.3.0`).

## Verification — the §11 acceptance gate

| Gate | Result |
|---|---|
| `grep -rIi 'decompose\|substrateDir\|selfCheck\|--apply'` (excl. `.git`, `docs/specs`, `CHANGELOG.md`, triage cache) | **empty** — exit 1, byte-clean |
| Harness re-run green (`tests/RESULTS.md`) | **4/4 green** on the v0.3.0 re-run (run-now 01/02/03/06), real `milestone-driver:triage-reviewer`/`design-reviewer` — read, not re-run (re-run landed in #36) |
| Plugin loads + commands resolve | `skills/{plan,create,update,setup}/SKILL.md` present, each `name:` matches; no `skills/decompose/` or `skills/refine/`; `agents/architect.md` + `agents/issue-author.md` present, no `decomposer.md`; `.claude-plugin/plugin.json` valid JSON @ `0.3.0` |
| Round-trip `plan`→`create`→`update` (contract-level) | **roundTripContractOk: true** — see below |

### Round-trip — contract-level walkthrough

The plugin is not installed as live commands, so this is an artifact-level walkthrough of the three skill bodies (not a live run):

- `plan` is the sole producer of `.milestone-feeder/plan-<slug>.md` (deterministic slug), carrying 8 contract fields including the load-bearing **`Milestone title (exact)`** identity field.
- `create` resolves that exact file by the same slug and deploys it faithfully — create-or-adopt by exact title, slug→`#n` rewrite, idempotent re-run — and **regenerates nothing** (no re-dispatch of architect/issue-author, no re-run of the reviewer gate) on the found path.
- `update` parses the **same** field set, reconciles a refreshed plan against an existing milestone: create-new, patch-drift (diff-shown, never silent), add-edge + re-render build order, **flag-but-never-close** removed issues, idempotent no-op when nothing differs.
- Field alignment: every field a consumer reads is a field `plan` writes; no orphan on either side.

**Remaining real-exercise follow-up:** a live sandbox install (actually running `plan`→`create`→`update` against a throwaway GitHub repo) — the spec's `docs/specs/v0.3.0-humanize-the-surface.md:311` gate — was **not** performed here and is the genuine remaining exercise. No live round-trip is claimed.

## Decision Log

| Choice | Rationale | Alternative rejected |
|---|---|---|
| Remove the courtesy-migration mapping rather than reword it | Optional per spec §6; redundant with the locked hard-break (re-run `setup` to migrate); it was the only old-key-naming text blocking a byte-clean purge | Keep + obfuscate the key names — would defeat the §11 gate's intent and leave a half-purged surface |
| Left "(re-run handling below)" pointer intact | It cross-references the surviving `## Re-run behavior` section, not the deleted block — still accurate | Rewording it — needless churn outside scope |
| No `plugin.json` bump | Milestone target `0.3.0`; file already `0.3.0` → idempotent no-op | A patch bump — wrong; this is the milestone-target run, version is already correct |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at xhigh effort (docs/config-only diff — correctness angles N/A; ran coherence + dangling-reference + conventions + scope angles)
  - none
- No park-triggering findings.
- Note: version-free for this PR — no version bump (milestone target `0.3.0` already set; idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)