### PR TITLE
docs(architecture): add a release-checklist step to re-sync the SPEC.md header (#113)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/.milestone-config/.gitignore
+++ b/.milestone-config/.gitignore
@@ -1,0 +1,10 @@
+# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.
+# Committed so per-run scratch stays out of `git status` with zero user setup.
+# Patterns are relative to this .milestone-config/ directory. Tracked config
+# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.
+preflight-notice
+trello-notice
+triage-cache.json
+tests-stamp
+.runtime/
+worktrees/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,12 +59,27 @@ file, not regenerated.
 
 ## Plugin version
 
-The plugin version lives only in `.claude-plugin/plugin.json` (currently `0.3.0`)
-as the single source of truth. There is **no per-PR version machinery** — the
+The plugin version's single source of truth is `.claude-plugin/plugin.json`.
+There is **no per-PR version machinery** — the
 feeder opens no PRs and touches no branches, so the driver's bump-rides-the-PR
 mechanism has nothing to ride. The version is bumped by hand when a release is cut.
 `.claude-plugin/marketplace.json` carries no `version` field (Claude Code resolves
 `plugin.json` first).
+
+### Release checklist
+
+When a release is cut and the plugin version is bumped, re-sync these
+version-bearing locations together so they all name the same version:
+
+1. `.claude-plugin/plugin.json` `version` — the single source of truth. Bump this
+   first; everything else is re-synced to match it.
+2. `SPEC.md` as-built header — line 1 (`# milestone-feeder — as-built spec
+   (vX.Y.Z)`) and the line-5 status reference (`Status: **as-built spec for
+   vX.Y.Z**`). Re-sync both to the new `plugin.json` version.
+
+Any other hand-maintained in-doc version reference should be re-synced to match
+as well. A future releaser — a human, or the driver's per-release docs-sweep
+issue — should run this re-sync as part of cutting the release.
 
 ## Pipeline position
 


### PR DESCRIPTION
## Summary

Adds a **Release checklist** subsection to `docs/architecture.md` so a future releaser re-syncs the version-bearing locations together at each release — `.claude-plugin/plugin.json` `version` (source of truth) → `SPEC.md` as-built header (lines 1 & 5). This prevents the recurrence of the header drift that companion issue #75 fixes one-time.

Also reworded the version note directly above it to drop the now-contradictory word **"only"** and the stale **`(currently 0.3.0)`** parenthetical (a `/code-review` consistency finding) — the note no longer fights the checklist, and a hand-maintained current-version number is removed at the source rather than re-seeded.

Carries the milestone **v0.4.2** version bump (`plugin.json` 0.4.1 → 0.4.2) and commits the `.milestone-config/.gitignore` scratch-ignore self-heal.

Closes #113

## Decision Log

| Choice | Rationale | Citation | Rejected |
|---|---|---|---|
| `###` heading nested under `## Plugin version` | AC: "subsection placed under the existing version-source-of-truth note" | `docs/architecture.md:60` | `##` (would be a sibling section, not a subsection) |
| Cite SPEC.md strings with `vX.Y.Z` placeholders, not a hardcoded version | A checklist must stay correct across releases | `SPEC.md:1`, `SPEC.md:5` | Hardcoding v0.3.1 (re-introduces drift) |
| Catch-all line for other hand-maintained version refs | Robustness without expanding the required minimum | locked plan (optional clause) | — |
| Reworded version note: dropped "only" + stale parenthetical | "single source of truth" already implies derived copies; removing the parenthetical eliminates a drift source | `docs/architecture.md` Release-checklist subsection | Updating to `(currently 0.4.2)` — re-seeds the same drift |
| Left line 11 (`as-built v0.3.0 components`) untouched | Version-pinned history, not stale drift (per #75 triage) | `docs/architecture.md:11` | — |

## Code Review

- /code-review run: yes
- Findings: 2 in-scope finding(s) at low effort
  - line 62 "only" contradicts the new checklist → re-dispatched and resolved (reworded; dropped "only" + the stale `(currently 0.3.0)` parenthetical at source)
  - line 80 catch-all doesn't enumerate architecture.md's own version refs → partially resolved (removed the stale line-62 parenthetical) / line-11 portion **rejected** with rationale: `architecture.md:11` is version-pinned history (correct reference to what v0.3.0 built), not drift — confirmed by the #75 triage classification
- No park-triggering findings.
- Version-bump: `plugin.json` 0.4.1 → 0.4.2 (milestone v0.4.2 target) — version-bump rides this PR, no logic change.
