### PR TITLE
docs(spec): sync SPEC.md as-built header to plugin.json v0.4.2 (#75)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,8 +1,8 @@
-# milestone-feeder — as-built spec (v0.3.1)
+# milestone-feeder — as-built spec (v0.4.2)
 
 A Claude Code plugin that turns a feature brief into a **GitHub milestone + small, well-formed issues** that `milestone-driver` can build with no human clarification. The direct predecessor of the driver.
 
-Sibling of `milestone-driver`, same design DNA (see the suite plan: [`../dev-tools/SUITE-PLAN.md`](../dev-tools/SUITE-PLAN.md) §1). Separate plugin, separate config. Status: **as-built spec for v0.3.1** — the live surface (verbs `plan` / `create` / `update` / `setup`, no flags, plan-file-as-contract), now with **user-owned, versioned milestone identity** (the semver lives in the milestone title), **`update` retargeting by deploy receipt + bounded rename-in-place**, and a **non-blocking multi-milestone advisory**.
+Sibling of `milestone-driver`, same design DNA (see the suite plan: [`../dev-tools/SUITE-PLAN.md`](../dev-tools/SUITE-PLAN.md) §1). Separate plugin, separate config. Status: **as-built spec for v0.4.2** — the live surface (verbs `plan` / `create` / `update` / `setup`, no flags, plan-file-as-contract), now with **user-owned, versioned milestone identity** (the semver lives in the milestone title), **`update` retargeting by deploy receipt + bounded rename-in-place**, and a **non-blocking multi-milestone advisory**.
 
 Decisions already locked: name `milestone-feeder`; config at `.milestone-config/feeder.json`; separate plugin in its own repo (suite/marketplace linkage deferred). Decisions taken as sensible defaults below are marked **Decision (default)** — veto any.
 


### PR DESCRIPTION
## Summary

Syncs `SPEC.md`'s live as-built version header (line 1 + line 5) from **v0.3.1** to **v0.4.2**, matching `.claude-plugin/plugin.json`'s `version` (the single source of truth). One-time drift fix; companion to #113 (the standing release-checklist step that prevents recurrence). Version-pinned history (the v0.3.1 changelog/section entries at lines 90/92/181) is left untouched.

Closes #75

## Decision Log

| Choice | Rationale | Citation | Rejected |
|---|---|---|---|
| Synced to `0.4.2` read directly from plugin.json | The version source of truth; read it rather than trusting the brief | `.claude-plugin/plugin.json:3` | Trusting the brief's stated version without reading |
| Anchored each Edit to a unique full-line `old_string` (line 1 header; line 5 status sentence) | Guarantees only the two live-header occurrences match — the historical v0.3.1 tokens at lines 90/92/181 cannot be hit | `SPEC.md:1`, `SPEC.md:5` | `replace_all` on `v0.3.1` (would corrupt version-pinned history) |

## Code Review

- /code-review run: yes
- Findings: 0 in-scope finding(s) at low effort
  - none — accuracy (matches plugin.json 0.4.2), scope (only line 1/5 changed; lines 90/92/181 historical refs preserved), and completeness all verified
- No park-triggering findings.
- Version-bump: `plugin.json` already at 0.4.2 (milestone v0.4.2 target) — version-bump only, idempotent (no change this PR), no logic change.
