### PR TITLE
Pin architect agent to model: opus (#81)

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -23,7 +23,7 @@ description: |
   assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
   <commentary>A candidate that references a type or screen another candidate introduces is a hard dependency edge. The agent emits "#B depends_on #A" grounded in the exact artifact reference, and places #B in a later Wave than #A — the Wave order is the topological sort of the edges, not a guess.</commentary>
   </example>
-model: inherit
+model: opus
 color: blue
 ---
 


### PR DESCRIPTION
Closes #81. Part of the milestone-feeder v0.4.0 efficiency pass (#79).

## What changed
- `agents/architect.md` frontmatter `model:` pinned from `inherit` to `opus` (one line).
- No version bump — develop already at 0.4.0 (set by #80); the milestone target is idempotent.

## Why
The architect is the suite's hardest reasoning step — decompose → dependency graph → topological Wave sort → classification, all grounded (architect.md:30,53). It runs exactly once per plan, so its absolute token share is small, and its decomposition quality is upstream of every downstream fan-out cost. Pinning it to `opus` makes the strong tier intentional rather than incidental. This is quality protection (~$0 savings); the agent must never be downshifted.

## Decision Log
- **Change:** set `agents/architect.md:26` `model: inherit` → `model: opus`. Rationale: locked plan from issue #81, grounded at the cited anchor. `opus` is the standard Claude Code subagent model alias (mirrors #80's `sonnet` on the sibling agent). Alternatives rejected: rewriting the frontmatter block (noisier diff, BOM/whitespace risk), editing any other line (out of scope).

## Code Review
- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at low effort
  - none
- No park-triggering findings.
- version-free — no version bump (develop already at the 0.4.0 milestone target; idempotent)

## Triage
- All-clear, no Blockers. 2 Advisories (no explicit acceptance-criteria checklist; `opus` is an unpinned alias) — both non-gating, resolved by the sibling pattern in #80. Confirmed #80 and #81 touch different files (issue-author.md vs architect.md) — genuinely Wave-1 independent. Minimal observable acceptance criterion recorded: frontmatter `model:` reads `opus`, no other line changed. Classification: Surface: logic; Risk: light (one-line frontmatter pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)