### PR TITLE
feat(setup): self-heal .milestone-config/.gitignore on feeder-first adoption (#120)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -72,6 +72,54 @@ Present keys in these tiers: **Core → Agents → Sizing**, plus the self-prote
 The canonical profile location is `<repo-root>/.milestone-config/feeder.json`.
 
 - Create the `.milestone-config/` directory if absent (`mkdir -p .milestone-config`).
+- **Self-heal the scratch-ignore (best-effort, create-only — never clobber).** With the directory now ensured, write a **committed** `.milestone-config/.gitignore` so per-clone scratch (`preflight-notice`, `trello-notice`, `triage-cache.json`, `tests-stamp`, plus the `.runtime/` and `worktrees/` dirs) is git-invisible in the consumer repo from the first write, with zero user setup — while tracked config (`driver.json`, `feeder.json` — intentionally NOT listed) stays tracked. A feeder-first adopter (setup runs before any milestone-driver hook has fired) would otherwise have no scratch-ignore until a driver run happens; this closes that gap. **Write the file only when it is absent** (`[ ! -f ]` / `-not (Test-Path …)`), so a user-edited `.gitignore` is never overwritten, appended to, or truncated, and a re-run is a no-op. The write is **best-effort**: swallow any failure and continue to write `feeder.json` and return control — a failed self-heal must never abort setup. This mirrors the driver's canonical block verbatim (`milestone-driver/hooks/tests-green.sh` / `tests-green.ps1`); keep the two in sync.
+
+  <!-- KEEP THIS BLOCK IN SYNC with the committed .milestone-config/.gitignore in this repo and with feeder plan, driver solve-issue / solve-milestone / triage. -->
+  ```gitignore
+  # milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.
+  # Committed so per-run scratch stays out of `git status` with zero user setup.
+  # Patterns are relative to this .milestone-config/ directory. Tracked config
+  # (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.
+  preflight-notice
+  trello-notice
+  triage-cache.json
+  tests-stamp
+  .runtime/
+  worktrees/
+  ```
+
+  ```bash
+  # bash — create-only self-heal; never clobbers a user-edited file, never aborts setup.
+  ignore_path=".milestone-config/.gitignore"
+  if [ ! -f "$ignore_path" ]; then
+    printf '%s\n' \
+      '# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.' \
+      '# Committed so per-run scratch stays out of `git status` with zero user setup.' \
+      '# Patterns are relative to this .milestone-config/ directory. Tracked config' \
+      '# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.' \
+      'preflight-notice' 'trello-notice' 'triage-cache.json' 'tests-stamp' \
+      '.runtime/' 'worktrees/' > "$ignore_path" 2>/dev/null || true
+  fi
+  ```
+
+  ```powershell
+  # PowerShell 7+ — same create-only self-heal; no-BOM UTF-8; never clobbers, never aborts.
+  try {
+    $ignorePath = Join-Path '.milestone-config' '.gitignore'
+    if (-not (Test-Path $ignorePath)) {
+      $ignoreBody = @(
+        '# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.'
+        '# Committed so per-run scratch stays out of `git status` with zero user setup.'
+        '# Patterns are relative to this .milestone-config/ directory. Tracked config'
+        '# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.'
+        'preflight-notice'; 'trello-notice'; 'triage-cache.json'; 'tests-stamp'
+        '.runtime/'; 'worktrees/'
+      ) -join "`n"
+      [System.IO.File]::WriteAllText($ignorePath, $ignoreBody + "`n", [System.Text.UTF8Encoding]::new($false))
+    }
+  } catch {}
+  ```
+
 - Assemble the profile object from the keys the user accepted or edited. **Omit any key left at its bundled default** (absent-means-default, `docs/profile-schema.md`): writing the default explicitly adds noise and drifts when the default changes. `versioning` has **no** default, so a skipped `versioning` is likewise **omitted** — never written as a placeholder; its absent state means `plan` infers-or-asks. A minimal feeder-own-repo profile carries only the self-protection `sourceGlobs`; an empty `{}` is valid.
 - Write the assembled object to `.milestone-config/feeder.json`. **Always write the file**, even when the result is `{}` — config-presence is the signal `plan`'s Step 0 reads to decide whether to auto-invoke setup, so an absent file and an empty file are deliberately distinct.
 - Print the final file contents so the user can verify.


### PR DESCRIPTION
## Summary

Setup Phase 3 now self-heals the nested `.milestone-config/.gitignore` — a best-effort, create-only write (never clobbers a user-edited file, never aborts setup) — so a **feeder-first** adoption (setup runs before any milestone-driver hook fires) gets the committed scratch-ignore with zero user setup, instead of free-riding on a later driver run. Mirrors the driver's canonical block verbatim (bash + PowerShell 7+). Closes #120.

## Decision Log

- **Mirror the hooks' 6-token canonical block** (not the solve-milestone doc-form) — the issue pins the source to `milestone-driver/hooks/tests-green.sh:71-80` / `tests-green.ps1:87-98` and quotes the exact 6 tokens; verified byte-identical via diff. (The driver's solve-milestone *doc-form* has drifted to a 7th token `visualcapture-notice`; followed the hooks per the issue spec — flagged for the driver side.)
- **Snippet carries no own `mkdir`** — the preceding Phase 3 bullet already ensures `.milestone-config/` (`skills/setup/SKILL.md:74`); the self-heal runs after it.
- **PowerShell write via `[System.IO.File]::WriteAllText(..., UTF8Encoding($false))`** — matches the driver's `.ps1` verbatim; guarantees no-BOM UTF-8 on any host.
- **Paired bash+PowerShell fenced house style** — mirrors `skills/plan/SKILL.md:338-348` (Step 7), without conflating that block's single-`*` `.milestone-feeder/.gitignore` content (a different directory/mechanism).
- **KEEP-IN-SYNC marker placed at this site** with the peer text feeder #122 expects, so #122 only verifies/peer-links.
- Bumped `.claude-plugin/plugin.json` to v0.4.3 (milestone target).

## Code Review

- /code-review run: yes (fresh reviewer agent, scaled to a verbatim-mirror markdown diff)
- Findings: 0 in-scope finding(s) at high effort
  - none
- No park-triggering findings.
- Both CI gates (vocab-purge + plugin-structure) verified green against the working tree pre-PR.
- Version-bump rode this PR (milestone target v0.4.3) — no separate chore PR; version-bump-only edit, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
