### PR TITLE
docs: bring canonical docs + metadata to the v0.3.1 surface (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.3.1 — Explicit milestone naming & the driver handoff
+
+**Theme:** v0.3.0 made the surface speak the user's language; v0.3.1 makes the
+**handoff to `milestone-driver` clean.** The driver derives its target version by
+parsing the milestone title for a semver — but a feeder-made milestone carried no
+version, silently degrading the driver to "no version → prompt the user." v0.3.1
+closes that gap by making **milestone identity explicit and user-owned, with the
+semver living in the milestone title** where the driver reads it. It also lets
+`update` find and rename the right milestone after a title change, and stops the
+feeder being silent when a brief is really several milestones. **This release is
+additive — nothing breaks.** No command or config changes; one new *optional*
+config key and new (optional) plan-file fields. A v0.3.0 plan file with none of
+the new fields still works — the new paths degrade gracefully.
+
+### ✨ Versioned milestone naming (#50)
+
+| Issue | What |
+|---|---|
+| #50 | The milestone title becomes a **user-owned field carrying the semver inside it** (e.g. `myapp v1.2.0`) — there is no separate version field, because the driver parses the version from the title. State the title up front (inline or a `Milestone: <name> vX.Y.Z` line in the brief), or let `plan` resolve a default by a **layered, first-match-wins ladder**: explicit → the project's `versioning` declaration → inference (the highest semver among existing milestone titles, else the latest `vX.Y.Z` git tag) → a one-time prompt only when nothing is inferable. The resolved title and a one-line **version provenance** (`explicit` / `declaration` / `inferred from <tag/milestone>` / `prompted`) are surfaced in the plan file for confirm/override before `create` — `plan` never silently invents an identity. A `"none"` declaration adds no version and never prompts. |
+
+### ✨ `update` retargeting + bounded rename-in-place (#51)
+
+| Issue | What |
+|---|---|
+| #51 | Because identity is now the explicit title, `update` resolves the **source plan** by the brief slug but the **target milestone** by identity — so a revised plan in a *new* brief reconciles onto its existing milestone. To survive a title change, `create` writes the GitHub milestone number back into the plan file as a **deploy receipt** (`Milestone number (GitHub): <n>`); `update` resolves **by that number first** (falling back to title-match when absent), and when it resolved by number and the plan's title differs, it **PATCHes the new title** — the single bounded way `update` mutates a milestone's identity. A wholesale new brief + new title + no receipt → no title match → **error-and-stop directing you to `create`**, with the one-line `gh` rename command for the rare true-rename case. `plan` carries the receipt forward on re-plan so the handle isn't stranded. Resolving by the stable number also hardens every non-rename `update`. |
+
+### ✨ The multi-milestone guardrail (advisory, non-blocking)
+
+| Issue | What |
+|---|---|
+| (guardrail) | The feeder stays **one brief → one milestone**, but stops being silent about a brief that's really several. When a brief reads as distinct phased deliverables / release boundaries, the architect raises a `SCOPE_SPANS_MULTIPLE_MILESTONES` signal with a proposed split (the candidate milestones and which issues fall under each). `plan` still writes a **deployable single-milestone plan** but **prominently flags** *"this looks like ~N milestones"* and shows the split, surfaced up front alongside the versioning step. Never a hard block, never a silent giant milestone — the user decides whether to deploy the one milestone or split the brief and re-run. Full `brief → N-milestones` decomposition is deferred to v0.4.0. |
+
+### ✨ The optional `versioning` config key
+
+| Issue | What |
+|---|---|
+| (config) | A new **optional** key in `.milestone-config/feeder.json` (no file rename). `versioning` answers only the *is-this-versioned* question — the version *number* comes from the layered ladder. Three-way: `"semver"` = version every milestone; `"none"` = non-versioned project, never add a version or prompt; **absent** = infer from repo signals (existing milestone titles, then git tags), else ask once at plan time. Forward-compatible with a future bootstrapper that will write this key at scaffold time. Defined in `docs/profile-schema.md` and offered by `setup` as an optional key (skip-consequence stated). |
+
+### Consumer notes
+
+- **This is an additive release.** Nothing breaks — same commands, same config
+  file. The new `versioning` key is optional, and a v0.3.0 plan file still works.
+- **Name your milestone with a version up front** (inline or a `Milestone: <name>
+  vX.Y.Z` line in your brief) so the driver builds toward the right version. Skip
+  it and the feeder proposes one from your existing milestones or git tags and
+  shows it to you before building anything.
+- **`update` finds the right milestone even after a rename.** It resolves by the
+  milestone number `create` recorded, falling back to the title — and renames in
+  place when your plan's title changed. A brand-new brief with a new title stops
+  and points you at `create`.
+- **The feeder flags a brief that looks like several milestones** — advisory only.
+  It still builds one milestone; the split is yours to make.
+
 ## v0.3.0 — Humanize the surface
 
 **Theme:** v0.2.0 works, but everything a user typed or read spoke in

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ That check is the guardrail. Two parts, in plain terms:
 
 The richer your project docs, the better the issues and the fewer decisions land back on your plate. Nothing here is new machinery — it's the grounding and the check, described in plain terms.
 
+Two more things the feeder does for you:
+
+- **Name your milestone with a version up front.** Add a line like `Milestone: myapp v1.2.0` to your brief (or just say it inline). The feeder reads the version straight from the milestone's name so its sibling, `milestone-driver`, knows exactly what version to build toward. If you don't name one, the feeder proposes a version — pulled from your existing milestones or git tags — and shows it to you to confirm or change before it builds anything. You're never handed a milestone whose name you didn't get to see.
+- **It flags a brief that looks like several milestones.** If your idea really reads as a few separate releases, the feeder still builds one milestone — but it tells you up front, "this looks like ~N milestones," and shows you how it would split them, so you can break the brief up and re-run if you want. Never a silent giant milestone, and never a hard stop — the call is yours.
+
 ## Config
 
 Configuration is **optional** — every setting has a sensible default, so the tool runs with no config at all. When you do want to tune it, the settings live in `.milestone-config/feeder.json` (the same folder `milestone-driver` keeps its `driver.json` in). The first `plan` run writes this file for you.
@@ -86,7 +91,7 @@ Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every 
 
 ## Status
 
-v0.3.0 — the surface speaks your language: `plan` to draft, `create` to build, `update` to sync. Self-hosted: the feeder was planned as its own milestone and built by milestone-driver.
+v0.3.1 — name your milestone with a version up front and the feeder hands it cleanly to `milestone-driver`: explicit, versioned milestone naming; `update` finds and renames the right milestone even after a title change; and a heads-up when your brief looks like several milestones. Self-hosted: the feeder was planned as its own milestone and built by milestone-driver.
 
 ## Docs
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,8 +1,8 @@
-# milestone-feeder — as-built spec (v0.3.0)
+# milestone-feeder — as-built spec (v0.3.1)
 
 A Claude Code plugin that turns a feature brief into a **GitHub milestone + small, well-formed issues** that `milestone-driver` can build with no human clarification. The direct predecessor of the driver.
 
-Sibling of `milestone-driver`, same design DNA (see the suite plan: [`../dev-tools/SUITE-PLAN.md`](../dev-tools/SUITE-PLAN.md) §1). Separate plugin, separate config. Status: **as-built spec for v0.3.0** — the live surface (verbs `plan` / `create` / `update` / `setup`, no flags, plan-file-as-contract).
+Sibling of `milestone-driver`, same design DNA (see the suite plan: [`../dev-tools/SUITE-PLAN.md`](../dev-tools/SUITE-PLAN.md) §1). Separate plugin, separate config. Status: **as-built spec for v0.3.1** — the live surface (verbs `plan` / `create` / `update` / `setup`, no flags, plan-file-as-contract), now with **user-owned, versioned milestone identity** (the semver lives in the milestone title), **`update` retargeting by deploy receipt + bounded rename-in-place**, and a **non-blocking multi-milestone advisory**.
 
 Decisions already locked: name `milestone-feeder`; config at `.milestone-config/feeder.json`; separate plugin in its own repo (suite/marketplace linkage deferred). Decisions taken as sensible defaults below are marked **Decision (default)** — veto any.
 
@@ -70,7 +70,10 @@ The plan file MUST carry, unambiguously, every field below:
 
 | Field | Why `create` / `update` need it |
 |---|---|
-| **Milestone title (exact)** + one-line goal | The **identity field**: `create` / `update` resolve the milestone by this exact title (create-or-adopt). Distinct from the one-line goal, which is descriptive only. |
+| **Milestone title (exact)** + one-line goal | The **identity field**: `create` / `update` resolve the milestone by this exact title (create-or-adopt). Now **user-owned and carrying the semver** — the version lives inside this one title string (there is no separate version field), and the driver parses the version from it. Distinct from the one-line goal, which is descriptive only. |
+| **Milestone number (GitHub):** `<n>` — the deploy receipt | The stable handle for `update`: `create` writes it post-deploy; `plan` preserves it on re-plan; `update` resolves the milestone by it (surviving a title change) and renames on a title diff. Additive — a plan file lacking it still parses. |
+| **Version provenance** (one line: `explicit` \| `declaration` \| `inferred from <tag/milestone>` \| `prompted`) | Records which ladder rung resolved the title (§7) so the surfaced default is legible — the user can trust or correct it. |
+| **Multi-milestone advisory** — the `SCOPE_SPANS_MULTIPLE_MILESTONES` flag + proposed split, when raised | Surfaces the guardrail when a brief reads as several milestones. Additive / optional; present only when raised, and **does not change what gets deployed** (the plan stays a deployable single milestone). |
 | **Milestone description** (Wave / build order, local slugs `#A`/`#B`) | The wave-encoded description to PATCH onto the milestone after issue numbers exist. |
 | **Per surviving issue** — slug, title, the FULL §4 body verbatim, labels, surface/risk | The issues to create / patch — verbatim, **no regeneration**. |
 | **Parked issues** — slug, title, kind (`product-gap` \| `needs-human-direction`) | Marked, **never created.** Routed to the needs-input report. |
@@ -83,6 +86,16 @@ The plan file MUST carry, unambiguously, every field below:
 Issue numbers don't exist until creation, so the plan file carries **local slugs** (`#A`/`#B`) throughout. The load-bearing two-pass slug→`#n` rewrite happens when `create` / `update` write to GitHub — once the issues exist and the slug→`#n` map is complete. `plan` itself does no rewrite.
 
 **What changed from v0.2.0 is ONLY the source** of the issue bodies / labels / waves: they are now **read from the plan file, not regenerated.** The write sequence (label ensure, create-or-adopt, two-pass slug→`#n`, report routing) is unchanged.
+
+### v0.3.1 — user-owned versioned identity, `update` retargeting, the multi-milestone guardrail
+
+v0.3.1 is an **additive** release on this surface — no command or config breaks, the new plan-file fields above degrade gracefully (a v0.3.0 plan file lacking them still parses), and the change is in **where a milestone's identity comes from and how the family carries it**, not in the `plan → create → update` pipeline. Three behaviors:
+
+- **User-owned, versioned milestone identity.** The milestone title is now a **user-owned field** carrying the **semver inside it** (e.g. `myapp v1.2.0`) — there is **no separate version field**, because the driver derives its target version by parsing the milestone title for a semver. The user can state the title up front (inline or as a `Milestone: <name> vX.Y.Z` line in the brief); if they don't, `plan` resolves a default by a **layered, first-match-wins ladder** — *explicit* up front → the project's `versioning` declaration (§7) → *inference* from the highest semver among existing milestone titles, else the latest `vX.Y.Z` git tag → a one-time *prompt* only when nothing is inferable. The resolved title and a one-line **version provenance** are **surfaced in the plan file for confirm/override before `create`** — `plan` never silently invents an identity the user can't see or change. A `"none"` declaration means no version and no prompt; non-versioned projects are left alone.
+
+- **`update` retargeting + bounded rename-in-place.** Because identity is now the explicit title (not a goal-derivative), `update` resolves the **source plan** by the brief slug but the **target milestone** by the identity — so a revised plan in a new brief file reconciles onto its existing milestone. To survive a title change, `create` writes the GitHub milestone number back into the plan file as a **deploy receipt** (`Milestone number (GitHub): <n>`); `update` resolves **by that number first** (falling back to title-match when absent), and when it resolved by number and the plan's title differs, it **PATCHes the new title** — the single bounded way `update` mutates a milestone's identity. A wholesale new brief with a new title and no receipt → title-match → no match → **error-and-stop directing you to `create`**, with the one-line `gh` rename command for the rare true-rename case. `plan` carries the receipt forward on re-plan so the handle isn't stranded.
+
+- **The multi-milestone guardrail (advisory, non-blocking).** The feeder stays **one brief → one milestone**, but stops being silent about a brief that's really several. When a brief reads as distinct phased deliverables / release boundaries, the architect raises `SCOPE_SPANS_MULTIPLE_MILESTONES` with a proposed split; `plan` still writes a **deployable single-milestone plan** but **prominently flags** *"this looks like ~N milestones"* and shows the split, surfaced up front alongside the versioning step. **Never a hard block, never a silent giant milestone** — the user decides whether to deploy the one milestone or split the brief and re-run. Full `brief → N-milestones` decomposition is deferred to v0.4.0.
 
 ---
 
@@ -165,13 +178,13 @@ Before writing the plan file, **`plan`** dispatches the driver's own `triage-rev
 | 2 | **Product-gap check** (the flag boundary): separate product decisions (no conventional default) from design/implementation decisions (resolvable from project docs/convention). Product gaps are recorded, not guessed. |
 | 3 | Dispatch the **`architect`** agent **once**: candidate issue set (small, independently-buildable, ~one PR each) + dependency edges + Wave order. |
 | 4 | Dispatch the **`issue-author`** agent **per candidate** (parallelizable) → full spec to §4. |
-| 5 | Assemble the dependency graph; render the milestone description (§4) with local slugs. |
+| 5 | Resolve the **milestone identity** — the user-owned exact title carrying the semver, by the v0.3.1 layered ladder (explicit → declaration → inference → prompt; §3.1), with its version provenance; assemble the dependency graph; render the milestone description (§4) with local slugs. |
 | 6 | **Self-check** (§5): iterate to clean (≤2 retries per issue) or flag product gaps. |
-| 7 | **Write the plan file** (`.milestone-feeder/plan-<slug>.md`) — the build artifact (§3.1), plus the needs-input report when anything was parked. No GitHub writes. |
+| 7 | **Write the plan file** (`.milestone-feeder/plan-<slug>.md`) — the build artifact (§3.1), plus the needs-input report when anything was parked; **surface the resolved identity (title + provenance) for confirm/override**, and the multi-milestone advisory **when raised**, before `create`; **carry forward** an existing deploy receipt on re-plan. No GitHub writes. |
 
-**Then `create` deploys the plan file** (faithful — the §6 apply write sequence): ensure labels → create-or-adopt the milestone by exact title → create the surviving issues + build the slug→`#n` map → second-pass slug→`#n` rewrite (issue bodies + the milestone description) → file the needs-input report (epic comment when the brief was an epic; else local file). On the found path it dispatches no agent and re-runs no gate.
+**Then `create` deploys the plan file** (faithful — the §6 apply write sequence): ensure labels → create-or-adopt the milestone by exact title → create the surviving issues + build the slug→`#n` map → second-pass slug→`#n` rewrite (issue bodies + the milestone description) → file the needs-input report (epic comment when the brief was an epic; else local file). On the found path it dispatches no agent and re-runs no gate. After the milestone is resolved, `create` **writes the deploy receipt** (`Milestone number (GitHub): <n>`) back into the plan file — the stable handle `update` later resolves by (a back-write failure is a reported notice, never a blocked deploy, since the plan file is gitignored scratch).
 
-**And `update` reconciles it** onto an existing milestone (create-or-patch / add-edge-and-re-render / flag-never-close / no-op): create any plan issue missing on GitHub, patch any drifted body (showing the diff first), add any new dependency edge and re-render the build order, and **flag** — never close — any live issue the plan no longer carries. A fully-synced milestone is a true no-op.
+**And `update` reconciles it** onto an existing milestone (create-or-patch / add-edge-and-re-render / flag-never-close / no-op): it resolves the milestone **by the deploy-receipt number first** (falling back to exact-title when absent) and, when resolved by number with a changed plan title, **renames the milestone in place** (a single bounded title PATCH) before reconciling; then create any plan issue missing on GitHub, patch any drifted body (showing the diff first), add any new dependency edge and re-render the build order, and **flag** — never close — any live issue the plan no longer carries. A wholesale new brief with a new title and no receipt → no title match → **error-and-stop directing you to `create`**, with the one-line `gh` rename command for the rare true-rename case. A fully-synced milestone is a true no-op.
 
 There are **no flags** anywhere: `plan` previews (writes the plan file), `create` / `update` write — each *is* its own verb.
 
@@ -185,6 +198,7 @@ Thin and consumer-driven, same discipline as the driver: new keys only when a re
 |---|---|---|---|
 | `projectDocs` | string | `.project/` | Where the project's standing docs live. |
 | `reviewer` | `"milestone-driver" \| "internal" \| false` | `"milestone-driver"` | Who checks each issue before it's created; `false` = off. |
+| `versioning` | `"semver" \| "none"` | *(none)* — absent is a distinct "infer-or-ask" state | Whether this project is semver-versioned; drives milestone-version resolution at plan time (three-way: `"semver"` = version every milestone, `"none"` = never add a version or prompt, **absent** = infer from repo signals else prompt). |
 | `issueSize` | string | *(none)* | Optional natural-language sizing rule (e.g. "≤1 PR, ≤1 new screen"). |
 | `architectAgent` | string | `milestone-feeder:architect` | Override the breakdown (architect) agent. |
 | `issueAuthorAgent` | string | `milestone-feeder:issue-author` | Override the authoring agent. |

--- a/docs/consumer-setup.md
+++ b/docs/consumer-setup.md
@@ -48,8 +48,8 @@ You can also run `/milestone-feeder:setup` directly at any time to create or rep
 the profile.
 
 **Manual authoring (fallback).** Create `.milestone-config/feeder.json` by hand —
-see [`profile-schema.md`](profile-schema.md) for the full key reference. Every
-own-key has a bundled default, so omit any key you do not override (absent-means-
+see [`profile-schema.md`](profile-schema.md) for the full key reference. Most keys
+have a bundled default, so omit any key you do not override (absent-means-
 default); a minimal profile carries only what diverges. Commit it so every clone
 and CI has the same `no-source-edit` behavior. Minimal example:
 
@@ -57,6 +57,26 @@ and CI has the same `no-source-edit` behavior. Minimal example:
 {
   "projectDocs": ".project/",
   "reviewer": "milestone-driver"
+}
+```
+
+**The optional `versioning` key.** `versioning` tells the feeder whether your
+project uses version numbers. Set it to `"semver"` if your project is versioned
+(every milestone gets a version), or `"none"` if it isn't (no version is ever
+added and you're never asked). It is **optional** — like `reviewer`, you can leave
+it out, and the feeder degrades gracefully: **if you skip it, the feeder figures
+out whether you version by looking at your repo** — your existing milestone titles
+first, then your git tags — and only **asks you once at plan time** if it can't
+tell. So skipping it costs you nothing on a repo that already has versioned
+milestones or `vX.Y.Z` tags; on a brand-new repo with neither, you'll get one
+quick question the first time you plan. Set it explicitly to skip even that
+question:
+
+```json
+{
+  "projectDocs": ".project/",
+  "reviewer": "milestone-driver",
+  "versioning": "semver"
 }
 ```
 


### PR DESCRIPTION
Closes #62.

Documents the already-built v0.3.1 behaviors (issues #56–#61, merged on `develop`) across the release-layer docs, per the design-spec §9 ownership split (the docs-sweep half). Additive only — no logic, skills, agents, or hooks touched.

## What changed
- **`SPEC.md`** — §3.1 "Fields a consumer parses" table gains three additive rows (deploy-receipt number, version provenance, multi-milestone advisory); the existing "Milestone title (exact)" row note now states the title is user-owned and carries the semver. §7 config-schema table gains a `versioning` row. New narrative: user-owned versioned identity, `update` resolve-by-number + bounded rename-in-place, the non-blocking multi-milestone guardrail; as-built version designation → v0.3.1 (historical refs left intact).
- **`README.md`** — How it works gains "name your milestone with a version up front" (and why: the driver reads the version from the title) and the several-milestones heads-up; `## Status` → v0.3.1.
- **`docs/consumer-setup.md`** — the optional `versioning` key + its skip-consequence, in consumer terms, mirroring the optional-`reviewer` treatment.
- **`CHANGELOG.md`** — additive v0.3.1 entry above v0.3.0, mirroring its heading format exactly.
- **`.claude-plugin/plugin.json`** — already at `0.3.1` (a prior issue in the run bumped it); empty-delta no-op, left byte-unchanged.

## Decision Log
- **CHANGELOG theme "Explicit milestone naming & the driver handoff"** → matches the design-spec title verbatim so release notes and spec speak one vocabulary (`docs/specs/v0.3.1-driver-handoff.md:1`). Alternative rejected: inventing a fresh theme (would diverge from the cited spec).
- **Guardrail + `versioning` CHANGELOG rows use `(guardrail)` / `(config)` in the Issue column** rather than a number → the design spec attributes these to "new issue"/"the config-key issue", not #50/#51; avoids asserting an unverified issue cross-reference. Alternative rejected: guessing issue numbers (risks a fabricated reference).
- **README/consumer-setup use the example line `Milestone: myapp v1.2.0`** → matches the design-spec's own example (`docs/specs/v0.3.1-driver-handoff.md:103`).
- **`versioning` skip-consequence framed like `reviewer`'s "degrades gracefully"** → per the issue's explicit instruction to mirror the optional-`reviewer` treatment; grounding `docs/profile-schema.md:42`.
- **SPEC §7 `versioning` Default cell** = "*(none)* — absent is a distinct 'infer-or-ask' state" → matches `docs/profile-schema.md:51` three-way semantics in SPEC's table style (`docs/specs/v0.3.1-driver-handoff.md:224`).
- **Kept SPEC §9 "bump to v0.3.0" and the "from v0.2.0" line unchanged** → both are genuinely historical as-built records, explicitly carved out by the issue and design-spec §9.
- **consumer-setup "Every own-key has a bundled default" → "Most keys have a bundled default"** → necessary factual fix: `versioning` is the one own-key with no bundled default (`docs/profile-schema.md:33-35,41-42`).

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at medium effort
  - Factual accuracy (every documented claim verified against the merged source: ladder order, provenance values, inference sub-order, `versioning` three-way default, deploy-receipt field name, `update` resolve-by-number + bounded rename, advisory-not-block guardrail) → none
  - Conventions / writing-for-humans (no internal jargon leaked into README/consumer-setup; SPEC/CHANGELOG correctly use spec-layer terms) → none
  - Removed-behavior (all ~10 deletions are faithful in-place rewrites; the "Every own-key"→"Most keys" fix is correct and necessary) → none
  - Consistency (CHANGELOG heading parses as a standard version entry, additive, above v0.3.0; markdown well-formed; SPEC/README/CHANGELOG agree on all three behaviors) → none
- No park-triggering findings.
- Version-bump annotation: version-bump only — no logic change (plugin.json already at 0.3.1, empty-delta no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)