### PR TITLE
feat(plan): brief the architect with the Step-0 grounding digest (#96)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -90,7 +90,7 @@ Dispatch the agent named in `architectAgent` (default `milestone-feeder:architec
 **Brief it with** (matches `agents/architect.md` → "What you receive"):
 
 - The **normalized brief** from Step 1 (`{ goal, in-scope, out-of-scope, surfaces }`).
-- The **filled project-docs sections** from Step 0 — only the sections that exist (absent / `[TBD]` skipped).
+- The **resolved grounding digest** from Step 0 — the `.project/<doc>.md#<section>` slices assembled there — as the architect's project-docs grounding. The digest is what is handed in; an **empty digest** (no `.project/`, or all sections absent / `[TBD]`) is passed through unchanged and is **not an error** (degrade exactly as Step 0 does — "a missing project-docs directory is not an error"). The digest **supplements, never replaces** the architect's on-demand Read/grep citation-verification path: the architect still reads the repo on demand to verify any citation per its rigor gate (`agents/architect.md` Rigor gate — "Every design default cites its grounding"), so where a slice is insufficient it falls back to reading source. (The digest's slice shape and absent-/`[TBD]`-skip rule are defined in Step 0; not restated here.)
 - The **resolved shared keys** — the *values* for `sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`.
 - `issueSize` when set; else the default (~1 PR each, independently buildable).
 - The `productGaps[]` carried from Step 2.


### PR DESCRIPTION
Closes #96.

## Summary
Reword the Step-3 architect-brief project-docs bullet (`skills/plan/SKILL.md`) so the architect is handed the **resolved grounding digest** produced at Step 0 (#95) — the `.project/<doc>.md#<section>` slices — instead of "the filled project-docs sections … only the sections that exist", a directory-to-re-read framing. This is the consumer of #95 and removes the architect's half of the O(N) whole-file re-read tax. Paired agent-side edit (`agents/architect.md:37`) is #98.

## Decision Log
- Reworded ONE bullet (the line-93 project-docs bullet); header + other four "Brief it with" bullets untouched (locked architecture: one-bullet reword).
- Quoted the Step-0 degrade phrase "a missing project-docs directory is not an error" verbatim (`skills/plan/SKILL.md:34`) to keep the two surfaces lexically aligned.
- Cited the architect rigor gate by section name + verbatim quote ("Every design default cites its grounding", `agents/architect.md:108`) rather than raw line numbers — survives renumbering.
- Deferred slice shape / absent-`[TBD]`-skip rule to Step 0 (single source of truth, #95) rather than restating.

## Code Review
- /code-review run: yes (high effort)
- Findings: 0 in-scope findings at high effort — every quoted anchor verified verbatim (digest produced at Step 0 with `.project/<doc>.md#<section>` slices; degrade phrase at `:34`; rigor-gate quote at `agents/architect.md:108`); supplements-not-replaces framing matches Step 0's model; neighboring bullets + header intact and true.
- No park-triggering findings.
- Version-bump: none — plugin.json already at milestone target 0.4.1 (idempotent; version-bump only — no logic change).

Advisory (from triage, accepted): the #96↔#98 lockstep is recorded as prose, not a tracked edge; topological direction is correct (#98 depends on #96) and #96 is independently mergeable — a transient SKILL↔agent wording mismatch until #98 lands is expected.