### PR TITLE
feat(config): add optional `versioning` key (profile-schema + setup) (#56)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/docs/profile-schema.md
+++ b/docs/profile-schema.md
@@ -28,15 +28,18 @@ CI.
 
 Keep it thin and consumer-driven, the same discipline as the driver: **new keys
 are added only when a real consumer needs them — never speculatively**
-(`SPEC.md` §7). Every own-key has a bundled default, so a profile may omit any
-key it does not override; an empty `{}` is valid (all defaults apply). The only
+(`SPEC.md` §7). Nearly every own-key has a bundled default, so a profile may omit
+any key it does not override; an empty `{}` is valid (defaults apply where they exist). The one
+exception is `versioning`, which has **no** bundled default — absent is a distinct
+"infer-or-ask" state, not a default value (see its per-key note). The only
 key the feeder's own repo must carry is the self-protection `sourceGlobs` (so the
 `no-source-edit` hook has a primary source to read).
 
 ## Own keys
 
 These keys are owned by the feeder and resolved from `feeder.json`. All are
-optional in the file (each has a bundled default).
+optional in the file. Every key except `versioning` has a bundled default;
+`versioning` has none — absent is its own "infer-or-ask" state (see its note).
 
 | Key | Type | Default | Purpose |
 |---|---|---|---|
@@ -45,6 +48,7 @@ optional in the file (each has a bundled default).
 | `architectAgent` | string | `milestone-feeder:architect` | Override the breakdown agent (default-filled). |
 | `issueAuthorAgent` | string | `milestone-feeder:issue-author` | Override the authoring agent (default-filled). |
 | `issueSize` | string | *(none)* | Optional natural-language sizing rule (e.g. "≤1 PR, ≤1 new screen"). |
+| `versioning` | `"semver" \| "none"` | *(none)* | Whether this project is semver-versioned. Drives milestone-version resolution at plan time. Three-way (see note). |
 | `sourceGlobs` | string[] | `["skills/**","agents/**","hooks/**"]` | **Self-protection only** — the paths the feeder's own `no-source-edit` hook guards in the feeder's *own* repo. Distinct from the consumer's shared `sourceGlobs`. Resolution chain below. |
 
 ### Per-key notes
@@ -66,6 +70,26 @@ rarely overridden. Omit them from the profile unless pointing at a custom agent.
 **`issueSize`.** Optional free-text sizing rule the author honours when
 splitting work into issues. Absent → no sizing constraint beyond the procedure's
 defaults.
+
+**`versioning`.** Answers only one question — *is this project
+semver-versioned?* — with a three-way contract (grounded in
+`docs/specs/v0.3.1-driver-handoff.md` §7 and the versioning model in
+`docs/specs/v0.3.1-driver-handoff.md` §2):
+
+- `"semver"` = the project is versioned: `plan` versions every milestone, finding
+  the actual number via the layered ladder.
+- `"none"` = the project is non-versioned: `plan` never adds a version and never
+  prompts for one.
+- **Absent** = unknown: `plan` infers from repo signals (existing milestone
+  titles, then git tags), and only asks when nothing is inferable.
+
+Unlike every other own-key, `versioning` has **no bundled default** — absent is a
+distinct documented state, *not* a default value. So it follows the
+[absent-means-default discipline](#absent-means-default-discipline) the same way:
+when it is skipped, it is **omitted** from the profile (never written as a
+placeholder), and the absent state means infer-or-ask. An **invalid or
+unrecognized value** (anything that is not exactly `"semver"` or `"none"`) is
+treated as absent — `plan` falls back to infer-or-ask and never errors on the key.
 
 **`sourceGlobs` (self-protection).** The paths the feeder's `no-source-edit` hook
 guards in the feeder's **own** repo. This is **semantically distinct** from the
@@ -135,11 +159,14 @@ that driver change has shipped in a given consumer's pinned version.
 
 ## Absent-means-default discipline
 
-**Omit a key rather than write its default value.** Every own-key has a bundled
-default; writing the default explicitly adds noise and drifts when the default
-changes. A minimal profile carries only the keys that diverge from default — for
-the feeder's own repo, that is just the self-protection `sourceGlobs` (so the
-hook has a primary source). An empty `{}` is a valid profile.
+**Omit a key rather than write its default value.** Almost every own-key has a
+bundled default; writing the default explicitly adds noise and drifts when the
+default changes. `versioning` is the exception — it has no default, so "skip"
+means **omit it** and let its absent state (infer-or-ask) apply, never write a
+placeholder. Either way the rule is the same: omit on skip. A minimal profile
+carries only the keys that diverge from default — for the feeder's own repo, that
+is just the self-protection `sourceGlobs` (so the hook has a primary source). An
+empty `{}` is a valid profile.
 
 ## Minimal example
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -7,7 +7,7 @@ description: This skill should be used when "milestone-feeder:setup" is invoked 
 
 Generate or repair the feeder profile through a guided, inference-first flow. Every key is presented with a plain-language description and a detected default. Optional keys state their skip-consequence. No blank prompts — if a default cannot be inferred, an example is shown.
 
