### PR TITLE
fix(hooks): make no-source-edit gate actor-aware so the driver builds the feeder without the blanket override (#63)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/hooks/no-source-edit.ps1
+++ b/hooks/no-source-edit.ps1
@@ -1,11 +1,26 @@
 #!/usr/bin/env pwsh
 # milestone-feeder — no-source-edit gate (Claude PreToolUse: Write|Edit|MultiEdit|NotebookEdit)
 #
-# Unconditionally blocks edits to the feeder's own source globs. The feeder
-# reads code and authors issue text — it never writes source — so the deny
-# applies in ANY context (no subagent carve-out). The orchestrator keeps
-# /docs/, /.claude/, and /Obsidian/ paths (plus any file outside sourceGlobs)
-# editable; files matching sourceGlobs are gated even when markdown.
+# Blocks edits to the feeder's own source globs. The feeder reads code and
+# authors issue text — it never writes source. The deny applies to the feeder's
+# OWN actors (the main thread and the feeder's own subagents); a positively-
+# identified non-feeder subagent (e.g. the driver's implementer building the
+# feeder) is allowed through. The orchestrator keeps /docs/, /.claude/, and
+# /Obsidian/ paths (plus any file outside sourceGlobs) editable; files matching
+# sourceGlobs are gated even when markdown.
+#
+# Actor gate (PreToolUse hooks carry no skill/plugin identity, only the agent
+# fields below — code.claude.com/docs/en/hooks.md):
+#   - agent_id is present ONLY inside a subagent call; absent => main thread.
+#   - agent_type is the subagent's BARE frontmatter `name` (NOT namespaced); for
+#     custom subagents it is "the `name` field from the agent's frontmatter, not
+#     the filename".
+# Decision (only when the target matches a source glob):
+#   BLOCK  when there is no agent_id (main thread) OR agent_type is one of the
+#          feeder's OWN agents ($FeederOwnAgents below) — fail-closed: an
+#          unknown/empty agent_type with an agent_id present also blocks.
+#   ALLOW  when agent_id is present AND agent_type is a positively-identified
+#          non-feeder subagent.
 #
 # Deny mechanism: exit 2 + stderr (stable across current Claude Code).
 # Deny globs: <repo>/.milestone-config/feeder.json first, then the resolved
@@ -13,7 +28,17 @@
 #   First file with a non-empty sourceGlobs wins; none -> fail-open.
 # Escape hatch: CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1
 #
-# Fail-open: any parse/IO error exits 0 so a hook bug never bricks editing.
+# Fail-open: any parse/IO error / unresolved sourceGlobs exits 0 so a hook bug
+# never bricks editing.
+
+# The feeder's OWN agent names (bare frontmatter `name`, NOT namespaced). This is
+# a SECURITY control, so the set is HARDCODED here inside the protected hooks/**
+# boundary rather than read from feeder.json. It MUST stay in sync with the
+# `name:` of every agents/*.md — enforced by the CI drift-guard in
+# scripts/validate-plugin-structure.py. Machine-parseable literal (one
+# space-separated set on the next line; keep that exact shape for the guard):
+# FEEDER_OWN_AGENTS: architect issue-author
+$FeederOwnAgents = @('architect', 'issue-author')
 
 if ($env:CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT -eq '1') { exit 0 }
 
@@ -27,10 +52,18 @@ if (-not $filePath) { $filePath = $hook.tool_input.notebook_path }
 if (-not $filePath) { exit 0 }
 $norm = ([string]$filePath) -replace '\\', '/'
 
-# Always-exempt: docs, .claude config, Obsidian vaults. Source globs are gated even when markdown.
-if ($norm -match '/docs/')    { exit 0 }
-if ($norm -match '/\.claude/'){ exit 0 }
-if ($norm -match '/Obsidian/'){ exit 0 }
+# Actor identity (see header). $hasAgentId distinguishes an absent agent_id (main
+# thread) from a present one; $agentType is a plain string so a missing/empty
+# value compares unequal to every name in $FeederOwnAgents.
+$hasAgentId = $null -ne $hook.agent_id -and "$($hook.agent_id)" -ne ''
+$agentType = [string]$hook.agent_type
+
+# Always-exempt: docs, .claude config, Obsidian vaults. Source globs are gated
+# even when markdown. Case-SENSITIVE (-cmatch) to match bash's case-sensitive
+# `case` path exemptions.
+if ($norm -cmatch '/docs/')    { exit 0 }
+if ($norm -cmatch '/\.claude/'){ exit 0 }
+if ($norm -cmatch '/Obsidian/'){ exit 0 }
 
 # Resolve project dir.
 $projectDir = $hook.cwd
@@ -58,8 +91,18 @@ if ($norm.StartsWith("$projectDir/")) { $rel = $norm.Substring($projectDir.Lengt
 
 foreach ($g in $globs) {
     $pattern = ([string]$g) -replace '\\', '/'
-    $pattern = $pattern -replace '\*\*', '*'   # ** -> * ; PowerShell -like '*' already crosses '/'
-    if (($rel -like $pattern) -or ($norm -like "*/$pattern")) {
+    $pattern = $pattern -replace '\*\*', '*'   # ** -> * ; PowerShell -clike '*' already crosses '/'
+    # Case-SENSITIVE (-clike) to match bash's case-sensitive `case` glob match.
+    if (($rel -clike $pattern) -or ($norm -clike "*/$pattern")) {
+        # Source-glob match. Apply the actor gate: ALLOW only a positively-
+        # identified non-feeder subagent (agent_id present AND a non-empty
+        # agent_type that is not one of the feeder's own agents). The main thread
+        # (no agent_id), the feeder's own subagents, and any ambiguous actor
+        # (agent_id present but empty agent_type) all fall through and are
+        # BLOCKED — fail-closed.
+        if ($hasAgentId -and $agentType -ne '' -and ($FeederOwnAgents -cnotcontains $agentType)) {
+            exit 0   # positively-identified non-feeder subagent
+        }
         [Console]::Error.WriteLine("milestone-feeder: edits to source ('$rel') are blocked — the feeder authors no code. Set CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1 to override.")
         exit 2
     }

--- a/hooks/no-source-edit.sh
+++ b/hooks/no-source-edit.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 # milestone-feeder — no-source-edit gate (Claude PreToolUse: Write|Edit|MultiEdit|NotebookEdit)
 #
-# Bash parity of no-source-edit.ps1. Unconditionally blocks edits to the
-# feeder's own source globs — the feeder reads code and authors issue text, it
-# never writes source, so the deny applies in ANY context (no subagent
-# carve-out). Requires `jq`.
+# Bash parity of no-source-edit.ps1. Blocks edits to the feeder's own source
+# globs — the feeder reads code and authors issue text, it never writes source.
+# The deny applies to the feeder's OWN actors (the main thread and the feeder's
+# own subagents); a positively-identified non-feeder subagent (e.g. the driver's
+# implementer building the feeder) is allowed through. Requires `jq`.
+#
+# Actor gate (PreToolUse hooks carry no skill/plugin identity, only the agent
+# fields below — code.claude.com/docs/en/hooks.md):
+#   - agent_id is non-empty ONLY inside a subagent call; absent or empty => main
+#     thread (matches ps1's $hasAgentId test).
+#   - agent_type is the subagent's BARE frontmatter `name` (NOT namespaced); for
+#     custom subagents it is "the `name` field from the agent's frontmatter, not
+#     the filename".
+# Decision (only when the target matches a source glob):
+#   BLOCK  when there is no (or empty) agent_id (main thread) OR agent_type is one
+#          of the feeder's OWN agents (FEEDER_OWN_AGENTS below) — fail-closed: an
+#          unknown/empty agent_type with an agent_id present also blocks.
+#   ALLOW  when agent_id is non-empty AND agent_type is a positively-identified
+#          non-feeder subagent.
 #
 # Deny mechanism: exit 2 + stderr. Escape hatch: CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1
-# Fail-open: missing jq / parse errors exit 0 so a hook bug never bricks editing.
+# Fail-open: missing jq / parse errors / unresolved sourceGlobs exit 0 so a hook
+# bug never bricks editing.
+
+# The feeder's OWN agent names (bare frontmatter `name`, NOT namespaced). This is
+# a SECURITY control, so the set is HARDCODED here inside the protected hooks/**
+# boundary rather than read from feeder.json. It MUST stay in sync with the
+# `name:` of every agents/*.md — enforced by the CI drift-guard in
+# scripts/validate-plugin-structure.py. Machine-parseable literal (one
+# space-separated set on the next line; keep that exact shape for the guard):
+# FEEDER_OWN_AGENTS: architect issue-author
+FEEDER_OWN_AGENTS="architect issue-author"
 
 [ "${CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT:-}" = "1" ] && exit 0
 
@@ -18,6 +43,14 @@ command -v jq >/dev/null 2>&1 || exit 0
 file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null)"
 [ -z "$file_path" ] && exit 0
 norm="${file_path//\\//}"
+
+# Actor identity (see header). An absent OR empty-string agent_id is the main
+# thread (BLOCK on a source path) — matching ps1's `$hasAgentId` test; `// empty`
+# collapses both to "", so a non-empty agent_id positively marks a subagent.
+# agent_type stays a plain string so a missing/empty value compares unequal to
+# every name in FEEDER_OWN_AGENTS.
+agent_id="$(printf '%s' "$input" | jq -r '.agent_id // empty' 2>/dev/null)"
+agent_type="$(printf '%s' "$input" | jq -r '.agent_type // empty' 2>/dev/null)"
 
 # Always-exempt paths. Source globs are gated even when markdown.
 case "$norm" in
@@ -60,6 +93,18 @@ while IFS= read -r g; do
   # shellcheck disable=SC2254
   case "$norm" in */$pat)  blocked=1 ;; esac
   if [ "$blocked" = "1" ]; then
+    # Source-glob match. Apply the actor gate: ALLOW only a positively-identified
+    # non-feeder subagent (a non-empty agent_id AND a non-empty agent_type that is
+    # not one of the feeder's own agents). The main thread (absent OR empty
+    # agent_id), the feeder's own subagents, and any ambiguous actor (agent_id
+    # present but empty agent_type) all fall through and are BLOCKED — fail-closed.
+    if [ -n "$agent_id" ] && [ -n "$agent_type" ]; then
+      is_own_agent=0
+      for own in $FEEDER_OWN_AGENTS; do
+        [ "$agent_type" = "$own" ] && is_own_agent=1 && break
+      done
+      [ "$is_own_agent" = "0" ] && exit 0   # positively-identified non-feeder subagent
+    fi
     echo "milestone-feeder: edits to source ('$rel') are blocked — the feeder authors no code. Set CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1 to override." >&2
     exit 2
   fi

--- a/scripts/validate-plugin-structure.py
+++ b/scripts/validate-plugin-structure.py
@@ -38,6 +38,7 @@ Exit 0 = valid. Exit 1 = at least one structural problem (each printed).
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -185,6 +186,8 @@ for skill_md in sorted((REPO_ROOT / "skills").rglob("SKILL.md")):
         require_keys(skill_md, fm, ["name", "description"])
 
 # Agents: every agents/**/*.md (recursive) — require name + description.
+# Also collect each agent's `name` for the no-source-edit drift-guard below.
+agent_names: list[str] = []
 agents_dir = REPO_ROOT / "agents"
 if agents_dir.is_dir():
     for agent_md in sorted(agents_dir.rglob("*.md")):
@@ -192,6 +195,9 @@ if agents_dir.is_dir():
         fm = parse_frontmatter(agent_md)
         if fm is not None:
             require_keys(agent_md, fm, ["name", "description"])
+            name = str(fm.get("name", "")).strip()
+            if name:
+                agent_names.append(name)
 
 # Commands: every commands/**/*.md (recursive) — require description only
 # (a command's name is derived from its filename). None exist today.
@@ -202,6 +208,134 @@ if commands_dir.is_dir():
         fm = parse_frontmatter(cmd_md)
         if fm is not None:
             require_keys(cmd_md, fm, ["description"])
+
+# --- 4: no-source-edit actor-gate drift-guard -------------------------------
+#
+# Why this exists: hooks/no-source-edit.{sh,ps1} carry a HARDCODED set of the
+# feeder's OWN agent names. That set is a security control — it must live inside
+# the protected hooks/** boundary, NOT be read from feeder.json — so it cannot be
+# auto-derived at runtime. This guard prevents the safety-relevant drift: if
+# someone adds or renames an agents/*.md without updating the hooks, that agent
+# would be MISSING from the hook set, so the gate would mis-classify it (treating
+# a feeder subagent as an outside actor and letting it write source).
+#
+# Each hook carries the set TWICE and the two must agree:
+#   1. A machine-parseable COMMENT literal:  # FEEDER_OWN_AGENTS: <name> <name>
+#      (identical text in both scripts; one regex parses it for sh and ps1).
+#   2. The RUNTIME literal the hook actually executes — language-specific:
+#        sh:   FEEDER_OWN_AGENTS="architect issue-author"   (space-separated)
+#        ps1:  $FeederOwnAgents = @('architect', 'issue-author')  (PS array)
+# The guard verifies BOTH literals: it parses the runtime set the hook truly
+# uses, asserts it equals the comment set (so neither a stale comment nor a stale
+# runtime line can pass silently — a maintainer who updates one but not the other
+# is caught), and coverage-checks the RUNTIME set against agents/*.md (the runtime
+# set is the one the live gate executes, so it is the safety-relevant one to
+# cover). The comment set is also coverage-checked as belt-and-suspenders.
+#
+# The coverage check is intentionally ONE-DIRECTIONAL: it asserts every agent
+# name in agents/*.md appears in each hook's set. It does NOT flag a stale extra
+# name that is in a hook set but no longer in agents/*.md — that direction is
+# fail-CLOSED (a non-existent agent name can never match a real actor, so at worst
+# it is dead weight). The comment-vs-runtime check, by contrast, IS strict set
+# equality, because a disagreement there is exactly the false-PASS this guard
+# exists to catch. All parsing is stdlib `re` only — NO shell/pwsh execution.
+
+FEEDER_AGENT_SET_RE = re.compile(r"^#\s*FEEDER_OWN_AGENTS:\s*(.+?)\s*$", re.MULTILINE)
+
+# Runtime literals, keyed by hook-script type (see the block comment above).
+#   sh:  capture the value inside FEEDER_OWN_AGENTS="...".
+#   ps1: capture the inside of $FeederOwnAgents = @( ... ), then pull each
+#        single- or double-quoted token out of that captured group.
+RUNTIME_SH_RE = re.compile(r'^FEEDER_OWN_AGENTS="([^"]*)"', re.MULTILINE)
+RUNTIME_PS1_RE = re.compile(r"\$FeederOwnAgents\s*=\s*@\(([^)]*)\)")
+PS1_TOKEN_RE = re.compile(r"""['"]([^'"]*)['"]""")
+
+
+def parse_hook_agent_set(path: Path) -> set[str] | None:
+    """Extract the COMMENT-literal feeder-agent set from a hook script.
+
+    Reads the `# FEEDER_OWN_AGENTS: a b c` comment literal both hook scripts
+    carry and returns the names as a set. This is only one of the two literals
+    the drift-guard verifies: it ALSO parses each script's RUNTIME literal (see
+    parse_hook_runtime_set) and asserts the two agree and both cover every agent,
+    so neither a stale comment nor a stale runtime line can pass silently.
+    Records an error and returns None if the comment literal is missing or empty
+    (a hook that lost the set can no longer be drift-checked).
+    """
+    if not path.is_file():
+        err(path, "required hook script is missing")
+        return None
+    text = path.read_text(encoding="utf-8-sig")
+    m = FEEDER_AGENT_SET_RE.search(text)
+    if m is None:
+        err(path, "missing the '# FEEDER_OWN_AGENTS: ...' set literal "
+                  "(required for the actor-gate drift-guard)")
+        return None
+    names = {n for n in m.group(1).split() if n}
+    if not names:
+        err(path, "'# FEEDER_OWN_AGENTS:' literal is empty")
+        return None
+    return names
+
+
+def parse_hook_runtime_set(path: Path, label: str) -> set[str] | None:
+    """Extract the RUNTIME feeder-agent literal the hook actually executes.
+
+    Language-specific (keyed by `label`, the hook_scripts dict key): the sh
+    `FEEDER_OWN_AGENTS="..."` string or the ps1 `$FeederOwnAgents = @(...)`
+    array. Returns the names as a set, or records an error and returns None if
+    the runtime literal is missing or empty (a hook that lost its executable set
+    can mis-classify actors). stdlib `re` only — the script is never executed.
+    """
+    text = path.read_text(encoding="utf-8-sig")
+    if label == "sh":
+        m = RUNTIME_SH_RE.search(text)
+        names = {n for n in m.group(1).split() if n} if m else None
+    elif label == "ps1":
+        m = RUNTIME_PS1_RE.search(text)
+        names = {t for t in PS1_TOKEN_RE.findall(m.group(1)) if t} if m else None
+    else:  # pragma: no cover — guard against an unknown script type.
+        names = None
+    if not names:
+        err(path, "missing or empty RUNTIME FEEDER_OWN_AGENTS literal "
+                  "(the set the hook actually executes) — required for the "
+                  "actor-gate drift-guard")
+        return None
+    return names
+
+
+hook_scripts = {
+    "sh": REPO_ROOT / "hooks" / "no-source-edit.sh",
+    "ps1": REPO_ROOT / "hooks" / "no-source-edit.ps1",
+}
+for _label, hook_path in hook_scripts.items():
+    checked += 1
+    comment_set = parse_hook_agent_set(hook_path)
+    runtime_set = parse_hook_runtime_set(hook_path, _label) if hook_path.is_file() else None
+    if comment_set is None or runtime_set is None:
+        continue
+    # Comment-vs-runtime: strict equality. A disagreement is the false-PASS this
+    # guard exists to catch (e.g. comment updated but runtime line left stale).
+    if comment_set != runtime_set:
+        err(hook_path, f"FEEDER_OWN_AGENTS comment literal "
+                       f"{sorted(comment_set)} disagrees with the runtime literal "
+                       f"{sorted(runtime_set)} the hook executes — update both so "
+                       f"the live actor gate matches its documented set")
+    # Coverage: every declared agent must appear in BOTH sets. The runtime set is
+    # the safety-relevant one (it is what the live gate executes); the comment set
+    # is checked too as belt-and-suspenders.
+    for agent_name in agent_names:
+        if agent_name not in runtime_set:
+            err(hook_path, f"runtime FEEDER_OWN_AGENTS set is missing agent "
+                           f"'{agent_name}' (declared in agents/*.md) — the "
+                           f"no-source-edit actor gate the hook executes has "
+                           f"drifted from the real agent set; add it to keep the "
+                           f"safety gate correct")
+        if agent_name not in comment_set:
+            err(hook_path, f"FEEDER_OWN_AGENTS comment literal is missing agent "
+                           f"'{agent_name}' (declared in agents/*.md) — the "
+                           f"actor-gate drift-guard comment has drifted from the "
+                           f"real agent set; add it to keep the safety gate correct")
 
 # --- report -----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #63.

## Summary
Makes the feeder's `no-source-edit` PreToolUse gate **actor-aware**: it keeps blocking the feeder's own actors (the main thread and the feeder's own subagents `architect`/`issue-author`) while allowing a positively-identified non-feeder subagent — e.g. milestone-driver's `implementer` — to edit source. The driver can now build the feeder's own skills/agents/hooks **with no blanket `CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT=1` override**, closing the latent feeder+driver consumer collision.

A PreToolUse hook gets no skill/plugin identity — only `agent_id` (present only inside a subagent) and `agent_type` (the subagent's BARE frontmatter `name`, not namespaced). The gate denylists the feeder's own bare names (fail-closed: a same-named stranger is over-blocked, which is safe) rather than allow-listing the builder, because a bare `agent_type` can't prove plugin provenance.

## Changes
- **`hooks/no-source-edit.sh` + `hooks/no-source-edit.ps1`** — identical actor gate at the source-glob match site (after the unchanged override check, path exemptions, and glob resolution). ALLOW (exit 0) only when `agent_id` is present and non-empty AND `agent_type` is a non-empty name NOT in the hardcoded feeder set; otherwise BLOCK (exit 2). Override-first and fail-open-on-unresolved-globs preserved. The feeder-agent set (`architect issue-author`) is hardcoded inside the protected `hooks/**` boundary — a security control, not editable config.
- **Cross-platform parity** — ps1 `-like`→`-clike` (source-glob match) and `-match`→`-cmatch` (path exemptions) so it is case-sensitive like bash's `case`.
- **`scripts/validate-plugin-structure.py`** — CI drift-guard: verifies both the machine-parseable comment literal AND the runtime literal each hook executes (sh string + ps1 array), requires they agree, and coverage-checks every `agents/*.md` `name:` against the runtime set. Runs in the existing plugin-structure gate; no new CI job.
- **`.claude-plugin/plugin.json`** — version bump 0.3.1 → 0.3.2 (version-bump only — no logic change).

## Decision Log
- **Hardcoded set inside `hooks/**`, not `feeder.json`** — a security control must live inside the boundary it enforces; `feeder.json` is not under `sourceGlobs` so an agent could edit it to remove itself. Alternative rejected: runtime config read (widens attack surface).
- **Fail-closed gate, byte-exact compare** — main thread (absent/empty `agent_id`), feeder's own subagents, and any ambiguous actor (agent_id present, empty agent_type) all BLOCK; only a positively-identified non-feeder subagent is allowed.
- **bash mirrors ps1's non-empty `agent_id`** (`// empty` + `[ -n "$agent_id" ]`) — review found jq's `// "__MISSING__"` only fires on absent/null, so an empty-string `agent_id` would have slipped the gate; fixed.
- **Denylist bare names, not namespaced prefix** — `agent_type` is the bare frontmatter name (`architect`), not `milestone-feeder:architect`; the original prefix approach would have allowed the feeder's own agents through (the parked finding). Source: code.claude.com/docs/en/hooks.md.
- **Drift-guard checks the runtime literal** — review found a comment-only check produced a false PASS while the live hook drifted; now both comment and runtime are verified and must agree.

## Code Review
- /code-review run: yes (high effort, 3 passes)
- Findings: across passes — 3 in-scope finding(s) resolved + 1 refuted
  - bash empty-string `agent_id` slipped the safety gate → re-dispatched and resolved
  - drift-guard comment over-promised the enforced invariant → re-dispatched and resolved (comment aligned)
  - drift-guard verified only the comment literal, not the runtime literal the hook executes (confirmed false-PASS hole) → re-dispatched and resolved (now verifies both)
  - claim that the bash `**` glob is "silently dead" → REFUTED empirically (the running script produces `hooks/*` and blocks main/architect end-to-end; the reviewer's repro was an interactive-shell quoting artifact)
  - 3rd pass: 0 findings (clean) at high effort
- No park-triggering findings. The safety guard was confirmed NOT weakened for the feeder's own actors.

## Verification (no test layer)
This repo has no unit-test harness; behavior verified by piping crafted stdin JSON to the bash hook (jq present; non-override cases under `env -u CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT`), all PASS: driver implementer+source→0; architect/issue-author+source→2; main-thread+source→2; `agent_id` w/ empty `agent_type`→2; empty `agent_id`+source→2; non-source path→0; override set→0; NotebookEdit+source→2; `SKILLS/foo.md` (uppercase)→same decision on both scripts. Drift-guard: PASS in-sync; FAILS on sh-runtime / ps1-runtime / comment drift. pwsh is absent on the build host — ps1 verified by reading + the drift-guard parsing its runtime set.

**AC8 (no-override end-to-end via `solve-milestone`) is a deliberate post-merge / next-session verification** — the session-wide override short-circuits before `agent_type` is read in-build. Recorded as a deferral, not a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)