### PR TITLE
fix(plan): bootstrap nudge honors configurable projectDocs (#137)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -153,11 +153,12 @@ try {
 } catch {}
 ```
 
-**Detect an un-bootstrapped repo and print a one-time non-blocking grounding-is-weak notice (read-only; NEVER auto-run the bootstrapper, NEVER scaffold config).** Grounding is strongest when this repo has both the `.project/` standing docs (the project constitution `plan` grounds issue design on) and a driver profile (`.milestone-config/driver.json`, the shared-keys source). When the repo is missing one or both — `.project/` absent or empty (no readable files), **OR** `.milestone-config/driver.json` missing — `plan` still runs, but falls back to thin inferred conventions, so the issues it writes are weaker. This notice tells the user that, points them at `milestone-bootstrapper`, and carries on. **It is purely advisory: never a hard block, never a prompt; it does NOT run `milestone-bootstrapper`, and it writes NOTHING to `.project/` or `driver.json` — its only writes are the `.runtime/` dir and the marker.** This trigger is **independent of** the `feeder.json`-absent → `setup` branch (`skills/plan/SKILL.md:22`) and of the driver-config absent-default resolution (the key-extraction table and the "Resolve the shared keys" steps below) — neither is altered, and a present `feeder.json` with an absent `driver.json` still nudges here while resolving driver keys by absent-default below. Mirrors the driver's one-time marker-gated notice pattern, the same family as the legacy-blanket sibling above (detect → print verbatim → drop a per-clone marker).
+**Detect an un-bootstrapped repo and print a one-time non-blocking grounding-is-weak notice (read-only; NEVER auto-run the bootstrapper, NEVER scaffold config).** Grounding is strongest when this repo has both the project's standing docs (the project constitution `plan` grounds issue design on, found under the configurable `projectDocs` path — default `.project/`) and a driver profile (`.milestone-config/driver.json`, the shared-keys source). **The standing-docs path is the resolved `projectDocs` value, not a hardcoded `.project/`** — a consumer with a custom `projectDocs` (e.g. `docs/standards/`) that *is* bootstrapped must not get a false nudge. So this block resolves `projectDocs` in-place **before** the detect (the key-extraction table below has not run yet), reading `.milestone-config/feeder.json` directly with the **same default (`.project/`) the table uses** so the two reads cannot diverge; a missing file / malformed JSON / missing `jq` falls back to `.project/`. When the repo is missing one or both — the resolved `projectDocs` path absent or empty (no readable files), **OR** `.milestone-config/driver.json` missing — `plan` still runs, but falls back to thin inferred conventions, so the issues it writes are weaker. This notice tells the user that, names the resolved `projectDocs` path, points them at `milestone-bootstrapper`, and carries on. **It is purely advisory: never a hard block, never a prompt; it does NOT run `milestone-bootstrapper`, and it writes NOTHING to `.project/` or `driver.json` — its only writes are the `.runtime/` dir and the marker.** This trigger is **independent of** the `feeder.json`-absent → `setup` branch (`skills/plan/SKILL.md:22`) and of the driver-config absent-default resolution (the key-extraction table and the "Resolve the shared keys" steps below) — neither is altered, and a present `feeder.json` with an absent `driver.json` still nudges here while resolving driver keys by absent-default below. Mirrors the driver's one-time marker-gated notice pattern, the same family as the legacy-blanket sibling above (detect → print verbatim → drop a per-clone marker).
 
-Gate: print the 🟡 notice **verbatim** ONLY when the repo is un-bootstrapped (`.project/` absent-or-no-readable-files **OR** `.milestone-config/driver.json` missing) **AND** the per-clone marker `.milestone-config/.runtime/bootstrap-nudge-notice` is **absent**. On print, ensure `.runtime/` exists (`mkdir -p .milestone-config/.runtime` / `New-Item -ItemType Directory -Force`), then create the marker. Stay **silent** if the marker already exists OR the repo is bootstrapped (both `.project/` has a readable file AND `driver.json` is present). The marker lives under `.runtime/`, which the nested `.milestone-config/.gitignore` (written above) already ignores — so the marker is git-invisible with **no new gitignore line**. **Both forms below are best-effort: swallow any failure (unwritable dir, permission error) and continue the `plan` run — a failed detect/notice/marker must never abort `plan`. Neither form ever writes to `.project/` or `driver.json`, and neither runs the bootstrapper.**
+Gate: print the 🟡 notice **verbatim** ONLY when the repo is un-bootstrapped (resolved `projectDocs` path absent-or-no-readable-files **OR** `.milestone-config/driver.json` missing) **AND** the per-clone marker `.milestone-config/.runtime/bootstrap-nudge-notice` is **absent**. On print, ensure `.runtime/` exists (`mkdir -p .milestone-config/.runtime` / `New-Item -ItemType Directory -Force`), then create the marker. Stay **silent** if the marker already exists OR the repo is bootstrapped (both the resolved `projectDocs` path has a readable file AND `driver.json` is present). The marker lives under `.runtime/`, which the nested `.milestone-config/.gitignore` (written above) already ignores — so the marker is git-invisible with **no new gitignore line**. **Both forms below are best-effort: swallow any failure (unwritable dir, permission error, malformed feeder.json, missing `jq`) and continue the `plan` run — a failed resolve/detect/notice/marker must never abort `plan`. Neither form ever writes to `projectDocs` / `.project/` or `driver.json`, and neither runs the bootstrapper.**
 
-<!-- KEEP THIS DETECTION + NOTICE BLOCK IN SYNC across the plan/setup one-time-notice family. plan Step 0 only (no setup twin). Read-only on .project/ and driver.json; never runs milestone-bootstrapper; marker is .milestone-config/.runtime/bootstrap-nudge-notice. -->
+<!-- KEEP THIS DETECTION + NOTICE BLOCK IN SYNC across the plan/setup one-time-notice family. plan Step 0 only (no setup twin). Read-only on projectDocs/.project/ and driver.json; never runs milestone-bootstrapper; marker is .milestone-config/.runtime/bootstrap-nudge-notice. -->
+<!-- This text block shows the DEFAULT-config rendering (projectDocs = .project/). The runnable bash/PowerShell forms below interpolate the RESOLVED projectDocs path into the "| What |" line — so a custom projectDocs (e.g. docs/standards/) prints "...no docs/standards/ standing docs..." while the default stays byte-identical to this template. Do not make this template dynamic. -->
 ```text
 🟡 This repo isn't bootstrapped — your plan's grounding will be weak
 