-The canonical profile location is `<repo-root>/.milestone-config/feeder.json` — the suite-wide `.milestone-config/` directory the sibling `milestone-driver` plugin also reads from (it stores `driver.json` alongside). **Unlike the driver, the feeder has no required hard-stop key:** the feeder writes no branches and runs fully on bundled defaults, so an empty `{}` profile is valid (all defaults apply). Setup still writes the file — even when every key defaults — so config-presence detection (`plan`'s Step 0 → auto-invoke setup when the file is absent) is unambiguous.
+The canonical profile location is `<repo-root>/.milestone-config/feeder.json` — the suite-wide `.milestone-config/` directory the sibling `milestone-driver` plugin also reads from (it stores `driver.json` alongside). **Unlike the driver, the feeder has no required hard-stop key:** the feeder writes no branches and no key hard-stops the write, so an empty `{}` profile is valid — nearly every key falls back to a bundled default (the exception is `versioning`, which has no default: skipping it means infer-or-ask, not a default value). Setup still writes the file — even when every key is left at its default or skipped — so config-presence detection (`plan`'s Step 0 → auto-invoke setup when the file is absent) is unambiguous.
 
 **After writing the file, return control to the caller** (`plan`) so the original task continues immediately. The user does not need to re-run the command.
 
@@ -38,7 +38,7 @@ Present keys in these tiers: **Core → Agents → Sizing**, plus the self-prote
 - For optional keys: state the skip-consequence on the same line.
 - Accept, edit, or skip — never leave a field blank without an explicit skip choice.
 
-**No required hard-stop key.** Unlike the driver (whose Core keys `integrationBranch` / `protectedBranch` / `sourceGlobs` hard-stop), the feeder has **no** key that blocks the write. The feeder writes no branches and runs fully on defaults, so every tier below is acceptable as a one-keystroke accept-the-default. An empty `{}` is a valid result — and setup still writes the file regardless, so config-presence detection is unambiguous.
+**No required hard-stop key.** Unlike the driver (whose Core keys `integrationBranch` / `protectedBranch` / `sourceGlobs` hard-stop), the feeder has **no** key that blocks the write. The feeder writes no branches and no key hard-stops, so every tier below is a one-keystroke accept-or-skip. Most keys accept the detected default; the exception is `versioning` (in the Sizing tier), which has no default — so its one-keystroke choice is accept-or-skip, and skip means infer-or-ask, not a default value. An empty `{}` is a valid result — and setup still writes the file regardless, so config-presence detection is unambiguous.
 
 **Tier: Core** (optional; show the detected default — accept with one keystroke)
 
@@ -54,11 +54,12 @@ Present keys in these tiers: **Core → Agents → Sizing**, plus the self-prote
 | `architectAgent` | "Which agent produces the issue breakdown + dependency graph? (Rarely changed — the bundled default is fine for most repos.)" | Auto-fill `"milestone-feeder:architect"` — show it, confirm, move on. Skip → bundled default used; key omitted. |
 | `issueAuthorAgent` | "Which agent authors each issue's full spec? (Rarely changed — the bundled default is fine for most repos.)" | Auto-fill `"milestone-feeder:issue-author"` — show it, confirm, move on. Skip → bundled default used; key omitted. |
 
-**Tier: Sizing** (optional)
+**Tier: Sizing & versioning** (optional)
 
 | Key | Plain-language label | Skip-consequence |
 |---|---|---|
 | `issueSize` | "Any natural-language sizing rule the author should honour when splitting work? (e.g. `≤1 PR, ≤1 new screen`)" | Skip → "No sizing constraint beyond the procedure's defaults." |
+| `versioning` | "Is this project semver-versioned? Drives whether `plan` adds a version to the milestone. Accept `\"semver\"` (versioned — version every milestone), `\"none\"` (non-versioned — never add a version), or skip." | Skip → the key is **omitted** (it has no default) and `plan` infers-or-asks at plan time. |
 
 **Self-protection key (the feeder's OWN repo)**
 
@@ -71,7 +72,7 @@ Present keys in these tiers: **Core → Agents → Sizing**, plus the self-prote
 The canonical profile location is `<repo-root>/.milestone-config/feeder.json`.
 
 - Create the `.milestone-config/` directory if absent (`mkdir -p .milestone-config`).
-- Assemble the profile object from the keys the user accepted or edited. **Omit any key left at its bundled default** (absent-means-default, `docs/profile-schema.md`): writing the default explicitly adds noise and drifts when the default changes. A minimal feeder-own-repo profile carries only the self-protection `sourceGlobs`; an empty `{}` is valid.
+- Assemble the profile object from the keys the user accepted or edited. **Omit any key left at its bundled default** (absent-means-default, `docs/profile-schema.md`): writing the default explicitly adds noise and drifts when the default changes. `versioning` has **no** default, so a skipped `versioning` is likewise **omitted** — never written as a placeholder; its absent state means `plan` infers-or-asks. A minimal feeder-own-repo profile carries only the self-protection `sourceGlobs`; an empty `{}` is valid.
 - Write the assembled object to `.milestone-config/feeder.json`. **Always write the file**, even when the result is `{}` — config-presence is the signal `plan`'s Step 0 reads to decide whether to auto-invoke setup, so an absent file and an empty file are deliberately distinct.
 - Print the final file contents so the user can verify.
 
@@ -133,6 +134,6 @@ Be concise — report status and outcomes flatly, no wall-of-text. Present steps
 
 - Never present a blank prompt. Every key shows either a detected default or an illustrative example.
 - Skip always states its consequence. A user who skips knows exactly what default or behavior applies.
-- No required hard-stop key. Unlike the driver, the feeder writes no branches and runs fully on defaults — there is no key whose absence blocks the write.
-- Always write the file. Even an all-defaults result writes `.milestone-config/feeder.json` (an empty `{}` is valid), so config-presence detection is unambiguous. Omit default-filled keys from the written object (absent-means-default).
+- No required hard-stop key. Unlike the driver, the feeder writes no branches and no key hard-stops the write — every key falls back to its default, except `versioning`, which has none (skip = infer-or-ask).
+- Always write the file. Even an all-defaults result writes `.milestone-config/feeder.json` (an empty `{}` is valid), so config-presence detection is unambiguous. Omit default-filled keys from the written object (absent-means-default); also omit `versioning` when skipped — it has no default, so a skip means omit (infer-or-ask), never a placeholder.
 - **Committing the profile:** writing the file is enough for `plan` to read it this session. When `setup` is invoked **directly** (`/milestone-feeder:setup`), suggest the user commit it (`git add .milestone-config/feeder.json && git commit -m "chore: add milestone-feeder profile"`) so every clone and CI has it. When `setup` is auto-invoked **by `plan`**, leave the commit to the normal flow — do not create a commit on the current branch.


### PR DESCRIPTION
Closes #56.

## Summary

Adds the optional `versioning` profile key to the feeder's **two definition surfaces only** — the consumer schema doc (`docs/profile-schema.md`) and the `setup` prompt (`skills/setup/SKILL.md`) — documenting a three-way contract:

| Value | Meaning |
|---|---|
| `"semver"` | versioned project — `plan` versions every milestone (number resolved via the layered ladder) |
| `"none"` | non-versioned project — never add a version, never prompt |
| **absent** | unknown → the feeder infers from repo signals, else asks. A **distinct documented state, not a default value**. |

`versioning` is the **first own-key with no bundled default**: skipping it omits it from the profile (infer-or-ask), and an invalid/unrecognized value is treated as absent (the feeder never errors on the key). This issue **defines** the key only — no runtime behavior, no `SPEC.md` edit.

## Acceptance criteria — all met

- Schema doc gains a `versioning` row (type `"semver" \| "none"`, Default `*(none)*` mirroring `issueSize`) plus a per-key note documenting the three-way semantics.
- `setup` offers `versioning` in the optional-key tier with its skip-consequence inline.
- Absent is documented as a distinct state with no bundled default (Default cell `*(none)*`).
- Skipped `versioning` is omitted from the written profile (omit-on-skip).
- Invalid value treated as absent; never errors (documented contract).
- Empty/minimal profile (`{}`, today's `feeder.json`) still valid; no existing key's meaning changed.
- `SPEC.md` §7 row deliberately **out of scope** (owned by #62 per `docs/specs/v0.3.1-driver-handoff.md` §9).

The change also reconciles the doc's prior "every own-key has a bundled default" claims (three sites in `profile-schema.md`, two in `SKILL.md`) so the new no-default key is non-contradictory.

## Version bump

`version` → `0.3.1` (`.claude-plugin/plugin.json`). First PR of the v0.3.1 milestone run — sets the milestone-derived target version. Config edit only; carries no logic change.

## Decision Log

| Choice | Rationale | Citation | Alternatives rejected |
|---|---|---|---|
| Setup row placed in the existing Sizing tier (renamed "Sizing & versioning") | `issueSize` is the closest structural sibling (the other no-default optional key); smaller edit than a new tier; keeps tier count stable | `skills/setup/SKILL.md:57-61`; issue design | Standalone "Tier: Versioning" — a section header for one row, more structure than needed |
| Default cell `*(none)*` + per-key note placed after `issueSize` | Mirrors the `issueSize` sibling byte-for-byte — the visible signal that there is no bundled default | `docs/profile-schema.md:47`, `:66-68` | A literal default value — would contradict the "absent is not a default" contract |
| Reconciled all "every own-key has a default" claims (5 sites) rather than a subset | A consistency reviewer flags an internal contradiction; `versioning` is the first no-default key, so every absolute claim had to acknowledge the exception | issue design; `docs/profile-schema.md` Absent-means-default section | Reconciling only the Design-principle line — would leave surviving contradictions (caught by `/code-review`) |
| "invalid → treated as absent" documented as a robustness contract, not attributed to the spec | The spec frames the model as three-way but doesn't use the word "invalid"; no-fabricated-citation rule | `docs/specs/v0.3.1-driver-handoff.md` §7 three-way model | Citing the spec as the source of "invalid" wording — would be a fabricated citation |
| All `§N` citations filename-qualified | `SPEC.md` and the design spec have colliding section numbers (dogfood §-collision lesson) | `docs/specs/v0.3.1-driver-handoff.md` | Bare `§N` — ambiguous, caught and fixed by `/code-review` |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 3 in-scope finding(s) at medium effort (run 1), 0 findings (run 2, re-review — last action before commit)
  - `skills/setup/SKILL.md:10` residual "all defaults apply" absolute claim → re-dispatched and resolved
  - `skills/setup/SKILL.md:41` residual "runs fully on defaults" absolute claim → re-dispatched and resolved
  - `docs/profile-schema.md:76` bare `§2` citation → re-dispatched and resolved (filename-qualified)
  - (orchestrator also reconciled two same-class residuals surfaced by the fix pass — `profile-schema.md:32` "(all defaults apply)" → "(defaults apply where they exist)"; `SKILL.md:137` Non-negotiables recap — to converge the re-review)
- Re-review (medium effort) returned **0 findings** — clean and converged; confirmed all 7 acceptance criteria present and unbroken, all `§N` qualified, table integrity intact, anchor resolves, only the intended files changed.
- No park-triggering findings.
- Version-bump annotation: version-bump only — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)