### PR TITLE
docs: add v0.3.1 design spec — explicit milestone identity & the driver handoff

### DIFF
--- a/docs/specs/v0.3.1-driver-handoff.md
+++ b/docs/specs/v0.3.1-driver-handoff.md
@@ -1,0 +1,293 @@
+# milestone-feeder v0.3.1 — explicit milestone identity & the driver handoff
+
+**Status:** design spec (brainstormed 2026-06-19, locked). Feeds the dogfood
+milestone: this document is the brief `plan` will consume to author v0.3.1 as a
+GitHub milestone the driver then builds.
+
+**Type:** additive feature release on the v0.3.0 surface. No breaking command or
+config changes — one new *optional* config key, new plan-file fields, and at most
+one conditional up-front prompt. A v0.3.0 plan file with none of the new fields
+still works (the new paths degrade gracefully). Bumps to **v0.3.1**.
+
+**Closes:** #50 (explicit, versioned milestone naming) and #51 (decouple
+`update`'s target milestone from the source brief; bounded rename-in-place). Adds
+a multi-milestone guardrail (new issue). Defers full multi-milestone
+decomposition to **0.4.0** (new backlog issue).
+
+> **A note on references.** A bare `§N` in this document refers to a section of
+> **this design spec** (`docs/specs/v0.3.1-driver-handoff.md`). The root product
+> spec is a *different* file, **`SPEC.md`**, with its own unrelated `§`-numbering
+> — always cite it by filename and an explicit anchor (e.g. "`SPEC.md` §3.1, the
+> plan-file fields table"), never as a bare `§N`.
+
+---
+
+## 1. Theme
+
+The feeder exists to **hand off cleanly to `milestone-driver`.** Today that
+handoff has a concrete, dogfooded break: a feeder-made milestone's title is
+derived from the brief's *goal* and carries **no version**. But the driver
+derives its target version by **parsing the milestone NAME for a semver
+(`x.y.z`)** — so a version-less feeder milestone silently degrades the driver to
+"no version parsed → prompt the user," defeating the unattended handoff for any
+versioned project. (This very `v0.3.1` milestone had to be **hand-named** for
+exactly this reason.)
+
+A second, related gap: `update` resolves **both** the source plan (by the
+brief-goal slug) **and** the target milestone (by exact title) from the *same*
+brief — so a revised plan written in a **new** brief file can't reconcile onto
+its existing milestone.
+
+v0.3.1 closes both by making **milestone identity explicit and user-owned**, with
+the **semver living in the milestone title** where the driver reads it. It also
+adds a small **multi-milestone guardrail** so a large brief doesn't silently
+become one giant milestone.
+
+It is **not** a redesign of the `plan → create → update` pipeline. The write
+sequences, the self-check gate, and the reconcile behavior are unchanged. What
+changes is **where a milestone's identity (its title, its version, and a stable
+handle) comes from**, and how the family carries it.
+
+---
+
+## 2. The versioning model (suite-wide)
+
+Versioning is a three-role contract across the suite. v0.3.1 builds the
+**feeder's** half; the bootstrapper (a separate, future project) later fills the
+declaration the feeder reads.
+
+| Role | Responsibility |
+|---|---|
+| **Bootstrapper** (future) | At scaffold time, asks *"is this project semver-versioned?"* and **records** the answer as the project's versioning declaration. |
+| **Feeder** (this release) | **Reads** the declaration as the default; **infers** from repo signals when there's no declaration; **prompts** only when nothing is inferable. Always writes the semver **into the milestone title**. |
+| **Driver** (unchanged) | **Parses** the milestone title for a semver to set the target version every PR bumps. Consumes the title the feeder produced; reads no versioning config. |
+
+**The semver always lives in the milestone title** — one user-owned title string
+(e.g. `myapp v1.2.0`). There is **no separate version field**; the driver parses
+the version from the title, so that is the single place it can live.
+
+### The layered version default
+
+When `plan` needs a version for the title, it resolves in this order — the first
+that yields an answer wins:
+
+1. **Explicit** — a version the user states up front (see §3) or types when
+   prompted.
+2. **Declaration** — the project versioning declaration (§7): if `"none"`, the
+   project is non-versioned → **no version, no prompt**; if `"semver"`, the
+   project is versioned → continue to find the number.
+3. **Inference** — the highest semver among existing **milestone titles**, else
+   the latest **git tag** (`vX.Y.Z`), taken as the **reference** version. The
+   **name** part of the title is reused from the matched milestone title when one
+   exists, else falls back to today's goal-derived name. The feeder proposes the
+   composed title and **surfaces it in the plan file** for the user to confirm or
+   adjust (only the user knows whether this milestone is a patch / minor / major
+   bump, and whether the name is right).
+4. **Prompt** — when **nothing** above resolves (no declaration, no tags, no
+   prior milestones — a greenfield repo), `plan` **asks up front**: *"Is this a
+   versioned project? If so, what version is this milestone?"* This is the one
+   sanctioned interactive moment, and only fires when nothing is inferable.
+
+The **resolved exact title** lands in the plan file's identity field (§6),
+**surfaced for review and override before `create`** — `plan` never silently
+invents a milestone identity the user can't see or change.
+
+---
+
+## 3. #50 — explicit, versioned milestone identity
+
+The milestone title becomes a **user-owned field**, not a goal-derivative.
+
+- **Up front.** The user can state the milestone name (with its version) **when
+  they start** — either inline with the brief or as a labelled line in the brief
+  doc (e.g. `Milestone: myapp v1.2.0`). If present, `plan` uses it verbatim as
+  the title's starting point.
+- **Default when unstated.** If the user states nothing, `plan` resolves a
+  default by the layered ladder (§2) and **writes it to the plan file's identity
+  field**, surfaced for confirm/override before `create`.
+- **Semver in the title.** Whatever the source, the version ends up **inside the
+  exact title string** so the driver's semver detection finds it.
+- **Non-versioned projects are left alone.** A `"none"` declaration (§7) means no
+  version is added and no prompt fires.
+- **`create` uses the title verbatim.** It create-or-adopts by the exact title
+  field — unchanged resolve idiom, new (user-owned) source for the string.
+
+**Acceptance (from #50):** a documented, flag-free way to set the milestone name;
+optional semver so the driver derives a target version; `plan` records the exact
+title and `create` uses it verbatim; an unstated name yields a surfaced,
+overridable default (never a silent identity); documented in SPEC, README, and
+the plan-file contract.
+
+---
+
+## 4. #51 — `update` targeting + bounded rename-in-place
+
+### The decoupling falls out of #50
+
+Once identity is the explicit title (not the goal), `update` already resolves the
+milestone **by that title field**, while the brief's goal-slug only locates the
+**source plan file**. So the #51 scenario is solved: revise your plan in a **new**
+brief file, keep the same milestone title, and `update` reconciles onto the
+existing milestone. Target resolution is decoupled from the source brief.
+
+### The deploy receipt — a stable handle for rename
+
+To rename a milestone, `update` needs a handle that survives a title change
+(after the title changes, the title can no longer match it). The handle is the
+**GitHub milestone number**, recorded as a deploy receipt:
+
+- **`create` writes the receipt.** After create-or-adopt, `create` writes the
+  resulting milestone number back into the plan file as a labelled field —
+  `Milestone number (GitHub): <n>`. The plan file becomes a record of *what it
+  deployed to*. (The plan file is gitignored per-run scratch, so this back-write
+  is low-stakes.)
+- **`update` resolves by the receipt first.** When the receipt is present,
+  `update` resolves the milestone **by number** (stable), falling back to
+  **resolve-by-title** when it's absent. Resolving by number also hardens every
+  non-rename `update`.
+- **Rename = a title PATCH.** When `update` resolved by number and the plan's
+  title differs from the live milestone's title, it **PATCHes the new title**.
+  That is the rename — `update` never mutates a milestone's identity on its own;
+  it only follows the receipt.
+- **Re-plan preserves the receipt.** `plan` regenerates the plan file from the
+  brief; before overwriting, it **carries forward** an existing
+  `Milestone number` receipt for the same slug, so a re-plan doesn't strand the
+  handle.
+
+### Bounded to edit-in-place
+
+Rename reaches exactly as far as the receipt does:
+
+- **Same brief/plan, changed title** → the receipt is present → `update` renames
+  the live milestone. ✅
+- **Wholesale new brief with a new title** → fresh plan file, **no receipt** →
+  `update` falls back to title-match → no match → 🔴 **error-and-stop directing
+  you to `create`** (correct: a renamed/version-bumped milestone from a new brief
+  is usually a *new* milestone). The stop message includes the **one-line `gh`
+  command to rename in place** for the rare true-rename case.
+
+Milestone-not-found still errors-and-stops ("run `create` first") — unchanged.
+
+**Acceptance (from #51):** `update` targets an existing milestone independently of
+the brief file; a revised/new brief reconciles onto the named milestone via the
+existing reconcile behavior; defined behavior for the title-change case (above);
+documented in SPEC + README.
+
+---
+
+## 5. The multi-milestone guardrail
+
+The feeder stays **one brief → one milestone** in v0.3.1, but it stops being
+*silent* about a brief that's really several milestones.
+
+- **Detection — the architect flags it.** The architect already reasons about the
+  brief's structure and builds the dependency graph, so it emits a new
+  **`SCOPE_SPANS_MULTIPLE_MILESTONES`** signal (a sibling to `PRODUCT_GAPS`) when
+  a brief reads as distinct phased deliverables / release boundaries, with a
+  **proposed split** (the candidate milestones and which issues fall under each).
+- **Behavior — advisory + proposed split, non-blocking.** `plan` still writes a
+  **deployable single-milestone plan**, but **prominently flags** *"this looks
+  like ~N milestones"* and shows the proposed split (A / B / C), surfaced up front
+  alongside the versioning step. The user decides: **deploy the one big
+  milestone, or split the brief and re-run.** Never a hard block, never a silent
+  giant milestone.
+- **Full support is deferred to 0.4.0.** True `brief → N-milestones`
+  decomposition (partition, version each, order them, create them all) is a theme
+  of its own — it multiplies #50/#51 (each milestone needs its own name, version,
+  and update targeting). Nothing in v0.3.1 blocks it: the plan-file format
+  extends **additively** to a list of milestones later.
+
+---
+
+## 6. Plan-file contract — additive fields
+
+The plan-file contract (v0.3.0 §3) gains fields; nothing is removed. A v0.3.0
+plan file lacking them still parses (the consumers degrade gracefully).
+
+| Field | Owner | Why a consumer needs it |
+|---|---|---|
+| **Milestone title (exact)** — now **user-owned**, carries the semver | `plan` writes (resolved per §2/§3); user may override before `create` | `create`/`update` resolve by it; the driver parses the version from it. |
+| **Milestone number (GitHub):** `<n>` — the deploy receipt | `create` writes it post-deploy; `plan` preserves it on re-plan | `update` resolves by it (stable handle) and renames on title diff (§4). |
+| **Version provenance** (one line: `explicit` \| `declaration` \| `inferred from <tag/milestone>` \| `prompted`) | `plan` writes it | Makes the surfaced default legible so the user can trust or correct it. |
+| **Multi-milestone advisory** — the `SCOPE_SPANS_MULTIPLE_MILESTONES` flag + proposed split, when raised | `plan` writes it | Surfaces the guardrail (§5); does **not** change what gets deployed. |
+
+---
+
+## 7. Config — the project versioning declaration
+
+A new **optional** key in the existing `.milestone-config/feeder.json` (no file
+rename, consistent with v0.3.0 §6). It answers only the *is-this-versioned*
+question; the version *number* comes from the layered ladder (§2).
+
+| Key | Type / value | Meaning |
+|---|---|---|
+| `versioning` | `"semver"` \| `"none"` | **Optional.** `"semver"` = version every milestone (find the number via §2). `"none"` = non-versioned project; never add a version, never prompt. **Absent** = unknown → the feeder infers from repo signals, else prompts (§2 steps 3–4). |
+
+- **Forward-compatible with the bootstrapper.** The bootstrapper will *write* this
+  key at scaffold time; until then it's simply absent and the feeder
+  infers-or-asks. Defining it now gives the bootstrapper a concrete target.
+- **`setup` learns the key.** `setup` may offer to set `versioning` (with a plain
+  description), but it's optional — skipping it just means infer-or-ask at plan
+  time. The skip-consequence is stated.
+
+---
+
+## 8. Build order (dogfood it)
+
+This spec becomes the brief the feeder runs on itself, driven by milestone-driver.
+The dependency spine is #50 → #51 → guardrail.
+
+1. **#50 — explicit, versioned identity (foundation).** `plan` version
+   resolution (layered ladder §2), the user-owned exact-title field, the optional
+   up-front milestone line, the `versioning` config key (§7), and surfacing the
+   resolved title + provenance in the plan file (§6). *Foundational; #51 builds on
+   the explicit-identity field.*
+2. **#51 — update targeting + bounded rename.** The `create` deploy-receipt
+   back-write, `update` resolve-by-number → rename-on-title-diff, the re-plan
+   receipt-preserve, and the new-brief/new-title error-and-stop with the `gh`
+   rename hint (§4).
+3. **Multi-milestone guardrail.** The architect's
+   `SCOPE_SPANS_MULTIPLE_MILESTONES` signal + proposed split, and `plan`'s
+   non-blocking advisory surfacing (§5).
+4. **Docs & metadata** (§9).
+5. **Verify** the round-trip on a sandbox repo; bump to v0.3.1.
+
+---
+
+## 9. Docs & metadata
+
+**Ownership split (so the `versioning` key isn't documented in two places by two
+issues).** The key's **definition surfaces** — the consumer schema doc
+(`docs/profile-schema.md`) and the `setup` prompt (`skills/setup/SKILL.md`) —
+belong to the **config-key issue** (the one that introduces `versioning`). The
+**narrative + canonical docs** — `SPEC.md`, `README.md`, `docs/consumer-setup.md`,
+`CHANGELOG.md`, `.claude-plugin/plugin.json` — belong to the **docs-sweep issue**,
+which depends on the config-key issue and therefore documents an
+already-established key. In particular, the `versioning` row in **`SPEC.md`'s §7
+config-schema table is the docs-sweep issue's edit**, not the config-key issue's.
+
+| File | Owner | Edit (with exact anchors) |
+|---|---|---|
+| `docs/profile-schema.md` | **config-key issue** | Add the `versioning` row to the Own-keys table (`SPEC.md`-independent), with a per-key note for the three-way `"semver"` / `"none"` / absent semantics. |
+| `skills/setup/SKILL.md` | **config-key issue** | Offer `versioning` as an optional key (skip-consequence inline), mirroring the existing optional-key tier. |
+| `SPEC.md` | **docs-sweep issue** | Plan-file-contract additions → the **§3.1 "Fields a consumer parses" table** (`SPEC.md` lines ~67–80); the `versioning` row → the **§7 config-schema table** (`SPEC.md` lines ~184–191); plus prose for user-owned versioned identity, `update` resolve-by-number + bounded rename, and the guardrail. |
+| `README.md` | **docs-sweep issue** | "How it works" gains: name your milestone with a version up front (and why — the driver reads the version from the title); the feeder flags a brief that looks like multiple milestones. Bump the `## Status` line to v0.3.1. |
+| `docs/consumer-setup.md` | **docs-sweep issue** | The optional `versioning` key + its skip-consequence, in consumer-facing terms. |
+| `CHANGELOG.md` | **docs-sweep issue** | A `v0.3.1` entry above v0.3.0: versioned milestone naming; `update` retargeting + bounded rename-in-place; multi-milestone guardrail (advisory). |
+| `.claude-plugin/plugin.json` | **docs-sweep issue** | `version` → `0.3.1` (the `version` field only). |
+| `skills/plan`, `skills/create`, `skills/update`, `agents/architect` | the **behavior issues** | The behavior above — owned by the behavior issues, not the docs sweep. |
+
+---
+
+## 10. Out of scope (non-goals)
+
+- **Full `brief → N-milestones` decomposition** — deferred to 0.4.0; v0.3.1 ships
+  only the advisory guardrail (§5).
+- **Rename from a wholesale new brief**, and any cross-machine / cross-clone
+  durable milestone mapping — rename is bounded to the edit-in-place receipt (§4).
+- **A separate version field** — the semver lives in the title, period (§2).
+- **The bootstrapper itself** — a separate project; v0.3.1 only defines the
+  declaration it will later write (§7).
+- **No change** to the self-check gate's logic, the create/update write
+  sequences, or the architect/issue-author contracts beyond the additions named
+  here.


### PR DESCRIPTION
## What

Adds the **v0.3.1 design spec** (`docs/specs/v0.3.1-driver-handoff.md`) — the brief the feeder dogfoods into the v0.3.1 milestone. It settles the open design decisions filed under #50/#51 and adds a non-blocking multi-milestone guardrail.

## The design

- **Milestone identity is user-owned and versioned.** The semver lives in the milestone title, where `milestone-driver` parses its target version. A layered version default (explicit → declaration → infer → prompt) resolves it; non-versioned projects are left alone.
- **New optional `versioning` config key** (`"semver" | "none"` | absent) declares whether a project is semver-versioned — forward-compatible with the future bootstrapper.
- **`update` resolves its target by a deploy receipt** (the GitHub milestone number, written back by `create`), decoupling the target from the source brief, and **renames in place** (bounded to edit-in-place) when the title changes.
- **Multi-milestone guardrail:** the architect flags a brief that spans release boundaries; `plan` surfaces it as a non-blocking advisory. Full `brief → N-milestones` decomposition is deferred to **0.4.0**.

## Provenance

Brainstormed and locked 2026-06-19, then **dogfooded through `/milestone-feeder:plan`** — the feeder decomposed this spec into 7 gate-clean issues (self-check PASS 7/7 via milestone-driver's reviewers). The dogfood gate caught a real section-number citation collision, fixed here at source: a **references note** (a bare `§N` is this design spec; `SPEC.md` is cited by name + anchor) and a **§9 ownership table** assigning the `SPEC.md` §7 `versioning` row to the docs-sweep issue.

Closes the design portion of #50 and #51 (implementation tracked as the deployed milestone issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)