### PR TITLE
Add explicit concurrent-batch orchestration to plan Step 4 author fan-out (#82)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -131,7 +131,11 @@ SCOPE_SPANS_MULTIPLE_MILESTONES:
 
 ### Step 4 — Dispatch issue-author per candidate (parallelizable)
 
-For **EACH** candidate returned at Step 3, dispatch the agent named in `issueAuthorAgent` (default `milestone-feeder:issue-author`). Dispatches are **parallelizable** — run them concurrently when the tool environment supports it (`SPEC.md` §6 Step 4).
+For **EACH** candidate returned at Step 3, dispatch the agent named in `issueAuthorAgent` (default `milestone-feeder:issue-author`). **Dispatch all N authors concurrently as background agents** — one `Agent(run_in_background: true)` per candidate — **with no more than 4 in flight at once**. If N > 4, use a **rolling window / batches** so the in-flight count never exceeds 4 (as one author returns, dispatch the next). When N ≤ 4 this rule is a no-op — dispatch all of them, no rolling window is needed (and N = 0 / N = 1 are trivial). Cap 4 is a safe, conservative default, mirroring the driver's worker fan-out (`milestone-driver` plugin `skills/solve-milestone/SKILL.md` Phase 1 step 2: "no more than 4 workers running at once… rolling window / batches so the in-flight count never exceeds 4"). **Quality hold:** issue-authors are stateless and write no shared state, so running them concurrently cannot change any issue body — the output is identical to a serial fan-out.
+
+**Barrier at Step 5.** **Await ALL author completions before Step 5 (Assemble graph) begins** — Step 5 consumes every returned issue, so the whole fan-out must have returned before it can start. Authors that return concurrently are collected at this join; a returned `STATUS: PRODUCT_GAP` routes to `productGaps[]` at the join exactly as the serial path does (see the routing rule below), and the rolling window keeps refilling until every candidate has returned.
+
+**Cap ownership (SKILL ↔ SPEC lockstep).** This SKILL carries the **operational** detail — the cap W = 4 and the rolling window above. `SPEC.md` §6 Step 4 remains the looser normative statement ("per candidate (parallelizable)"); it does not name a cap. SKILL.md owns the cap; SPEC.md is intentionally not made more specific here.
 
 **Brief each with** (matches `agents/issue-author.md` → "What you receive"):
 


### PR DESCRIPTION
Closes #82. Part of the milestone-feeder v0.4.0 efficiency pass (#79).

## What changed
- `skills/plan/SKILL.md` Step 4 dispatch prose (line 134) rewritten from permissive "parallelizable — run them concurrently when the tool environment supports it" to an explicit concurrent-batch instruction: dispatch all N authors as background agents (`Agent(run_in_background: true)`), cap W=4, rolling window for N>4, barrier/join before Step 5. (+5/-1 lines, one file.)
- No version bump — develop already at 0.4.0 (milestone target), idempotent.

## Why
Step 4 declared parallelism but shipped no mechanism (a grep finds only the one prose line — no `run_in_background`/barrier/cap), so the issue-authors almost certainly ran serially and wall-clock scaled O(N) instead of O(ceil(N/4)) — a ~2-3x speedup on the author segment, zero token change. The fan-out now mirrors the driver's proven worker pattern.

## Quality hold
Issue-authors are stateless and write no shared state, so running them concurrently cannot change any issue body — the output is identical to a serial fan-out. The existing per-candidate `STATUS: PRODUCT_GAP` routing is preserved under concurrency (collected at the Step-5 join exactly as the serial path does).

## Decision Log
- **Cap W=4 + rolling-window phrasing:** matches the driver's proven default verbatim so the two skills stay in lockstep. Citation: `milestone-driver` `skills/solve-milestone/SKILL.md:274` ("no more than 4 workers… rolling window / batches… Cap 4 is a safe, conservative default"). Rejected: inventing a different cap (divergence), a semaphore/queue abstraction (over-engineering prose).
- **Barrier as its own paragraph:** mirrors the driver's separate barrier item (`solve-milestone:280`, "Await ALL completion notifications"); keeps the join + PRODUCT_GAP reasoning legible.
- **PRODUCT_GAP via cross-reference, not restated:** least-code, single source of truth at `skills/plan/SKILL.md:161` (unchanged). Rejected: duplicating the rule (drift risk).
- **SKILL↔SPEC lockstep note, SPEC untouched:** the SPEC step-table edit was scoped out; a one-clause note records "SKILL owns the operational cap" so SKILL.md (now cap-explicit) does not silently diverge from `SPEC.md:180` (the looser normative "(parallelizable)"). Rejected: editing SPEC.md §6 Step 4 (out of scope).

## Code Review
- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at high effort
  - none
- No park-triggering findings.
- Both CI gates (vocabulary-purge, plugin-structure) verified passing locally before commit. version-free — no version bump (develop already at the 0.4.0 milestone target; idempotent).

## Triage
- All-clear, no Blockers. Classification: Surface: logic; Risk: heavy (skill control-flow change). 2 Advisories, both addressed in the implementation: (1) SKILL-vs-SPEC divergence → resolved by the lockstep note; (2) N≤4 / PRODUCT_GAP-under-concurrency handling → both explicitly covered in the new prose. Confirmed #82 and #83 edit different non-overlapping sections of the same file (Step 4 vs Step 6) — adjacent edits, no build-order dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)