@@ -174,16 +175,24 @@ Gate: print the 🟡 notice **verbatim** ONLY when the repo is un-bootstrapped (
 ```
 
 ```bash
-# bash — read-only detect + one-time notice; NEVER writes .project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
+# bash — read-only detect + one-time notice; NEVER writes projectDocs/.project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
 # printf '%s\n' (NOT a heredoc): the same indent-safe construct the sibling legacy-blanket block uses, so both
 # sites emit one consistent form. The notice text is the quoted args, so it prints flush-left.
+# Resolve projectDocs in-block (the key-extraction table below has not run yet) with the SAME default the table uses,
+# so the two reads can't diverge; a non-string projectDocs (number/array), missing file / malformed JSON / missing jq
+# all fall back to .project/. Strip ALL trailing slashes for the detect operand; an empty result (e.g. "/") falls back
+# to .project so bash and PowerShell agree; the notice re-adds a single "/" so the printed path always ends in "/".
+pd="$(jq -r 'if (.projectDocs | type) == "string" then .projectDocs else ".project/" end' .milestone-config/feeder.json 2>/dev/null || echo ".project/")"
+[ -z "$pd" ] && pd=".project/"
+while [ "$pd" != "${pd%/}" ]; do pd="${pd%/}"; done
+[ -z "$pd" ] && pd=".project"
 marker=".milestone-config/.runtime/bootstrap-nudge-notice"
 if [ ! -f "$marker" ] \
-   && { [ -z "$(find -L .project -type f 2>/dev/null | head -1)" ] || [ ! -f ".milestone-config/driver.json" ]; }; then
+   && { [ -z "$(find -L "$pd" -type f 2>/dev/null | head -1)" ] || [ ! -f ".milestone-config/driver.json" ]; }; then
   printf '%s\n' \
     '🟡 This repo isn'"'"'t bootstrapped — your plan'"'"'s grounding will be weak' \
     '' \
-    '| What | This repo has no .project/ standing docs and/or no' \
+    "| What | This repo has no ${pd}/ standing docs and/or no" \
     '|      | .milestone-config/driver.json. Without them, plan has no project' \
     '|      | constitution to ground issue design on and no driver profile to' \
     '|      | resolve shared keys from, so it falls back to thin inferred' \
@@ -198,19 +207,27 @@ fi
 ```
 
 ```powershell
-# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes .project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
+# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes projectDocs/.project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
 try {
+  # Resolve projectDocs in-block (the key-extraction table below has not run yet) with the SAME default the table uses,
+  # so the two reads can't diverge; a non-string projectDocs (number/array), missing file / malformed JSON all fall
+  # back to .project/. Strip ALL trailing slashes for the detect operand; an empty result (e.g. "/") falls back to
+  # .project so PowerShell and bash agree; the notice re-adds a single "/" so the printed path always ends in "/".
+  $pd = '.project/'
+  try { $pdRaw = (Get-Content -Raw -LiteralPath (Join-Path '.milestone-config' 'feeder.json') -ErrorAction Stop | ConvertFrom-Json).projectDocs; if ($pdRaw -is [string]) { $pd = $pdRaw } } catch {}
+  $pd = $pd -replace '/+$',''
+  if (-not $pd) { $pd = '.project' }
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'bootstrap-nudge-notice')
-  $projectEmpty = -not (Test-Path '.project') -or -not (Get-ChildItem -LiteralPath '.project' -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $projectEmpty = -not (Test-Path $pd) -or -not (Get-ChildItem -LiteralPath $pd -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)
   $driverMissing = -not (Test-Path (Join-Path '.milestone-config' 'driver.json'))
   if ((-not (Test-Path $marker)) -and ($projectEmpty -or $driverMissing)) {
     # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
     # @'…'@ closing terminator must sit at column 0, which breaks when nested under indented
-    # markdown. The text below is byte-identical to the bash printf args.
+    # markdown. The text below is byte-identical to the bash printf args (same resolved $pd).
     Write-Host (@(
       '🟡 This repo isn''t bootstrapped — your plan''s grounding will be weak'
       ''
-      '| What | This repo has no .project/ standing docs and/or no'
+      "| What | This repo has no ${pd}/ standing docs and/or no"
       '|      | .milestone-config/driver.json. Without them, plan has no project'
       '|      | constitution to ground issue design on and no driver profile to'
       '|      | resolve shared keys from, so it falls back to thin inferred'


### PR DESCRIPTION
Closes #137.

## Summary
The #132 bootstrap-nudge hardcoded the literal `.project/` in both its detection and its notice text. A consumer who points the configurable `projectDocs` key at a custom directory (and is fully bootstrapped) got a false "your grounding will be weak" nudge. The nudge now resolves `projectDocs` **in-block** (reading `.milestone-config/feeder.json` directly, default `.project/` — the same default the key-extraction table uses, so the two reads can't diverge) and uses the resolved path in both the detect operand and the notice's `| What |` line. Default-config repos render **byte-identically**. Bumps `plugin.json` to 0.4.5.

This was authored through the feeder pipeline itself (`/milestone-feeder:plan #133` → architect → issue-author → self-check gate → `create`), then built by the driver — dogfooding the plugin for the exact thing it exists to do.

## Decision Log
| Choice | Rationale | Citation | Alternative rejected |
|---|---|---|---|
| Resolve `projectDocs` via direct `jq`/`ConvertFrom-Json` read of `feeder.json`, default `.project/` | The nudge fires before the key-extraction table runs, so the table's resolution isn't available; using the table's identical default prevents the two reads from diverging (the recorded self-check Advisory) | `docs/profile-schema.md:46`; the key-extraction table's `projectDocs` default | hoisting the key-extraction table earlier (out of scope; entangles the nudge with shared-key resolution) |
| Display the resolved path with a single trailing slash (`${pd}/`) in the notice; strip slashes for the detect operand | Gives a clean detect operand while preserving byte-identity (default `.project` → displays `.project/`) | the AC byte-identity requirement | storing the slash form and stripping at detect (more churn, same result) |
| Harden resolution: JSON string-type guard + strip-**all**-trailing-slashes + empty-after-normalize → `.project` fallback | A `/code-review` parity finding: `projectDocs: "/"` made the **bash** form nudge but the **PowerShell** form go silent (post-strip empty operand: bash `find -L ""` fires, PowerShell `Test-Path ''` throws → swallowed → block skipped). Also fixes doubled-slash and non-string (array → multi-line garbage) rendering. Both forms now resolve identically. | the "Cross-platform: bash (jq) and PowerShell 7+" nonNegotiable | one-slash strip + bare truthy-check (left the divergence) |
| `\| Fix \|` line kept literal `.project/` | It names the bootstrapper's default scaffold dir (not the consumer's `projectDocs`); only `\| What \|` is dynamic | implementer scoping decision | interpolating the resolved path into Fix (reaches into bootstrapper semantics; out of scope) |

## Code Review
- /code-review run: yes (high effort)
- Findings: 6 (1 parity bug + 2 robustness + 3 accepted)
  - **F4** `projectDocs: "/"` bash↔PowerShell divergence (genuine parity bug) → **re-dispatched and resolved** (strip-all-slashes + empty→`.project` fallback; both forms agree)
  - **F1** double-trailing-slash doubled the notice path → **re-dispatched and resolved** (strip-all-trailing-slashes)
  - **F2** non-string `projectDocs` diverged / bash array → multi-line garbage → **re-dispatched and resolved** (JSON string-type guard)
  - **F3** whitespace-only `projectDocs` leaks a space path → **accepted** (degenerate config; both forms agree — no parity break)
  - **F5** `..`/absolute `projectDocs` probes outside the repo → **accepted** (probing a user-configured path is intended; a monorepo may legitimately point elsewhere; a containment check would be wrong)
  - **F6** `\| Fix \|` line still names `.project/` while `\| What \|` is dynamic → **accepted** (Fix names the bootstrapper's default scaffold dir; mixed-path is deliberate)
- Re-review after the fix: clean; byte-identity for default config preserved (0 diff).
- No park-triggering findings.
- Version-bump (`plugin.json` 0.4.4 → 0.4.5): config edit, no logic change.

## Verification (no test layer)
Skill-markdown has no unit-test layer. Verified by behavioral harness (8 cases + the hardening re-verify): default byte-identity (0 diff), custom `projectDocs` silent-when-bootstrapped / names-resolved-path-when-not, trailing-slash + explicit-default normalization, error/best-effort fallback to `.project/`, and the hardening cases (`"/"`, `docs/x//`, number/array). PowerShell form verified by inspection against the bash form (pwsh unavailable on host).
