### PR TITLE
feat(plan): resolve milestone version by the layered ladder + user-owned exact title (#57)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -61,11 +61,14 @@ The brief arrives in one of three forms. **Detect** which:
   in-scope:        [<bullets>],
   out-of-scope:    [<bullets>],
   surfaces:        [<the screens / modules / surfaces the brief touches>],
-  epicIssueNumber: <n>   # present only when the brief was a GitHub epic issue; else omitted
+  epicIssueNumber: <n>                # present only when the brief was a GitHub epic issue; else omitted
+  milestoneLine:   <the verbatim "<name> vX.Y.Z" string>   # present only when the user stated the milestone identity up front; else omitted
 }
 ```
 
 Record `epicIssueNumber` when the brief was an epic issue. `plan` posts **nothing** to the epic — the number is recorded in the plan file's source-brief reference so the downstream `create` / `update` can route their needs-input report to the epic comment. `plan` itself writes no GitHub state.
+
+**Capture the explicit milestone identity (`milestoneLine`) when the user states it up front** (`docs/specs/v0.3.1-driver-handoff.md` §3 — milestone identity is a user-owned field). The user may name the milestone — with its version — either as a labelled `Milestone: <name> vX.Y.Z` line **in the brief doc** or as an inline statement alongside the brief. When present, capture that verbatim `<name> vX.Y.Z` string as `milestoneLine` — it is carried **verbatim** into the version-resolution step (Step 5's ladder, rung 1; `docs/specs/v0.3.1-driver-handoff.md` §2). This field is **optional and additive**: a brief with no `Milestone:` line and no inline statement omits it and normalizes exactly as before (`skills/plan/SKILL.md:46` ingest, `:56` normalize) — the missing field degrades gracefully to the rest of the ladder.
 
 ### Step 2 — Product-gap check (the park boundary)
 
@@ -159,6 +162,30 @@ Render the **milestone description** to the `SPEC.md` §4 Wave template, substit
 ```
 
 This is the human-readable description and the exact ordering source the driver's `solve-milestone` and `triage` consume (`SPEC.md` §4). In the plan file the identifiers are **local slugs** (`#A`/`#B`); `create` rewrites them to real GitHub numbers once the issues exist (the two-pass slug→`#n` mechanic, owned by `create`). `plan` itself does no slug→`#n` rewrite — no GitHub numbers exist yet, so it writes local slugs only.
