### PR TITLE
test: add nested-layout (siteroot/{web,api}) scenario verifying baked sourceGlobs (#118)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,7 @@ tests/
     04-no-code-refusal/           { ... }
     05-reviewer-backends/         { ... }
     06-cross-cutting-consistency/ { ... }
+    10-nested-layout/             { brief.md, project/, feeder-env.md, expected.md }
   RESULTS.md                      # scorecard + claim→evidence map (the metric)
 ```
 
@@ -72,6 +73,7 @@ loaded as plugin skills.
 | 07 | `create` idempotency | create, then re-run | create-or-adopt by title; idempotent re-run (no dupes); never delete | sandbox follow-up |
 | 08 | update no-op / not-found / patch | clean milestone; missing milestone; gapped issue | update is idempotent (clean → no-op); milestone-not-found → error-and-stop; gapped body patched | sandbox follow-up |
 | 09 | slug→#n at scale | >26 candidates | substring-safe slug rewrite (`#A` not corrupting `#AB`) | sandbox follow-up |
+| 10 | nested layout | a nested monorepo (`siteroot/{web,api}`) where source lives only under app roots, never the repo root | bootstrapper-v0.2.0-baked nested `sourceGlobs` route issue file scope into the nested app roots, never the repo root | ✅ |
 
 ### 06 — the flagship, in detail
 

--- a/tests/scenarios/10-nested-layout/brief.md
+++ b/tests/scenarios/10-nested-layout/brief.md
@@ -1,0 +1,12 @@
+# Brief: Export-status banner on the dashboard
+
+The dashboard should tell a user when their last export is still running.
+
+In scope:
+- A backend endpoint that reports the status of the user's most recent export job.
+- A banner on the dashboard that polls that endpoint and shows "Export in progress…"
+  while a job is running, and clears when it finishes.
+
+Out of scope:
+- Starting or cancelling exports (the export pipeline already exists).
+- Push/websocket delivery — polling the endpoint is fine for now.

--- a/tests/scenarios/10-nested-layout/expected.md
+++ b/tests/scenarios/10-nested-layout/expected.md
@@ -1,0 +1,68 @@
+# Expected contract — 10 nested-layout  (GRADER ONLY)
+
+A clean, well-specified brief against a **nested monorepo** layout. The source/UI globs are the
+root-absolute globs the bootstrapper (v0.2.0) baked from `appRoots: ["siteroot/web",
+"siteroot/api"]`. The feeder consumes those globs verbatim — it has no `appRoot` key of its own.
+The claim under test: issue file scope lands **inside the nested app roots**, and nothing
+resolves to the bare repo root.
+
+## Why this scenario is adversarial
+`project/conventions.md` describes the two app roots and the role of each (web owns pages /
+components / client; api owns routes / handlers) but **deliberately does NOT hand the feeder
+copy-paste, repo-prefixed file paths for this feature** — there is no "pages under
+`siteroot/web/src/pages/`" lookup table to transcribe. The only authoritative source for *where
+file scope lands* is the baked `sourceGlobs` / `uiSurfaceGlobs` in `feeder-env.md`. A feeder that
+ignored the nested globs and assigned scope from prose alone would have nothing to copy — so the
+scope assignment must be **glob-driven** to land correctly. That is the mechanism this scenario
+isolates: a glob-ignoring feeder FAILS here; it cannot pass by prose-transcription.
+
+## MUST
+- 2 issues (3 acceptable if it splits sensibly): the **status endpoint** (in `siteroot/api`) and
+  the **dashboard export-status banner** (in `siteroot/web`). ~1 PR each.
+- **Nested path scope — the load-bearing assertion (glob-driven, not transcribed):**
+  - **Every assigned path falls inside a baked nested glob** — inside `siteroot/api/**` for the
+    endpoint issue, inside `siteroot/web/**` for the banner issue — and is consistent with the
+    matching glob, NOT merely copied from a prefix that also appears in prose.
+  - The api-endpoint issue's file scope is **inside `siteroot/api/**`** (e.g. a route under
+    `siteroot/api/src/routes/`, a handler under `siteroot/api/src/handlers/`).
+  - The web-banner issue's file scope is **inside `siteroot/web/**`** and its **primary surface is
+    a page or component under `uiSurfaceGlobs`** — i.e. under `siteroot/web/src/pages/**` or
+    `siteroot/web/src/components/**`. It MAY *secondarily* touch the shared API client at
+    `siteroot/web/src/api/client.ts`, but that secondary path does not stand in for the
+    page/component surface and is not the basis of the classification.
+  - **NOTHING resolves to a bare repo-root path** — no top-level `src/**`, no top-level file scope,
+    no path that omits the `siteroot/web` or `siteroot/api` prefix.
+- Dependency edge: the web banner **depends on** the endpoint (the banner polls it). Endpoint =
+  Wave 1; banner = Wave 2.
+- Classification: the web-banner issue classifies **`ui`** **because its primary page/component
+  surface matches `uiSurfaceGlobs`** under `siteroot/web` (not because of the API-client path,
+  which is under `siteroot/web/src/api/` and is NOT in `uiSurfaceGlobs`); the api-endpoint issue
+  classifies **`logic`**.
+- Each issue body has all five §4 sections. Acceptance criteria include empty/error states (per
+  convention). The web-banner issue records the shared API-client + `useToast()` conventions.
+- The milestone description encodes the Wave order (§4 template).
+- Self-check gate: every emitted issue returns `GAPS: none` **or Advisory-only** (advisories are
+  non-gating). No re-author, or at most a bounded one that clears.
+- ZERO parks; needs-product-input report absent or "none" — the brief is fully specified and the
+  conventions ground every design call.
+
+## SHOULD
+- Convention citations point at the provided `project/conventions.md` (real grounding), not invented.
+- The split mirrors the nested layout: one issue per app root, not one issue spanning both roots.
+
+## FAIL if
+- **Any issue's file scope resolves to the repo root** instead of a nested app root (e.g. a bare
+  `src/**`, a top-level file, or a path missing the `siteroot/web` / `siteroot/api` prefix) — the
+  primary failure mode this scenario hunts.
+- **The scope assignment is not glob-driven** — an assigned path falls outside every baked nested
+  glob, or the scope is justified only by prose transcription rather than by the baked
+  `sourceGlobs` / `uiSurfaceGlobs`. Merely reusing a prefix that also appears in the conventions
+  text does NOT demonstrate the routing claim; the grader confirms every assigned path falls
+  within a baked nested glob and none falls outside them or at the repo root.
+- The web-banner issue's primary surface is NOT a page/component under `uiSurfaceGlobs` (e.g. it is
+  scoped only at the API client `siteroot/web/src/api/`), so the `ui` classification is unfounded
+  or the design lens never engages.
+- The nested globs are ignored (file scope assigned without honoring `siteroot/web/**` /
+  `siteroot/api/**`).
+- Misses the banner→endpoint dependency edge; invents scope not in the brief; parks something a
+  convention answers; or produces issues missing error/empty states.

