### PR TITLE
docs: finalize v0.4.2 — CHANGELOG, README status, stale-version cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.4.2 — Release hygiene
+
+**Theme:** Pure housekeeping — nothing about how the feeder works changes. The
+docs had drifted behind the real plugin version: the as-built spec header, the
+README status line, and a leftover label in the architecture doc all still named
+an older version. This release re-syncs them to the source of truth and adds a
+short release checklist so they stay in step from here on.
+
+### 🧹 Hygiene — keep the version references honest
+
+| Change | PR | What |
+|---|---|---|
+| Re-sync the spec header to the real version | #75 (#115) | `SPEC.md`'s as-built header (line 1 and the status line) still read `v0.3.1` while the plugin had already moved several releases ahead. It's now re-synced to `.claude-plugin/plugin.json`'s `version` — the single source of truth. |
+| Add a release checklist so it can't drift again | #113 (#114) | Added a short "Release checklist" to `docs/architecture.md` — when the plugin version is bumped, re-sync the spec header to match — and tidied the version note above it, dropping the now-contradictory "only" and the stale "(currently `0.3.0`)" aside. |
+
+### Consumer notes (upgrading from v0.4.1)
+
+- **Pure housekeeping — nothing breaks, nothing changes for you.** Same commands
+  (`plan` / `create` / `update`), same config file, same plan-file output. Only
+  internal docs were touched — including the README `## Status` line and a stale
+  `v0.3.0` label in the architecture doc, both refreshed to the current version.
+- **Nested-app support isn't here — it moved to the bootstrapper.** This milestone
+  was originally scoped to also add a configurable app-root for repos whose code
+  lives in a subfolder. That work belongs in `milestone-bootstrapper` (v0.2.0): its
+  new `appRoots` setting bakes each nested path into the `sourceGlobs` /
+  `uiSurfaceGlobs` it scaffolds, while keeping the shared config and `.project/`
+  docs at the repo root — so the feeder already works on a nested-app repo with
+  **no feeder-side change**. The feeder issue was closed as superseded.
+- **No config-key or schema changes** to `.milestone-config/feeder.json`.
+
+### ⚖️ Post-run audit trail
+
+Judgment-call PRs for this release: none
+
 ## v0.4.1 — Read your house docs once, not once per helper
 
 **Theme:** This release stops `plan` from paying to read the same project docs over

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Full setup walkthrough: [docs/consumer-setup.md](docs/consumer-setup.md). Every 
 
 ## Status
 
-v0.3.1 — name your milestone with a version up front and the feeder hands it cleanly to `milestone-driver`: explicit, versioned milestone naming; `update` finds and renames the right milestone even after a title change; and a heads-up when your brief looks like several milestones. Self-hosted: the feeder was planned as its own milestone and built by milestone-driver.
+v0.4.2 — the live surface (`plan` / `create` / `update`, no flags, plan-file-as-contract): name your milestone with a version up front and the feeder hands it cleanly to `milestone-driver`; `plan` reads your house docs once up front and parks real product gaps before it fans out; and you get a heads-up when your brief looks like several milestones. v0.4.2 itself is a docs-hygiene release — no behavior change. Self-hosted: the feeder is planned as its own milestone and built by milestone-driver.
 
 ## Docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ stack, the conventions, and the design defaults the engine grounds the breakdown
 
 ## Plugin contents
 
-The as-built v0.3.0 components. `plan` previews to a plan file, `create` deploys the
+The as-built components. `plan` previews to a plan file, `create` deploys the
 approved plan, and `update` reconciles a refreshed plan onto an existing milestone
 (see [The reviewer gate](#the-reviewer-gate) and [The plan procedure](#the-plan-procedure)).
 The plan file is the **build artifact** (see [The plan file as build artifact](#the-plan-file-as-build-artifact)).


### PR DESCRIPTION
## Summary

Finalizes the v0.4.2 release docs now that all three milestone issues are resolved (#75 + #113 merged, #112 closed as superseded):

- **CHANGELOG.md** — adds the v0.4.2 "Release hygiene" entry.
- **README.md** — bumps the `## Status` line from v0.3.1 to v0.4.2 (it was three releases stale).
- **docs/architecture.md** — drops a leftover `v0.3.0` label from the component list (the same drift class the line-62 fix in #113 already handled).

## Decision Log

| Choice | Rationale | Verification |
|---|---|---|
| Closed #112 (configurable app-root) as **superseded** by milestone-bootstrapper v0.2.0 | The feeder needs no `appRoot` key — the bootstrapper resolves nesting at scaffold time | **Vetted against the loaded bootstrapper v0.2.0**: its plan-file-only `appRoots` bakes each nested path into the scaffolded `sourceGlobs`/`uiSurfaceGlobs`; configs + `.project/` stay at the repo root; their CHANGELOG states "milestone-driver and milestone-feeder need no changes to consume a nested-app config" |
| `architecture.md:11` `as-built v0.3.0 components` → `as-built components` | Living architecture doc describing the *current* components; the `v0.3.0` label is stale drift, not version-pinned history | Consistent with the line-62 fix in #113; the verbs (`plan`/`create`/`update`) are unchanged across v0.3.0→v0.4.2 |
| Left `architecture.md:57` (`what changed from v0.2.0…`) untouched | A deliberate "since v0.2.0" comparison, not a stale current-version label | — |

## Code Review

- /code-review run: yes (low effort, docs diff)
- Findings: 2 in-scope finding(s) at low effort
  - The `#75 (#115)` row mis-credited the "(currently `0.3.0`)" removal — that was `#113 (#114)`'s work → **resolved**: the `#75` row now describes the SPEC sync only; the aside is re-attributed to the `#113` row.
  - The `architecture.md` edit shipping in this diff (the `as-built v0.3.0` label drop) wasn't mentioned → **resolved**: now covered in the Theme and the first consumer note.
- The bootstrapper v0.2.0 app-root claim was independently vetted against the loaded plugin — confirmed accurate.
- No park-triggering findings.
- Version-bump: none — `plugin.json` is already at 0.4.2 (set by #113's PR); this is a docs-only finalize PR.