+
+#### 5.1 — Resolve the milestone version + exact title (the version ladder)
+
+Resolve the milestone's **exact title** — the load-bearing identity string that carries the semver **inside it** (there is **no separate version field**; the driver parses the version from the title, so that is the single place it can live — `docs/specs/v0.3.1-driver-handoff.md` §2, and §10's "A separate version field" non-goal). Resolve it by the **layered ladder below, FIRST-MATCH-WINS** — the first rung that yields an answer wins and the ladder STOPS (`docs/specs/v0.3.1-driver-handoff.md` §2 *"The layered version default"*). Alongside the title, record a one-line **version provenance** (one of `explicit` | `declaration` | `inferred from <tag/milestone>` | `prompted`) so the surfaced default is legible (`docs/specs/v0.3.1-driver-handoff.md` §6).
+
+**This sub-step is READ-ONLY on GitHub.** Its only new repo reads are a read-only `git tag` read and a **read-only** `gh api` milestones read (rung 3); it **creates, posts, and patches nothing**. The greenfield prompt (rung 4) is the **one sanctioned interactive moment** of the run. This is consistent with the no-GitHub-write invariant (`skills/plan/SKILL.md:10` and the **Non-negotiables** section): `plan` writes NO GitHub state.
+
+| Rung | Source | Outcome | Provenance |
+|---|---|---|---|
+| **1. Explicit** | The `milestoneLine` captured at Step 1 (the up-front `Milestone: <name> vX.Y.Z` line or inline statement) — **or** a version the user types when prompted at rung 4. | Used **verbatim** as the exact title. Ladder STOPS. | `explicit` |
+| **2. Declaration** | `versioning` from `.milestone-config/feeder.json` (the optional key #56 introduced; `docs/profile-schema.md` — the `versioning` own-keys row + its per-key note). | `"none"` → **NO version, NO prompt**; goal-derived name only → ladder STOPS. `"semver"` → project IS versioned → **continue DOWN to rung 3** to find the number (the declaration confirms *versioned* but carries no number). Absent / invalid / unrecognized value → **treat as absent** → continue to rung 3 (infer-or-ask); **never error on the key** (per the `docs/profile-schema.md` `versioning` per-key note: an invalid/unrecognized value is treated as absent). | `declaration` (only on the `"none"` stop) |
+| **3. Infer** | Read-only repo signals (see the two sub-rungs below). | The matched/latest **reference** semver composes the title (carried **verbatim**); the feeder **PROPOSES** the title and **surfaces it** in the plan file for confirm/adjust — it does **not** silently finalize. Falls to rung 4 only if neither signal yields anything. | `inferred from <milestone>` or `inferred from <tag>` |
+| **4. Prompt** | Only when **nothing above resolved** (no declaration / no `"semver"`-with-a-number, no milestone titles, no tags — a greenfield repo). | Ask up front, **ONCE** — the one sanctioned interactive moment: *"Is this a versioned project? If so, what version is this milestone?"* (`docs/specs/v0.3.1-driver-handoff.md` §2 rung 4). **Version typed →** used **verbatim** as the exact title (the same verbatim-into-title mechanic as rung 1), with provenance `prompted` (NOT `explicit` — the value was prompted, not stated up front); ladder STOPS. **DECLINE →** NO version is added, the title uses the goal-derived name (exactly as rung 2 `"none"`), provenance is recorded as `declaration` (the user has declared this project non-versioned at the prompt), and the ladder STOPS. | `prompted` (version typed) / `declaration` (declined) |
+
+**Provenance legibility note.** `declaration` provenance applies only to the rung-2 `"none"` STOP and the rung-4 DECLINE (above) — both record that the user declared the project non-versioned. A project declared `versioning:"semver"` (rung 2) that reaches the rung-4 prompt because nothing was inferable still records provenance `prompted`, not `declaration`: a number had to be prompted, so the provenance reflects how the *number* was obtained, even though the project was declared versioned.
+
+**Rung 3 — the two read-only infer signals (in order):**
+
+1. **FIRST, the highest semver among EXISTING milestone TITLES.** **Reuse the canonical `env.t`-style quote-safe `gh api` milestones read defined in `skills/create/SKILL.md` Step 3 pass (b) BY REFERENCE — do NOT re-define it** (the same reuse-by-reference discipline `skills/update/SKILL.md:60` follows; both bash and PowerShell 7+ forms are given at `skills/create/SKILL.md:84-90`). **One intentional delta from create pass (b):** create pass (b) `select`s the **one** milestone whose title equals `env.t`; here you read **ALL** milestone titles (no `env.t` filter — e.g. `--jq '.[] | .title'`) and scan them for the **highest** semver, since you are finding a reference version rather than matching one exact title (the delta is noted here exactly as `skills/update/SKILL.md` notes its own pass-(b) delta). The matched milestone's **NAME part is reused** for the title; its (highest) semver is the **REFERENCE** version. Provenance `inferred from <milestone>`.
+2. **ELSE the latest `vX.Y.Z` git tag.** Use a cross-platform `git tag` read (plain `git tag` works identically on bash and PowerShell 7+; e.g. `git tag --list 'v*'` then pick the highest semver — keep any sort shell-neutral, do not rely on a shell-specific sort flag). The **reference** version is that tag; the **name** falls back to today's goal-derived name. Provenance `inferred from <tag>`.
+
+**On EITHER infer path:** the inferred/composed title carries the **REFERENCE (highest existing) semver VERBATIM**, and the surfaced plan-file line is **WHERE THE USER ADJUSTS the patch / minor / major bump** — the feeder cannot know whether this milestone is a patch, minor, or major bump, so it proposes the reference version verbatim and lets the user adjust the bump on the surfaced line (`docs/specs/v0.3.1-driver-handoff.md` §2 rung 3). The feeder PROPOSES; it does not silently finalize.
+
+**The resolved exact title always carries the semver INSIDE the title string** — there is no separate version field (`docs/specs/v0.3.1-driver-handoff.md` §2, §10). It lands in the plan file's `Milestone title (exact)` identity field (Step 7; `docs/specs/v0.3.1-driver-handoff.md` §6), with its `Version provenance` line, **both SURFACED for the user to confirm or override BEFORE running `create`** (`docs/specs/v0.3.1-driver-handoff.md` §2, §3). A `"none"` declaration (rung 2) yields a goal-derived name with **no semver** and provenance `declaration`; non-versioned projects are left alone.
 
 ### Step 6 — Self-check gate (the keystone)
 
@@ -265,7 +292,8 @@ Write the reviewable **plan file** to a gitignored per-run scratch path: `.miles
 
 | Field | Requirement |
 |---|---|
-| **Milestone title (exact)** | The exact milestone title, on its own labeled line — **distinct** from the one-line goal. `create` / `update` resolve the milestone by this exact title (creating it if absent, adopting it if it already exists). This is the load-bearing identity field; the one-line goal is descriptive only. |
+| **Milestone title (exact)** | The exact milestone title, on its own labeled line — **distinct** from the one-line goal. Now **user-owned** and carrying the resolved **semver inside the string** (no separate version field), resolved at Step 5.1 by the version ladder and **surfaced for the user to confirm or override BEFORE `create`** (`docs/specs/v0.3.1-driver-handoff.md` §3, §6). `create` / `update` still resolve the milestone by this exact title (creating it if absent, adopting it if it already exists), and the driver parses the version from it — this remains the load-bearing identity field; the one-line goal is descriptive only. |
+| **Version provenance** | One line, one of `explicit` \| `declaration` \| `inferred from <tag/milestone>` \| `prompted` (the Step 5.1 ladder rung that resolved the title — `docs/specs/v0.3.1-driver-handoff.md` §6 "Version provenance" row). It makes the surfaced default **legible** so the user can trust or correct it. |
 | **One-line goal** | The milestone goal in one line — the header. |
 | **Milestone description (Wave order)** | The Step 5 build-order / Wave description, verbatim, with local slugs (`#A`/`#B`). This is what `create` PATCHes onto the milestone after issue numbers exist. |
 | **Per surviving issue** | For each surviving (gate-clean / Advisory-only) issue: its slug, title, the FULL §4 `ISSUE_BODY` verbatim, its labels, and its surface/risk. `create` reads these — no regeneration. |
@@ -274,12 +302,15 @@ Write the reviewable **plan file** to a gitignored per-run scratch path: `.miles
 | **Self-check verdict line** | The Step 6 outcome (PASS / INTERNAL / PARKED / SKIPPED(reviewer:false)). `create` trusts it; no re-vet. |
 | **Source brief reference** | `inline` \| `file:<path>` \| `epic #<n>` — drives the downstream report routing and the brief↔plan match. Record `epicIssueNumber` here when the brief was an epic. |
 
+**Surface the resolved identity for confirm/override.** Both the resolved `Milestone title (exact)` (carrying the semver per the Step 5.1 ladder) **and** its `Version provenance` line are written to the plan file and **surfaced for the user to confirm or override BEFORE running `create`** — `plan` never silently finalizes a milestone identity the user cannot see or change (`docs/specs/v0.3.1-driver-handoff.md` §2, §3, §6). On an infer rung the title carries the **reference version verbatim**, and this surfaced line is **where the user adjusts the patch / minor / major bump** before `create` deploys it.
+
 **Plan-file format.** Write the file in this shape — the **Milestone title (exact)** line is its own labeled field, separate from the goal in the header:
 
 ```markdown
 # Milestone plan — <milestone goal, one line>
 
-Milestone title (exact): <the exact milestone title — create/update resolve the milestone by THIS string>
+Milestone title (exact): <the exact milestone title — carries the resolved semver INSIDE the string; create/update resolve the milestone by THIS string. SURFACED for the user to confirm/override before `create`; on an infer rung it carries the reference version verbatim — adjust the patch/minor/major bump on this line>
+Version provenance: <explicit | declaration | inferred from <tag/milestone> | prompted>
 Self-check: <the Step 6 outcome — one of:
   PASS — all <N> issues GAPS: none (milestone-driver reviewers)
   INTERNAL — all <N> issues GAPS: none (internal checklist; milestone-driver reviewers did not resolve)


### PR DESCRIPTION
Closes #57.

## Summary

Adds a layered, first-match-wins version-resolution ladder to `plan` so the milestone version lands inside the user-owned exact title (the single place the driver parses it from), surfaced in the plan file for confirm/override before `create`. All additive on the v0.3.0 surface; a v0.3.0-style flow with none of the new inputs still works.

Three touch-points in `skills/plan/SKILL.md` (one file):
- **Step 1** captures an optional `milestoneLine` (an up-front `Milestone: <name> vX.Y.Z` line or inline statement) — degrades gracefully when absent.
- **New sub-step 5.1** resolves the exact title + a one-line version provenance via the ladder, first-match-wins:
  1. **explicit** — `milestoneLine` (or a prompted value) used verbatim → provenance `explicit`
  2. **declaration** — `versioning:"none"` → no version, no prompt, goal-derived name → provenance `declaration`; `"semver"` → continue down; absent/invalid → treated as absent, continue (never errors)
  3. **infer** — highest semver among existing milestone titles (reuse the name part) else latest `vX.Y.Z` git tag (goal-derived name) → provenance `inferred from <milestone|tag>`
  4. **prompt** — greenfield only, once; version typed → `prompted`; decline → no version, provenance `declaration`
- **Step 7** gains a `Version provenance` plan-file field and updates the `Milestone title (exact)` field to reflect the user-owned, semver-carrying title surfaced for override before `create`.

The inference rung carries the reference (highest existing) semver **verbatim**; the surfaced plan-file line is where the user adjusts the patch/minor/major bump (`docs/specs/v0.3.1-driver-handoff.md` §2 rung 3) — recorded explicitly so a builder isn't left guessing.

**No-GitHub-write invariant preserved:** inference reads only `git tag` + a read-only `gh api` milestones read (the create-skill `env.t` idiom reused by reference); the greenfield prompt is the only interactive moment. `plan` still writes no GitHub state.

Depends on #56 (the `versioning` key — merged).

## Decision Log

| Choice | Rationale | Citation | Alternatives rejected |
|---|---|---|---|
| Placed the ladder as numbered sub-step `#### 5.1` inside Step 5 | Step 5 builds the milestone title/description context; a `5.x` sub-section keeps Steps 6/7 ordinals and all cross-references intact | in-file `####`-numbered sub-section convention (6.1–6.6) | A new top-level Step (would renumber 6/7, break cross-refs — a deviation) |
| Reused create's `gh api` milestones-read idiom **by reference**, not re-defined | Least-code / reuse-first; the quote-safe `env.t` form is single-source-owned | `skills/create/SKILL.md` Step 3 pass (b); reuse precedent at `skills/update/SKILL.md` | Re-printing the `gh api` block (duplicates a single-source idiom) |
| Noted the one intentional delta (read ALL titles for the highest semver vs match one exact title) | Mirrors how `update` documents its own pass-(b) delta | `skills/update/SKILL.md` | Silent divergence from the cited idiom |
| Captured explicit identity as optional `milestoneLine` (verbatim `<name> vX.Y.Z`) | Additive; a no-`Milestone:`-line brief normalizes as before | `docs/specs/v0.3.1-driver-handoff.md` §3 | A required field (would break the existing ingest contract) |
| Added `Version provenance` to both the contract table and the format block | The user needs it to judge/correct the surfaced default | `docs/specs/v0.3.1-driver-handoff.md` §6 "Version provenance" row | A provenance-less surfaced title (illegible default) |
| Kept the `git tag` read shell-neutral (no shell-specific sort flag) | nonNegotiable: cross-platform bash + PowerShell 7+ | profile `nonNegotiables` | A bash-only sort (breaks PowerShell) |
| DECLINE at the greenfield prompt reuses provenance `declaration` (not a new token) | A decline = "user declared non-versioned" (same meaning as rung-2 `"none"`); avoids widening the legal token set in three enumerations | rung-2 `"none"` model | Minting a 5th token (would require editing all three token enumerations) |
| Rung-4 "version typed" stamps `prompted` via rung 1's verbatim-into-title **mechanic only**, not its provenance | Routing "through rung 1" would mis-stamp `explicit` on a prompted value | code-review finding (cycle 1) | Leaving the contradiction (mislabels a prompted version) |
| Fix-1 cited the Non-negotiables **section by name**, not a numeric anchor | The ladder insertions shifted the section; a numeric anchor would just go stale again | code-review finding (cycle 1) | A new numeric self-anchor (re-staleable) |

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review)
- **Cycle 1** — Findings: 4 in-scope finding(s) at high (xhigh) effort
  - Stale `:341` self-anchor (insertions shifted the Non-negotiables section) → re-dispatched and resolved (now cites the section by name + the stable `:10` anchor)
  - Rung-4 "routed through rung 1's verbatim use" → provenance contradiction (`explicit` vs `prompted`) → re-dispatched and resolved (borrows only the title mechanic; stamps `prompted`)
  - Rung-4 "DECLINE → no version" had no defined provenance/title terminus → re-dispatched and resolved (mirrors rung-2 `"none"`: goal-derived name, provenance `declaration`, STOPS)
  - Declared-`semver`-but-prompted provenance legibility → re-dispatched and resolved (one-line legibility note distinguishing where `declaration` vs `prompted` apply)
- **Cycle 2** (re-review after fixes, the last action before commit) — Findings: 0 at high (xhigh) effort. Ladder terminates on every path; provenance token set byte-identical across all three enumerations; all citation anchors resolve; downstream create/update parse contract unchanged.
- No park-triggering findings.
- Version: version-bump only — no logic change (idempotent no-op; `.claude-plugin/plugin.json` already at the milestone target 0.3.1).

## Verification (no test layer)

This is a markdown procedure spec; the profile defines no `unitTestCmd` (and the issue touches no UI → no E2E). Verified by re-reading the edited procedure end-to-end and checking each acceptance criterion against the exact added lines (full trace in the implementer report). Both CI PR gates pass locally: vocabulary-purge (no retired tokens) and plugin-structure. The ladder is first-match-wins and terminates on every path; the semver always lands inside the title; the no-GitHub-write invariant holds (only read-only `git tag` + `gh api` reads added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)