### PR TITLE
feat: bootstrap this repo's own .project/ standing docs (dogfood)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ __pycache__/
 # NOTE: does not match .milestone-config/ (the committed feeder/driver profiles).
 # Un-anchored so it matches at any depth (e.g. under tests/scenarios/<n>/).
 .milestone-feeder/
+
+# milestone-bootstrapper provisioning-plan scratch (per-run, e.g.
+# .milestone-bootstrapper/plan-<slug>.md) — the bootstrapper analog of the
+# .milestone-feeder/ scratch above: reviewed then deployed by `apply`, never
+# committed. NOTE: does not match .milestone-config/ (the committed profiles).
+.milestone-bootstrapper/

--- a/.project/conventions.md
+++ b/.project/conventions.md
@@ -1,0 +1,39 @@
+# Conventions
+
+<!--
+Project doc (.project/). Cite as `.project/conventions.md#<section>`. This is the file the
+implementer and coherence-reviewer lean on hardest — "reuse conventions" and
+"does this fit the app?" both resolve here. Prefer pointing at a canonical
+exemplar in the codebase (path:line) over prose. Keep ## headings stable — they
+are citation anchors.
+-->
+
+## Naming
+Files, types, functions, tests, branches.
+Skills live at `skills/<verb>/SKILL.md` (verbs: `plan`, `create`, `update`, `setup`); agents at `agents/<name>.md` (ids `milestone-feeder:architect`, `milestone-feeder:issue-author`); hooks at `hooks/` (`hooks.json`, `run-hook.cmd`, `<name>.sh`, `<name>.ps1`). Issue labels: `ui`/`logic` + `risk:light`/`risk:heavy` (the feeder's taxonomy, aligned to the driver's). Plan files: `.milestone-feeder/plan-<slug>.md` where `<slug>` is the lowercased milestone goal with non-alphanumeric runs collapsed to single hyphens, trimmed. Branches: `develop` (integration) / `main` (protected). (Grounded in `docs/architecture.md` Plugin contents, The plan file as build artifact; `SPEC.md` §3, §3.1.)
+
+## File & folder layout
+Where things go, and the shape of a feature.
+`skills/` (one folder per verb, each a `SKILL.md`) · `agents/` (one `.md` per agent) · `hooks/` (the `no-source-edit` gate + polyglot launcher) · `.claude-plugin/` (`plugin.json` + `marketplace.json`) · `docs/` (architecture, profile-schema, consumer-setup, `specs/`) · `tests/scenarios/NN-*/` (end-to-end fixtures) · `scripts/` (validation helpers) · `.milestone-config/` (`feeder.json`, `driver.json`, nested `.gitignore`). SPEC.md + README.md + CHANGELOG.md at the root. (Grounded in repo layout; `docs/architecture.md` Plugin contents table.)
+
+## Test patterns
+Where tests live, how they're named, fixtures/factories, and what a good test looks like.
+End-to-end scenarios under `tests/scenarios/NN-<slug>/`: each carries a `brief.md` (the input) and a `.milestone-config/feeder.json` fixture, exercising one planning path (01-clean-happy-path, 02-product-gap-parks, 03-design-resolvable-no-park, 04-no-code-refusal, 05-reviewer-backends, 06-cross-cutting-consistency). The README lists planned 07–09. New scenarios append, and the `tests/scenarios/` README is updated to list them. Cross-platform parity is itself a test obligation: bash and pwsh twins must produce identical findings on degenerate inputs. (Grounded in `tests/scenarios/` 01–06; issue #118 acceptance criteria; `CHANGELOG.md` v0.4.5 "cross-platform-parity-hardened".)
+
+## Canonical exemplars (mirror these)
+The reference implementations to copy when building something similar. Point at real code.
+
+| For… | Mirror | Notes |
+|---|---|---|
+| A new skill (orchestrator verb) | `skills/plan/SKILL.md` | Frontmatter name/description, "Announce first", numbered Procedure, output style, non-negotiables block — the suite's SKILL shape. |
+| A new read-only agent | `agents/architect.md`, `agents/issue-author.md` | Read-only; returns structured text; never writes repo files or opens issues. |
+| A cross-platform hook | `hooks/no-source-edit.sh` + `hooks/no-source-edit.ps1` + `hooks/run-hook.cmd` | Bash-first / pwsh-fallback twins via the polyglot launcher; fail-open. |
+| A one-time discovery notice | `plan` Step 0 bootstrap nudge (`CHANGELOG.md` v0.4.4/v0.4.5) | Best-effort, read-only, marker-gated to show at most once per clone; honors configurable `projectDocs`. |
+
+## Commits & PRs
+Message format and PR expectations.
+Feature branch → PR → `develop` (the integration branch); `develop` → `main` is the human-owned release, done by hand. `main` is protected (never push directly; never open a PR to it from automation). Conventional-commit-style messages. The feeder itself opens **no** PRs and touches **no** branches — the version is bumped by hand at release time (no per-PR version machinery, because the feeder has no PR to ride). A release re-syncs the version-bearing locations together (see Versioning). (Grounded in `.milestone-config/driver.json` integrationBranch/protectedBranch; `docs/architecture.md` Plugin version, Modes & autonomy.)
+
+## Versioning
+Does the project follow semantic versioning? If so, **where the version lives** (e.g. `pyproject.toml`, `package.json`, `*.csproj`, a `VERSION` file) and the **bump cadence** (per feature / milestone). When semver is on, `milestone-driver` applies the bump per PR and `milestone-feeder` names milestones as versions so the driver can derive the target.
+**SemVer.** The single source of truth is `.claude-plugin/plugin.json` `version`. There is **no per-PR version machinery** — the feeder opens no PRs, so the driver's bump-rides-the-PR mechanism has nothing to ride; the version is bumped **by hand** when a release is cut. `.claude-plugin/marketplace.json` carries no `version` field (Claude Code resolves `plugin.json` first). **Release checklist:** bump `plugin.json` first, then re-sync any other hand-maintained in-doc version reference. (Open drift, issue #143: the `SPEC.md` as-built header lags `plugin.json`; the preferred fix is to **drop** the version from the SPEC header and point readers at `plugin.json` as the single source of truth — one fewer place to drift.) (Grounded in `docs/architecture.md` Plugin version + Release checklist; `.claude-plugin/plugin.json`; issue #143.)

--- a/.project/conventions.md
+++ b/.project/conventions.md
@@ -18,7 +18,7 @@ Where things go, and the shape of a feature.
 
 ## Test patterns
 Where tests live, how they're named, fixtures/factories, and what a good test looks like.
-End-to-end scenarios under `tests/scenarios/NN-<slug>/`: each carries a `brief.md` (the input) and a `.milestone-config/feeder.json` fixture, exercising one planning path (01-clean-happy-path, 02-product-gap-parks, 03-design-resolvable-no-park, 04-no-code-refusal, 05-reviewer-backends, 06-cross-cutting-consistency). The README lists planned 07–09. New scenarios append, and the `tests/scenarios/` README is updated to list them. Cross-platform parity is itself a test obligation: bash and pwsh twins must produce identical findings on degenerate inputs. (Grounded in `tests/scenarios/` 01–06; issue #118 acceptance criteria; `CHANGELOG.md` v0.4.5 "cross-platform-parity-hardened".)
+End-to-end scenarios under `tests/scenarios/NN-<slug>/`: each carries a `brief.md` (the input) plus a `project/` fixture, a `feeder-env.md`, and an `expected.md`, exercising one planning path (01-clean-happy-path, 02-product-gap-parks, 03-design-resolvable-no-park, 04-no-code-refusal, 05-reviewer-backends, 06-cross-cutting-consistency). The scenarios index `tests/README.md` lists planned 07–09 and documents how to run them and how to read `tests/RESULTS.md`. New scenarios append, and `tests/README.md` is updated to list them. Cross-platform parity is itself a test obligation: bash and pwsh twins must produce identical findings on degenerate inputs. (Grounded in `tests/README.md`; `tests/scenarios/` 01–06; issue #118 acceptance criteria; `CHANGELOG.md` v0.4.5 "cross-platform-parity-hardened".)
 
 ## Canonical exemplars (mirror these)
 The reference implementations to copy when building something similar. Point at real code.

--- a/.project/design-philosophy.md
+++ b/.project/design-philosophy.md
@@ -1,0 +1,34 @@
+# Design philosophy
+
+<!--
+Part of your project docs (.project/). Tools read and cite this file as
+`.project/design-philosophy.md#<section>`. Fill every [TBD]. A section left as
+[TBD] is treated as "not specified" — tools fall back to inferred repo
+convention rather than ground on a placeholder. Humans own this file; tools may
+*propose* changes but never rewrite it. Keep the ## headings stable — they are
+citation anchors. Add new sections by appending, not renaming.
+-->
+
+## Architectural stance
+What kind of system is this, and what does it fundamentally optimize for?
+A stack-agnostic, generic planning **engine** ships in the plugin; each repo supplies a thin per-repo profile (`.milestone-config/feeder.json`) plus its standing docs (`.project/`). One job: turn a feature brief into a GitHub milestone of small, well-formed issues that `milestone-driver` can build with no human clarification. It optimizes for **issues that pass the driver's triage clean (`GAPS: none`)** — its quality bar *is* the driver's entry gate, reused not redefined. Reads code; never writes it. (Grounded in `SPEC.md` §1 Purpose & scope; `docs/architecture.md` Architecture.)
+
+## Layering & boundaries
+The layers and the allowed dependency directions — what may depend on what, and what must never.
+`plan` (orchestrator, Steps 0–6) dispatches the `architect` agent **once**, then the `issue-author` agent **per candidate**; the **reviewer gate** (Step 6) vets every generated issue; `plan` emits the plan file at Step 7. `create` deploys the approved plan file to GitHub; `update` reconciles a refreshed plan onto an existing milestone. **Skills orchestrate and perform GitHub writes; agents are read-only and author issue text, never opening issues themselves** (the agent-read-only invariant). The plan file is the **build artifact** — the single source of truth `create`/`update` deploy ("the plan file is the spec; GitHub is the deployment"). (Grounded in `docs/architecture.md` The plan procedure, Plugin contents, The plan file as build artifact; `SPEC.md` §3, §3.1.)
+
+## What we optimize for
+Ranked priorities, and the explicit non-goals that follow from them.
+1) Issues that pass the driver's triage clean — no second, drifting definition of "well-formed" (reuse the driver's reviewers as the acceptance gate). 2) Grounded design — every recorded decision cites a `.project/<doc>.md#<section>` or a sibling `file:line`; nothing invented. 3) Composability — reuse the driver's reviewer agents and `create`'s write-primitives by reference rather than re-deriving a drifting copy. **Non-goals (refuses on purpose):** writing code, opening PRs, touching branches, and inventing **product** decisions (what to build / user-facing behavior with no conventional default). (Grounded in `SPEC.md` §1; `docs/architecture.md` Reused-not-rebuilt, Modes & autonomy.)
+
+## One-way doors
+Decisions that require human sign-off *before* they're made — irreversible or expensive-to-reverse choices.
+Product calls (what to build / user-facing behavior with no conventional default) are **parked** to a "needs product input" report, never guessed — the load-bearing park boundary. A new profile key is consumer-driven: **added only when a real consumer needs it, never speculatively**. Adding a dependency is a PAUSE gate (see `library-manifest.md`). Every new feature / config key / behavior change must ship an existing-user **discovery / migration path** (the normative principle, `SPEC.md` §3.1) — non-breaking is necessary but not sufficient. (Grounded in `docs/architecture.md` Pipeline position, Modes & autonomy; `SPEC.md` §2, §3.1; `docs/profile-schema.md` Design principle.)
+
+## Error & failure philosophy
+How the system handles and surfaces failure: fail-open vs fail-closed, the user-facing error policy, logging expectations.
+The mechanical gate (`no-source-edit` hook) is **fail-open**: if no `sourceGlobs` source resolves, the hook does not block (a robustness measure so a hook bug never bricks the repo). The bootstrap nudge and one-time notices are **best-effort, read-only, non-blocking** — they never stop `plan` and show at most once per clone (marker-gated). The reviewer gate degrades gracefully: `reviewer: "milestone-driver"` falls back to `"internal"` when the driver's reviewers don't resolve (a notice, never a failure); `reviewer: false` skips the gate with a visible 🔴 warning. Standing docs are read **best-effort** — a missing directory or `[TBD]` section is skipped, never grounded on. (Grounded in `docs/architecture.md` The mechanical gate; `docs/profile-schema.md` resolution chains; `CHANGELOG.md` v0.4.4/v0.4.5; `docs/consumer-setup.md` §4.)
+
+## Testing philosophy
+What we test, at what level, and what "verified" means before a change is done.
+Success is testable: everything the feeder emits passes the same triage that gates the driver. End-to-end **scenarios** live under `tests/scenarios/` (01–06 today, all single-root) — each a `brief.md` + a `.milestone-config/feeder.json` fixture exercising a planning path. The cross-platform contract is verified by shipping every hook/script as a **bash + PowerShell 7+ twin** with identical behavior. `scripts/validate-plugin-structure.py` and `scripts/check-vocabulary.sh` guard structural and vocabulary invariants. (Grounded in `tests/scenarios/` 01–06; issue #118 "existing scenarios … are all single-root"; `scripts/`; `.milestone-config/driver.json` nonNegotiables.)

--- a/.project/design-system.md
+++ b/.project/design-system.md
@@ -1,0 +1,39 @@
+# Design system
+
+<!--
+Project doc (.project/). Cite as `.project/design-system.md#<section>`. Machine-readable
+design tokens live in `tokens.json` alongside this file. Absent or all-[TBD] →
+no design-lens grounding (design-reviewer / coherence-reviewer / wireframing
+skip it). Skip this file entirely for repos with no UI surface. Keep ## headings
+stable — they are citation anchors.
+-->
+
+## Design tokens
+Canonical color, type, spacing, and radius scales. Source of truth is `tokens.json`; describe intent and usage here.
+> [TBD] — e.g. "Brand primary for primary actions only; never for body text. Spacing on a 4px rhythm."
+
+## Component inventory
+The canonical components and where they live. New UI reuses these before introducing a one-off.
+
+| Component | Location | Use for |
+|---|---|---|
+| [TBD] | [TBD path] | [TBD] |
+
+## Layout & responsive rules
+Grid, breakpoints, spacing rhythm, density.
+> [TBD]
+
+## Required states
+Every interactive surface must handle these explicitly.
+- **Empty:** [TBD]
+- **Loading:** [TBD]
+- **Error:** [TBD]
+- **Disabled:** [TBD]
+
+## Accessibility baseline
+The standard you hold, plus contrast, focus, target size, and semantics expectations.
+> [TBD] — e.g. "WCAG 2.2 AA; visible focus on all interactive elements; min 44px touch targets."
+
+## Voice & microcopy
+Tone for labels, errors, and empty states.
+> [TBD]

--- a/.project/environment.md
+++ b/.project/environment.md
@@ -1,0 +1,34 @@
+# Environment
+
+<!--
+Project doc (.project/). Cite as `.project/environment.md#<section>`. Declares what the
+project's runtime and production environment looks like — the facts downstream tools ground
+their data, test, and caching decisions in. It does NOT provision anything; it records the
+model so issues don't drift. Fill every [TBD]; a section left [TBD] is treated as "not
+specified." Humans own this file; tools propose, never rewrite. Keep the ## headings stable
+— they are citation anchors.
+-->
+
+## Environments
+Which environments exist (production, staging, test, local) and how they differ.
+No runtime/deploy environments — milestone-feeder is a Claude Code plugin that runs inside the user's Claude Code session against their local repo and GitHub via `gh`. "Environments" = the consumer repos that adopt it; the plugin itself ships via a marketplace (`.claude-plugin/marketplace.json`) and is dev-installable via `claude --plugin-dir`. (Grounded in `docs/consumer-setup.md` §1; `.claude-plugin/marketplace.json`.)
+
+## Data stores
+Databases and other persistent stores: the engine(s), and the **topology** — separate prod / staging / test databases, or a shared one. **Test-data isolation:** how tests get a clean, isolated database (a dedicated test DB, a per-worker DB suffix, transactional rollback, truncate-on-start). This is the single biggest drift source if left unstated.
+None. The plugin holds no database. Its only persisted state is local **scratch** under `.milestone-feeder/` (the plan file `plan-<slug>.md`, gitignored via a `*` drop on first write) and per-clone runtime markers under `.milestone-config/.runtime/` (one-time-notice gates). Tracked config lives in `.milestone-config/feeder.json` and `.milestone-config/driver.json`. Test-data isolation: each `tests/scenarios/NN-*/` is a self-contained fixture. (Grounded in `docs/architecture.md` The plan file as build artifact; `CHANGELOG.md` v0.4.4 marker note; `.milestone-config/.gitignore`.)
+
+## Caching
+Whether caching exists and, if so, the layer and technology (in-memory, Redis, CDN), what is cached, and the invalidation policy. **"None" is a valid, drift-preventing answer** — record it explicitly.
+None — no caching layer.
+
+## Async & messaging
+Background jobs, queues, streams, schedulers — or "none."
+None. Synchronous skill execution; agents are dispatched as subagents within a `plan` run (architect once, issue-author per candidate, parallelizable). No queues, schedulers, or background jobs. (Grounded in `docs/architecture.md` The plan procedure Steps 3–4.)
+
+## External services & integrations
+Third-party services the app depends on: auth / identity, payments, email / SMS, object storage, analytics, other APIs.
+**GitHub** via the `gh` CLI (the only external service) — `gh label create`, `gh api .../milestones` (POST/PATCH), `gh issue create/edit/list/view/comment`. Optional sibling plugins: `milestone-driver` (reviewer backend) and `milestone-coherence-reviewer` (post-build review). Hard dependency: `superpowers`. No auth / payments / email / storage. (Grounded in `docs/consumer-setup.md` Before you start, §1; `README.md` Before you start.)
+
+## Runtime & hosting
+Where it runs and the runtime/version targets (hosting platform, language-runtime versions, regions). For mandated frameworks and packages, cross-reference `library-manifest.md`.
+Runs in the user's Claude Code CLI session; no hosting. Requires `gh` installed and signed in, `git`, and **bash with `jq`** or **PowerShell 7+** (for the `no-source-edit` hook). Cross-platform: macOS, Linux, WSL, git-bash, Windows (pwsh 7+). (Grounded in `README.md` Before you start; `.gitattributes`.)

--- a/.project/library-manifest.md
+++ b/.project/library-manifest.md
@@ -1,0 +1,31 @@
+# Library manifest
+
+<!--
+Project doc (.project/). Cite as `.project/library-manifest.md#<section>`. The
+implementer's "new dependency = PAUSE" gate reads this; the coherence-reviewer
+flags a new library that duplicates one listed here. Keep it current. Keep ##
+headings stable — they are citation anchors.
+-->
+
+## Runtime & frameworks
+The platform/runtime and primary frameworks, with versions. (Mirror these into milestone-driver `nonNegotiables` where they're hard constraints.)
+Claude Code plugin: markdown **skills** (frontmatter triggers) + markdown **agents** + **hooks** shipped as cross-platform **bash (`jq`) and PowerShell 7+** twins, BOM-free, LF line endings. No compiled runtime. Hard dependency: the `superpowers` plugin (declared in `.claude-plugin/plugin.json`). The plugin version is pinned in `.claude-plugin/plugin.json` (`version: 0.4.5`). Mirror into `milestone-driver` `nonNegotiables` — already present: "Claude Code plugin: markdown skills + bash-first/pwsh-fallback hooks"; "Cross-platform: bash (jq) and PowerShell 7+". (Grounded in `.claude-plugin/plugin.json`; `.milestone-config/driver.json` nonNegotiables; `.gitattributes`; stack detection.)
+
+## Approved libraries (by purpose)
+One approved choice per purpose, so a redundant alternative is easy to spot.
+
+| Purpose | Library | Notes |
+|---|---|---|
+| GitHub writes/reads | `gh` (GitHub CLI) | `gh label/issue/api` — the only way the feeder touches GitHub (`docs/consumer-setup.md` Before you start). |
+| JSON parsing in hooks | `jq` (bash path) | The bash hook form; the PowerShell 7+ twin uses native `ConvertFrom-Json`. |
+| Cross-platform shell | bash + PowerShell 7+ | Every hook/script ships as a twin (`.sh` + `.ps1`) via the `run-hook.cmd` polyglot launcher. |
+| Reviewer backend (optional) | `milestone-driver` plugin | Backs `reviewer: "milestone-driver"`; absent → degrades to `"internal"`. |
+| Plan pipeline dependency | `superpowers` plugin | Hard dependency declared in the manifest. |
+
+## Adding a dependency (the gate)
+A new dependency is a PAUSE, not an autonomous call. Record what it buys, its license / OSS status, and why nothing approved suffices; a human approves before it's added.
+A new dependency is a PAUSE, not an autonomous call — record what it buys, its license / OSS status, and why nothing approved suffices; a human approves before it's added. Profile keys follow the same discipline: **added only when a real consumer needs them, never speculatively**. Proposals go to a GitHub issue labeled `needs decision`. (Grounded in `docs/profile-schema.md` Design principle; suite convention.)
+
+## Avoid / banned
+Libraries explicitly not to use, and why.
+No CRLF line endings in `*.cmd` / `*.sh` / `*.ps1` (CRLF breaks the bash heredoc delimiter and produces "bad interpreter" — enforced by `.gitattributes`). No BOM in scripts. No bash-only or pwsh-only hook — every hook/script must ship **both** twins with identical behavior. No `version` field in `.claude-plugin/marketplace.json` (Claude Code resolves `plugin.json` first). The feeder must never write source, open a PR, or touch a branch. (Grounded in `.gitattributes`; `docs/architecture.md` Plugin version, The mechanical gate.)

--- a/.project/tokens.json
+++ b/.project/tokens.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Machine-readable design tokens for .project/design-system.md. Replace [TBD] values. Consumed by the design-reviewer, coherence-reviewer, and wireframing tool. A token left as [TBD] is treated as unspecified. Extend per project; keep keys stable once consumers depend on them.",
+  "color": {
+    "brand": { "primary": "[TBD hex]", "secondary": "[TBD hex]" },
+    "text": { "default": "[TBD]", "muted": "[TBD]", "inverse": "[TBD]" },
+    "bg": { "default": "[TBD]", "subtle": "[TBD]" },
+    "state": { "success": "[TBD]", "warning": "[TBD]", "error": "[TBD]", "info": "[TBD]" }
+  },
+  "type": {
+    "family": { "sans": "[TBD]", "mono": "[TBD]" },
+    "scale": { "xs": "[TBD]", "sm": "[TBD]", "base": "[TBD]", "lg": "[TBD]", "xl": "[TBD]", "2xl": "[TBD]" },
+    "weight": { "regular": 400, "medium": 500, "bold": 700 }
+  },
+  "space": { "0": "0", "1": "[TBD]", "2": "[TBD]", "3": "[TBD]", "4": "[TBD]", "6": "[TBD]", "8": "[TBD]" },
+  "radius": { "sm": "[TBD]", "md": "[TBD]", "lg": "[TBD]", "full": "9999px" },
+  "breakpoint": { "sm": "[TBD]", "md": "[TBD]", "lg": "[TBD]", "xl": "[TBD]" }
+}


### PR DESCRIPTION
## Summary

Dogfoods `milestone-bootstrapper` on milestone-feeder itself (issue #144): captures this repo's real conventions into `.project/` so the feeder and coherence-reviewer build/review changes here on grounded standing docs instead of thin inferred conventions — and the `plan` Step 0 bootstrap nudge (CHANGELOG v0.4.4/v0.4.5) stops firing every run.

## What's in here

| Doc | State | Grounded in |
|---|---|---|
| `design-philosophy.md` | populated | `SPEC.md` §1/§3/§3.1, `docs/architecture.md` (stance, layering, optimize-for, one-way doors, error philosophy, testing) |
| `library-manifest.md` | populated | `.claude-plugin/plugin.json`, `.milestone-config/driver.json` nonNegotiables, `.gitattributes`, stack detection (runtime, approved libs, dependency gate, avoid/banned) |
| `environment.md` | populated | `docs/consumer-setup.md`, `README.md`, `docs/architecture.md`, `.milestone-config/.gitignore` (environments, data stores=scratch, caching=none, async=none, external=GitHub via gh, hosting) |
| `conventions.md` | populated | repo layout, `docs/architecture.md`, `tests/scenarios/`, issue #118, `.milestone-config/driver.json`, issue #143 (naming, layout, test patterns, canonical exemplars, commits/PRs, versioning) |
| `design-system.md` / `tokens.json` | **left as template** | correct "no design-lens grounding" signal — milestone-feeder is a Claude Code plugin with no UI surface |

Every captured value cites the repo file it came from; nothing is fabricated. No `🔴` unknowns.

Also gitignores `.milestone-bootstrapper/` (the bootstrapper's per-run plan scratch), the analog of the existing `.milestone-feeder/` ignore.

## How it was produced

`milestone-bootstrapper:plan` → reviewable provisioning plan (unattended; the repo's own docs ARE the captured understanding) → `milestone-bootstrapper:apply` populated the docs via the per-anchor `write-project-docs` primitive. Configs/labels/branches reconciled to **no-op** (already present); `main` protection and CI were explicitly left untouched. `versioning` correctly stays **absent** (the writer's contract is absent-means-versioned for a semver project).

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)