### PR TITLE
feat(setup,plan): detect legacy root .gitignore blanket + one-time notice (#123)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -71,6 +71,88 @@ try {
 } catch {}
 ```
 
+**Detect a legacy-blanket root `.gitignore` and print a one-time by-hand-fix notice (read-only; NEVER auto-edit the root).** The self-heal above writes the *nested* `.milestone-config/.gitignore`, but it cannot help a consumer whose **root** `.gitignore` carries a legacy blanket for the config dir — `.milestone-config/`, `.milestone-config/*`, or bare `.milestone-config` (with or without a leading `/`). A root blanket hides everything under `.milestone-config/` from git — `feeder.json`, `driver.json`, and the nested `.gitignore` we just wrote — so the tracked config is silently dropped from version control and the self-heal is void for exactly those repos. **Detection is read-only — it writes NOTHING to the root `.gitignore` under any condition; the root file is the consumer's and may hold unrelated rules, so the fix is the user's to apply** (this skill already scopes its own scratch self-ignore to the nested `.milestone-config/.gitignore` "without touching the consumer's root `.gitignore`", `skills/plan/SKILL.md:336`). Mirrors the driver's one-time marker-gated notice pattern (`milestone-driver/skills/solve-milestone/SKILL.md` preflight / Trello notice: detect → print verbatim → drop a per-clone marker; `milestone-driver/skills/solve-issue/SKILL.md` first-run preflight notice).
+
+Gate: print the 🔴 notice **verbatim** ONLY when a root blanket is detected **AND** the per-clone marker `.milestone-config/.runtime/legacy-blanket-notice` is **absent**. On print, ensure `.runtime/` exists (`mkdir -p .milestone-config/.runtime` / `New-Item -ItemType Directory -Force`), then create the marker. Stay **silent** if the marker already exists OR no blanket is detected. The marker lives under `.runtime/`, which the nested `.milestone-config/.gitignore` (written above) already ignores — so the marker is git-invisible with **no new gitignore line** (verified: `git check-ignore .milestone-config/.runtime/legacy-blanket-notice` resolves against the nested `.runtime/` entry). **Blanket-clearing rule:** a blanket counts as present UNLESS it is paired with a **broad** un-ignore that actually re-exposes tracked config (`!.milestone-config`, `!.milestone-config/`, or `!.milestone-config/*`). A lone single-file un-ignore such as `!.milestone-config/driver.json` does **NOT** clear it — `feeder.json` and the nested `.gitignore` stay hidden — so it still counts as a blanket and the notice fires. **Both forms below are best-effort: swallow any failure (unwritable dir, permission error, missing git) and continue the `plan` run — a failed detect/marker must never abort `plan`. Neither form ever writes to the root `.gitignore`.**
+
+<!-- KEEP THIS DETECTION + NOTICE BLOCK IN SYNC with setup Phase 3 (skills/setup/SKILL.md). Read-only on the root .gitignore; marker is .milestone-config/.runtime/legacy-blanket-notice. -->
+```text
+🔴 Legacy blanket detected in your root .gitignore
+
+| What | Your root .gitignore ignores the whole .milestone-config/ directory
+|      | (a line like `.milestone-config/`, `.milestone-config/*`, or
+|      | `.milestone-config`). That hides this suite's TRACKED config —
+|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —
+|      | from git, so your config is silently dropped from version control.
+| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`
+|      | blanket line. The nested .milestone-config/.gitignore (already
+|      | written) then keeps per-run scratch invisible while feeder.json /
+|      | driver.json / the nested .gitignore stay tracked. We never edit your
+|      | root .gitignore for you — it is yours and may hold unrelated rules.
+| Note | This notice shows at most once per clone.
+```
+
+```bash
+# bash — read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts plan.
+# printf '%s\n' (NOT a heredoc): the same indent-safe construct the setup site uses, so both sites
+# emit one consistent form. The notice text is the quoted args, so it prints flush-left —
+# byte-identical to the setup site.
+marker=".milestone-config/.runtime/legacy-blanket-notice"
+if [ ! -f "$marker" ] && [ -f ".gitignore" ] \
+   && grep -Eq '^[[:space:]]*/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore \
+   && ! grep -Eq '^[[:space:]]*!/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore; then
+  printf '%s\n' \
+    '🔴 Legacy blanket detected in your root .gitignore' \
+    '' \
+    '| What | Your root .gitignore ignores the whole .milestone-config/ directory' \
+    '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or' \
+    '|      | `.milestone-config`). That hides this suite'"'"'s TRACKED config —' \
+    '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —' \
+    '|      | from git, so your config is silently dropped from version control.' \
+    '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`' \
+    '|      | blanket line. The nested .milestone-config/.gitignore (already' \
+    '|      | written) then keeps per-run scratch invisible while feeder.json /' \
+    '|      | driver.json / the nested .gitignore stay tracked. We never edit your' \
+    '|      | root .gitignore for you — it is yours and may hold unrelated rules.' \
+    '| Note | This notice shows at most once per clone.'
+  mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts plan.
+try {
+  $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'legacy-blanket-notice')
+  if ((-not (Test-Path $marker)) -and (Test-Path '.gitignore')) {
+    $lines = Get-Content -LiteralPath '.gitignore'
+    $blanket   = $lines | Where-Object { $_ -match '^\s*/?\.milestone-config(/\*?)?\s*$' }
+    $unignored = $lines | Where-Object { $_ -match '^\s*!/?\.milestone-config(/\*?)?\s*$' }
+    if ($blanket -and -not $unignored) {
+      # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
+      # @'…'@ closing terminator must sit at column 0, which breaks when nested under indented
+      # markdown. The text below is byte-identical to the bash printf args and the setup site.
+      Write-Host (@(
+        '🔴 Legacy blanket detected in your root .gitignore'
+        ''
+        '| What | Your root .gitignore ignores the whole .milestone-config/ directory'
+        '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or'
+        '|      | `.milestone-config`). That hides this suite''s TRACKED config —'
+        '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —'
+        '|      | from git, so your config is silently dropped from version control.'
+        '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`'
+        '|      | blanket line. The nested .milestone-config/.gitignore (already'
+        '|      | written) then keeps per-run scratch invisible while feeder.json /'
+        '|      | driver.json / the nested .gitignore stay tracked. We never edit your'
+        '|      | root .gitignore for you — it is yours and may hold unrelated rules.'
+        '| Note | This notice shows at most once per clone.'
+      ) -join "`n")
+      New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+      New-Item -ItemType File -Force -Path $marker | Out-Null
+    }
+  }
+} catch {}
+```
+
 Extract the feeder's own keys with their bundled defaults (`docs/profile-schema.md`, absent-means-default):
 
 | Key | Default | Use |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -120,6 +120,89 @@ The canonical profile location is `<repo-root>/.milestone-config/feeder.json`.
   } catch {}
   ```
 