--- a/tests/scenarios/10-nested-layout/feeder-env.md
+++ b/tests/scenarios/10-nested-layout/feeder-env.md
@@ -1,0 +1,21 @@
+# Test environment — 10 nested layout (what the run assumes)
+
+The repo is a nested monorepo: a web frontend at `siteroot/web` and an API backend at
+`siteroot/api`. The bootstrapper (v0.2.0) baked the app roots into the glob keys at scaffold
+time — its `plan` Step 4 prefixes each `appRoots` entry onto the source/UI globs and writes
+the already-resolved, **root-absolute** globs into `.milestone-config/driver.json`. The feeder
+consumes those globs verbatim; it has no `appRoot` key of its own (that's why feeder #112 was
+closed as superseded — the prefix is resolved upstream, not re-applied by the feeder).
+
+- `feeder.json`: defaults (`reviewer: "milestone-driver"`, `projectDocs: project/`).
+- Driver shared keys (as if from `.milestone-config/driver.json`, baked from
+  `appRoots: ["siteroot/web", "siteroot/api"]`):
+  - `sourceGlobs`: `["siteroot/web/**", "siteroot/api/**"]`  ← root-absolute nested roots; NO bare repo-root glob
+  - `uiSurfaceGlobs`: `["siteroot/web/src/components/**", "siteroot/web/src/pages/**"]`  ← UI lives only under the web root
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["Node web frontend in siteroot/web; Node API backend in siteroot/api"]`
+- Project docs dir: `project/`
+
+> The globs above are **root-absolute** — every path the feeder assigns must fall inside one
+> of the nested app roots (`siteroot/web/**` or `siteroot/api/**`). Nothing should resolve to a
+> bare repo-root path (no top-level `src/**`, no top-level file scope).

--- a/tests/scenarios/10-nested-layout/project/conventions.md
+++ b/tests/scenarios/10-nested-layout/project/conventions.md
@@ -1,0 +1,23 @@
+# Engineering conventions
+
+This is a nested monorepo. The application is split into two app roots; nothing
+application-level sits at the repo root — the root holds only config and tooling.
+
+## App roots
+- **Web frontend** (`siteroot/web`): the user-facing app. Owns every page, component, and the
+  client code that talks to the backend. All web work belongs to this root.
+- **API backend** (`siteroot/api`): the HTTP service. Owns every route and request handler. All
+  backend work belongs to this root.
+
+Each root is self-contained: the web app and the API are developed and scoped independently, and
+a single piece of work lives entirely inside one root. Where exactly a given file lands inside its
+root is governed by the project's baked source/UI globs, not restated here.
+
+## API
+- REST endpoints under `/api/v1/`; JSON bodies; auth required; errors return `{ "error": "..." }`
+  with the correct HTTP status.
+
+## Web
+- Pages call the backend through the shared API client — never `fetch` directly from a page.
+- User-facing surfaces: show a success/error toast via the shared `useToast()` hook; empty and
+  error states are required on every surface.


### PR DESCRIPTION
Closes #118.

## Summary
Adds `tests/scenarios/10-nested-layout/` — a nested-monorepo (`siteroot/{web,api}`) end-to-end scenario that verifies the feeder routes issue file scope into the bootstrapper-v0.2.0-baked nested **root-absolute** globs and never resolves to the repo root. Closes the one gap from the 2026-06-23 feeder↔bootstrapper wiring audit (behavior previously verified only by reasoning). Also bumps `plugin.json` to 0.4.6 (first PR of the milestone).

## What changed
- **New scenario** `tests/scenarios/10-nested-layout/`: `brief.md` (a dashboard export-status banner in `siteroot/web` + a status endpoint in `siteroot/api`), `project/conventions.md` (the nested-stack conventions), `feeder-env.md` (the baked nested globs under "Driver shared keys": `sourceGlobs: ["siteroot/web/**","siteroot/api/**"]`, `uiSurfaceGlobs: ["siteroot/web/src/components/**","siteroot/web/src/pages/**"]`), and `expected.md` (grader-only contract).
- **`tests/README.md`**: one scenario-table row (`10 | nested layout | …`) + one layout-tree entry. Scenario number 10 avoids the reserved 07–09 sandbox-follow-up block.
- **`.claude-plugin/plugin.json`**: 0.4.5 → 0.4.6.

## Decision Log
- **Scenario number `10`, not `07`** — README reserves 07/08/09 for the `create`/`update`/`slug` sandbox follow-ups (`tests/README.md` reserved rows); used the next free number. *Alt rejected:* reusing 07 (collides with a reserved row).
- **Baked globs in `feeder-env.md` under "Driver shared keys", not a literal `feeder.json`** — `sourceGlobs`/`uiSurfaceGlobs` are driver-shared keys the feeder consumes, not feeder-owned (corrects the issue's AC1 wording). Grounded in `tests/scenarios/01-clean-happy-path/feeder-env.md` (same placement). The nested prefix is baked upstream by the bootstrapper's `plan` Step 4 → `driver.json`; the feeder needs no `appRoot` key (feeder #112 superseded).
- **Adversarial design mirroring scenario 06** — `conventions.md` describes the app roots and their roles but does NOT hand the feeder copy-paste repo-prefixed file paths for the new work, so the nested globs are the sole authoritative source for file scope. A glob-ignoring feeder FAILS rather than passing by prose-transcription. *Alt rejected:* leaving prefixed paths in conventions + a grader caveat (the author could still pass by transcription).
- **Run now? = ✅** — preview-only planning scenario, zero GitHub writes (like 01–03/06); the `sandbox follow-up` rows are the write-path `create`/`update` scenarios.

## Code Review
- /code-review run: yes (medium effort)
- Findings: 2 in-scope finding(s) at medium effort
  - **Scenario hole** — `conventions.md` handed the feeder copy-paste repo-prefixed paths, so a glob-ignoring feeder could pass by transcription, not exercising the #118 mechanism → re-dispatched and resolved (conventions now describe roles only; globs are authoritative; `expected.md` gained a glob-driven MUST + FAIL-if).
  - **Internal contradiction in `expected.md`** — `siteroot/web/src/api/` listed as an acceptable banner scope but not in `uiSurfaceGlobs`, contradicting the `ui`-classification MUST → re-dispatched and resolved (banner's primary surface must be a page/component under `uiSurfaceGlobs` → `ui`; `src/api/client.ts` demoted to secondary, non-classifying).
- No park-triggering findings.
- Version-bump: 0.4.5 → 0.4.6 (version-bump rides this PR — no logic change to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)