### PR TITLE
feat(plan): brief each issue-author with the Step-0 grounding digest (#97)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -160,7 +160,7 @@ For **EACH** candidate returned at Step 3 **that was not pre-parked (or dropped)
 **Brief each with** (matches `agents/issue-author.md` → "What you receive"):
 
 - The **candidate** — its tag, title, surface/risk hint, and sketch (from Step 3).
-- The **brief + project docs** — the grounding sources from Steps 0–1.
+- The **brief** (the grounding source carrying *what to build*, in product terms) **and the resolved grounding digest** from Step 0 — the `.project/<doc>.md#<section>` slices assembled there — as the author's project-docs grounding. The digest is what is handed in; an **empty digest** (no `.project/`, or all sections absent / `[TBD]`) is passed through unchanged and is **not an error** (degrade exactly as Step 0 does — "a missing project-docs directory is not an error"). The digest **supplements, never replaces** the author's on-demand Read/grep citation-verification path: the author still greps the live repo to verify any citation before recording it per its rigor gate (`agents/issue-author.md` Rigor gate — "grep before you cite"), and may grep for anything not in the digest — the digest is not an allowlist. (The digest's slice shape and absent-/`[TBD]`-skip rule are defined in Step 0; not restated here.)
 - The **resolved shared keys** — `sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch`.
 - The **edges naming this candidate** — the architect edges that touch this tag, to record verbatim (the author transcribes; it does not invent edges or reorder Waves).
 - Any `productGaps[]` **scoped to this candidate**.


### PR DESCRIPTION
Closes #97.

## Summary
Reword the Step-4 issue-author brief project-docs bullet (`skills/plan/SKILL.md`) so each author is handed the **resolved grounding digest** produced at Step 0 (#95) — the `.project/<doc>.md#<section>` slices — instead of "the brief + project docs … grounding sources from Steps 0–1", a whole-directory re-read framing. The brief stays a grounding source. This is the largest slice of the O(N) tax: N authors each re-reading the same docs. Paired agent-side edit (`agents/issue-author.md:38`) is #99.

## Decision Log
- Mirrored #96's Step-3 architect bullet pattern (`skills/plan/SKILL.md:93`) for digest/degrade/supplements wording — consistency + least-code.
- Kept the brief inside the same bullet (not split into a separate bullet) — minimal one-bullet edit per locked architecture; bullet count preserved.
- Cited the issue-author's own gate verb "grep before you cite" (`agents/issue-author.md:100`) — the author-side gate, not the architect's "cites its grounding".
- Added "not an allowlist" clause so the digest never narrows what the author may grep.

## Code Review
- /code-review run: yes (high effort)
- Findings: 0 in-scope findings at high effort — all anchors verified verbatim (Step-0 digest at `:36`; degrade phrase at `:34`; gate "grep before you cite" at `agents/issue-author.md:100`); mirrors #96's established pattern; header + other bullets intact; no internal contradiction.
- No park-triggering findings.
- Version-bump: none — plugin.json already at milestone target 0.4.1 (idempotent; version-bump only — no logic change).