+- **Detect a legacy-blanket root `.gitignore` and print a one-time by-hand-fix notice (read-only; NEVER auto-edit the root).** The self-heal above writes the *nested* `.milestone-config/.gitignore`, but it cannot help a consumer whose **root** `.gitignore` carries a legacy blanket for the config dir — `.milestone-config/`, `.milestone-config/*`, or bare `.milestone-config` (with or without a leading `/`). A root blanket hides everything under `.milestone-config/` from git — `feeder.json`, `driver.json`, and the nested `.gitignore` we just wrote — so the tracked config is silently dropped from version control and the self-heal is void for exactly those repos. **Detection is read-only — it writes NOTHING to the root `.gitignore` under any condition; the root file is the consumer's and may hold unrelated rules, so the fix is the user's to apply.** Mirrors the driver's one-time marker-gated notice pattern (`milestone-driver/skills/solve-milestone/SKILL.md` preflight / Trello notice: detect → print verbatim → drop a per-clone marker; `milestone-driver/skills/solve-issue/SKILL.md` first-run preflight notice).
+
+  Gate: print the 🔴 notice **verbatim** ONLY when a root blanket is detected **AND** the per-clone marker `.milestone-config/.runtime/legacy-blanket-notice` is **absent**. On print, ensure `.runtime/` exists (`mkdir -p .milestone-config/.runtime` / `New-Item -ItemType Directory -Force`), then create the marker. Stay **silent** if the marker already exists OR no blanket is detected. The marker lives under `.runtime/`, which the nested `.milestone-config/.gitignore` (written above) already ignores — so the marker is git-invisible with **no new gitignore line** (verified: `git check-ignore .milestone-config/.runtime/legacy-blanket-notice` resolves against the nested `.runtime/` entry). **Blanket-clearing rule:** a blanket counts as present UNLESS it is paired with a **broad** un-ignore that actually re-exposes tracked config (`!.milestone-config`, `!.milestone-config/`, or `!.milestone-config/*`). A lone single-file un-ignore such as `!.milestone-config/driver.json` does **NOT** clear it — `feeder.json` and the nested `.gitignore` stay hidden — so it still counts as a blanket and the notice fires. **Both forms below are best-effort: swallow any failure (unwritable dir, permission error, missing git) and continue — a failed detect/marker must never abort setup. Neither form ever writes to the root `.gitignore`.**
+
+  <!-- KEEP THIS DETECTION + NOTICE BLOCK IN SYNC with plan Step 0 (skills/plan/SKILL.md). Read-only on the root .gitignore; marker is .milestone-config/.runtime/legacy-blanket-notice. -->
+  ```text
+  🔴 Legacy blanket detected in your root .gitignore
+
+  | What | Your root .gitignore ignores the whole .milestone-config/ directory
+  |      | (a line like `.milestone-config/`, `.milestone-config/*`, or
+  |      | `.milestone-config`). That hides this suite's TRACKED config —
+  |      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —
+  |      | from git, so your config is silently dropped from version control.
+  | Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`
+  |      | blanket line. The nested .milestone-config/.gitignore (already
+  |      | written) then keeps per-run scratch invisible while feeder.json /
+  |      | driver.json / the nested .gitignore stay tracked. We never edit your
+  |      | root .gitignore for you — it is yours and may hold unrelated rules.
+  | Note | This notice shows at most once per clone.
+  ```
+
+  ```bash
+  # bash — read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts setup.
+  # printf '%s\n' (NOT a heredoc): indent-safe under this list item — a heredoc terminator must sit
+  # at column 0, but this block is nested, so an indented EOF would be a syntax error. Matches the
+  # printf form the self-heal block above uses. The notice text is the quoted args, so it prints
+  # flush-left regardless of this block's indentation — byte-identical to the plan site.
+  marker=".milestone-config/.runtime/legacy-blanket-notice"
+  if [ ! -f "$marker" ] && [ -f ".gitignore" ] \
+     && grep -Eq '^[[:space:]]*/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore \
+     && ! grep -Eq '^[[:space:]]*!/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore; then
+    printf '%s\n' \
+      '🔴 Legacy blanket detected in your root .gitignore' \
+      '' \
+      '| What | Your root .gitignore ignores the whole .milestone-config/ directory' \
+      '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or' \
+      '|      | `.milestone-config`). That hides this suite'"'"'s TRACKED config —' \
+      '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —' \
+      '|      | from git, so your config is silently dropped from version control.' \
+      '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`' \
+      '|      | blanket line. The nested .milestone-config/.gitignore (already' \
+      '|      | written) then keeps per-run scratch invisible while feeder.json /' \
+      '|      | driver.json / the nested .gitignore stay tracked. We never edit your' \
+      '|      | root .gitignore for you — it is yours and may hold unrelated rules.' \
+      '| Note | This notice shows at most once per clone.'
+    mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+  fi
+  ```
+
+  ```powershell
+  # PowerShell 7+ — same read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts setup.
+  try {
+    $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'legacy-blanket-notice')
+    if ((-not (Test-Path $marker)) -and (Test-Path '.gitignore')) {
+      $lines = Get-Content -LiteralPath '.gitignore'
+      $blanket   = $lines | Where-Object { $_ -match '^\s*/?\.milestone-config(/\*?)?\s*$' }
+      $unignored = $lines | Where-Object { $_ -match '^\s*!/?\.milestone-config(/\*?)?\s*$' }
+      if ($blanket -and -not $unignored) {
+        # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
+        # @'…'@ closing terminator must sit at column 0, which breaks when nested under this
+        # indented markdown list item. The text below is byte-identical to the bash printf args.
+        Write-Host (@(
+          '🔴 Legacy blanket detected in your root .gitignore'
+          ''
+          '| What | Your root .gitignore ignores the whole .milestone-config/ directory'
+          '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or'
+          '|      | `.milestone-config`). That hides this suite''s TRACKED config —'
+          '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —'
+          '|      | from git, so your config is silently dropped from version control.'
+          '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`'
+          '|      | blanket line. The nested .milestone-config/.gitignore (already'
+          '|      | written) then keeps per-run scratch invisible while feeder.json /'
+          '|      | driver.json / the nested .gitignore stay tracked. We never edit your'
+          '|      | root .gitignore for you — it is yours and may hold unrelated rules.'
+          '| Note | This notice shows at most once per clone.'
+        ) -join "`n")
+        New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+        New-Item -ItemType File -Force -Path $marker | Out-Null
+      }
+    }
+  } catch {}
+  ```
+
 - Assemble the profile object from the keys the user accepted or edited. **Omit any key left at its bundled default** (absent-means-default, `docs/profile-schema.md`): writing the default explicitly adds noise and drifts when the default changes. `versioning` has **no** default, so a skipped `versioning` is likewise **omitted** — never written as a placeholder; its absent state means `plan` infers-or-asks. A minimal feeder-own-repo profile carries only the self-protection `sourceGlobs`; an empty `{}` is valid.
 - Write the assembled object to `.milestone-config/feeder.json`. **Always write the file**, even when the result is `{}` — config-presence is the signal `plan`'s Step 0 reads to decide whether to auto-invoke setup, so an absent file and an empty file are deliberately distinct.
 - Print the final file contents so the user can verify.


### PR DESCRIPTION
## Summary

Adds read-only detection of a legacy root `.gitignore` blanket (`.milestone-config/`, `.milestone-config/*`, or bare `.milestone-config` without a tracked-config un-ignore) at both `setup` Phase 3 and `plan` Step 0, plus a **one-time 🔴 by-hand-fix notice**. Those legacy-blanket repos are the exact case where the #120/#121 self-heal is silently void (the blanket hides `feeder.json` and the nested gitignore), so this gives existing users the discovery path #119 was filed against. The suite **never auto-edits** the consumer's root `.gitignore` — detection is read-only; the notice fires at most once per clone, gated by a per-clone marker under the already-ignored `.runtime/`. Closes #123.

## Decision Log

- **Detection forms** match `.milestone-config/`, `.milestone-config/*`, bare `.milestone-config`, and the leading-slash variant; a lone `!.milestone-config/driver.json` still counts as blanketed (it leaves `feeder.json`/the nested gitignore hidden); a broad `!.milestone-config[/|/*]` clears it. 18-fixture matrix verified.
- **Notice-only, never auto-edit** the consumer root `.gitignore` — it's the consumer's file and may hold unrelated rules (`skills/plan/SKILL.md`'s scratch-self-ignore is deliberately scoped to the nested gitignore "without touching the consumer's root `.gitignore`").
- **One-time gate** mirrors the driver's marker-gated notice idiom (`milestone-driver/skills/solve-milestone/SKILL.md`); marker `.milestone-config/.runtime/legacy-blanket-notice` is git-invisible via the existing `.runtime/` entry #120/#121 wrote — **no new gitignore line**.
- **Both shells, indent-safe constructs:** bash uses the `printf '%s\n'` house pattern (not a heredoc — a heredoc terminator must sit at column 0 and breaks under the markdown list indent); PowerShell uses `Write-Host (@(…) -join "\`n")` (not a here-string — a here-string `'@` terminator likewise must be at column 0). Both emit a byte-identical notice at both sites.

## Code Review

- /code-review run: yes — **3 rounds** (fresh reviewer agents; the detection logic was tested against fixtures, not assumed)
- Findings across rounds: 2 in-scope defects, both re-dispatched and resolved (≤2-cap), final round 0 findings:
  - **[HIGH] bash heredoc syntax error** at the setup site — `<<'EOF'` terminator indented under the list item → `syntax error: unexpected end of file` (reproduced, exit 2). **Resolved**: replaced both sites' heredoc with the indent-safe `printf '%s\n'` house pattern.
  - **[correctness] PowerShell here-string syntax error** at the setup site — `@'…'@` terminator must be at column 0; indented under the list it fails on Windows/pwsh (a prior reviewer under-rated this as cosmetic, lacking pwsh). **Resolved**: replaced both sites' here-string with the indent-safe `Write-Host (@(…) -join "\`n")` array-join (the repo's established pwsh multi-line pattern from #120/#121).
  - Final review: 0 findings — notice byte-identical across all forms (sha256 match), detection/marker/gate unchanged, read-only preserved.
- No park-triggering findings.
- Both CI gates (vocab-purge + plugin-structure) verified green against the working tree.
- version-free for this PR — version already at the milestone target v0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
