### PR TITLE
test: add e2e scenario 11 exercising the roadmap path (#160)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,8 +31,9 @@ is executed by **following the prose directly**:
 5. A **grader** subagent scores observed-vs-`expected.md` → ✅ pass / ⚠️ partial / ❌ fail,
    with the observed behavior recorded.
 
-`create` and `update` make real GitHub writes, so their scenarios (07–09) are designed
-here but run later against a throwaway sandbox repo — labeled, not silently skipped.
+`create` and `update` make real GitHub writes, so their scenarios (07–09, and the
+create-loop + verification portion of 11) are designed here but run later against a
+throwaway sandbox repo — labeled, not silently skipped.
 
 ## Layout
 
@@ -47,6 +48,7 @@ tests/
     05-reviewer-backends/         { ... }
     06-cross-cutting-consistency/ { ... }
     10-nested-layout/             { brief.md, project/, feeder-env.md, expected.md }
+    11-roadmap-fan-out/           { brief.md, project/, feeder-env.md, expected.md }
   RESULTS.md                      # scorecard + claim→evidence map (the metric)
 ```
 
@@ -74,6 +76,7 @@ loaded as plugin skills.
 | 08 | update no-op / not-found / patch | clean milestone; missing milestone; gapped issue | update is idempotent (clean → no-op); milestone-not-found → error-and-stop; gapped body patched | sandbox follow-up |
 | 09 | slug→#n at scale | >26 candidates | substring-safe slug rewrite (`#A` not corrupting `#AB`) | sandbox follow-up |
 | 10 | nested layout | a nested monorepo (`siteroot/{web,api}`) where source lives only under app roots, never the repo root | bootstrapper-v0.2.0-baked nested `sourceGlobs` route issue file scope into the nested app roots, never the repo root | ✅ |
+| 11 | roadmap fan-out | an oversized whole-app brief (auth, data model, invoicing, billing, screens) that spans several milestones, seeded from its own author sections | a whole-app brief routes into `build-roadmap`: **split → confirm → parallel-plan** emits the roadmap manifest + N per-milestone plan files; the **create deploy-loop + brief-coverage verification** deploy and audit them back; single-milestone collapse falls back cleanly; an undecided product call parks one issue and siblings continue | plan-side ✅ now / create-loop + verification sandbox follow-up |
 
 ### 06 — the flagship, in detail
 

--- a/tests/scenarios/11-roadmap-fan-out/brief.md
+++ b/tests/scenarios/11-roadmap-fan-out/brief.md
@@ -1,0 +1,50 @@
+# Brief: build the invoicing & client-portal app (whole product)
+
+Build the whole product: a small-business app where an owner manages clients,
+sends invoices, takes payment, and gives each client a portal to view and pay.
+This is a from-scratch, multi-release build — far more than one milestone.
+
+The sections below are the author's own grouping. They are the natural seams the
+build splits along; the split may merge, reorder, or keep them as it sees fit.
+
+## Accounts & access
+- Email/password sign-up and login, password reset.
+- Two roles: **owner** (full access) and **staff** (no billing settings).
+- Every API route requires auth; sessions expire.
+
+## Data model
+- Core entities: `Client`, `Invoice`, `LineItem`, `Payment`, `User`.
+- An `Invoice` belongs to a `Client` and has many `LineItem`s and `Payment`s.
+- Every entity is owner-scoped (an owner sees only their own records).
+
+## Client management
+- Create, view, edit, and archive client records (name, email, address, notes).
+- A searchable client list.
+
+## Invoicing
+- Create an invoice for a client: add line items (description, qty, unit price),
+  see the computed total, save as draft, then send.
+- An invoice has a status: draft → sent → paid → overdue.
+
+## Payments & billing
+- Let clients pay an invoice online, and bill the owner on a recurring plan for
+  using the app.
+- Record each payment against its invoice and flip the invoice to **paid** when
+  fully covered.
+- (The brief does not name a payment provider, a currency, or how tax/processor
+  fees are handled — those are left open.)
+
+## Client portal (screens)
+- A client signs in to a portal and sees a list of their invoices with status.
+- A client opens an invoice and pays it from that screen.
+
+## Admin dashboard & reporting (screens)
+- An owner dashboard: outstanding total, paid-this-month, overdue count.
+- A revenue report table: one row per invoice, sortable and filterable.
+
+## Notifications
+- Email a client when an invoice is sent and again when it is overdue.
+- Email the owner a weekly summary.
+
+## Out of scope
+- Multi-currency, tax jurisdictions, mobile apps, and a public marketing site.

--- a/tests/scenarios/11-roadmap-fan-out/expected.md
+++ b/tests/scenarios/11-roadmap-fan-out/expected.md
@@ -1,0 +1,193 @@
+# Expected contract — 11 roadmap-fan-out  (GRADER ONLY)
+
+An **oversized whole-app brief** that spans several milestones. `plan`'s front-door
+(Step 3.6) must route it into the `build-roadmap` flow: **split** the brief into a
+sequenced set of milestones → **confirm** that split → **parallel-plan** each
+milestone (Step 3.7 fan-out) → (then `create`) **deploy-loop** + **verify** against
+the original brief. This scenario asserts the three roadmap artifact classes the
+path must emit, the empty / clean / degenerate outcomes, and the preview-vs-sandbox
+execution split.
+
+The claim under test (currently Unbacked): **`plan` turns a whole-app brief into an
+ordered roadmap of milestones, plans each, and `create` deploys + audits them back
+against the original brief.**
+
+## Run-now scope vs sandbox follow-up (the execution split)
+
+Per the harness write-path rule (`tests/README.md` "Execution model", lines 29 & 33–35):
+
+| Path | Artifacts | Run now? |
+|---|---|---|
+| **Plan-side:** split → confirm → parallel-plan | the roadmap **manifest** + the **N per-milestone plan files**, emitted as **text artifacts** under `.milestone-feeder/` with **zero GitHub writes** | **✅ preview now** |
+| **Create-side:** create deploy-loop (Step 1R) + post-create brief-coverage verification (Step 3V) | live milestones/issues + the coverage **punch-list** | **Sandbox follow-up** — designed here, run later against a throwaway repo, **labeled, not silently skipped** |
+
+A grader runs the **✅** rows now and confirms the **sandbox** rows are designed (the
+assertions exist), not executed.
+
+---
+
+## MUST — artifact class 1: the roadmap MANIFEST  (✅ preview)
+
+- The front-door **routes** (architect raises `SCOPE_SPANS_MULTIPLE_MILESTONES`;
+  `plan` Step 3.6 enters `build-roadmap`). It does **not** fall through to the
+  single-milestone pipeline for the whole brief.
+- Exactly **one** manifest is written, at `.milestone-feeder/roadmap-<slug>.md`
+  (`<slug>` derived from the whole-app brief's one-line goal by the Naming rule).
+- The manifest header carries: `Source brief:` (here `inline` or `file:…`),
+  `Confirmed: yes` (the user-confirmed split, not the raw proposal), and a
+  `Build order: <M1> → <M2> → … → <MN>` line.
+- A **`## Original brief` section persists the FULL whole-app brief, multi-line** —
+  every author section, verbatim or near-verbatim. (This is the durable copy the
+  Step-3V verification reads; persisting it is the manifest's contract.)
+- `## Milestones (in build order)` lists **N ≥ 2** entries forming a **strict
+  partition** of the brief's in-scope: every author section assigned to exactly one
+  milestone, none dropped, none duplicated, positions running `1..N` with no gaps or
+  repeats. Each `### <position>. <name>` entry carries all five fields:
+  - **name** — a milestone title,
+  - **Brief slice** — the author section(s) this milestone owns,
+  - **Build-order position** — its `1..N` slot,
+  - **Plan file** — the `.milestone-feeder/plan-<slug>.md` handle (PENDING when
+    `build-roadmap` writes the manifest; **populated by the Step-3.7 fan-out** after
+    each milestone is planned — see artifact class 2),
+  - **Change-rationale** — `merged | split | reordered | unchanged` **vs the
+    author's headings**, with the reason.
+- **The split records a real diff:** at least one milestone's change-rationale is a
+  non-trivial **merge** or **reorder** (e.g. the data-model section folded into the
+  milestone that first needs it; auth ordered first as the foundation;
+  notifications/payments ordered after the things they act on). A roadmap that is a
+  1:1 copy of the author's headings with every rationale `unchanged` fails to
+  demonstrate the split.
+- **Build order is a real dependency sequence**, not the author's listing order:
+  the foundation milestone (accounts/auth) is **position 1**; a milestone that can
+  only act on data another milestone introduces (notifications, payments,
+  portal/reporting screens) sits **after** it.
+
+## MUST — artifact class 2: the N per-milestone PLAN FILES  (✅ preview)
+
+- The Step-3.7 fan-out plans **every** milestone the confirmed manifest names and
+  emits **one plan file per milestone** at `.milestone-feeder/plan-<slug>.md`
+  (with the deterministic `-m<index>` tiebreaker only if two milestones derive the
+  same slug). **N milestones → N plan files.**
+- Each plan file is an **ordinary single-milestone plan** produced by the existing
+  pipeline unchanged: §4-shaped issue bodies, the milestone's intra-milestone Wave
+  order, the self-check verdict, the `Milestone title (exact)` line. (Per-milestone
+  planning reuses the single-milestone pipeline; the roadmap path adds the **outer**
+  fan-out, not a new per-issue format.)
+- After the fan-out, **each manifest entry's `Plan file:` field is populated** with
+  that milestone's real path (no longer PENDING) — the handle `create`'s deploy-loop
+  later resolves each milestone by (never a name-derived slug).
+- **UI classification engages per milestone:** because `uiSurfaceGlobs` is set, the
+  portal / dashboard / revenue-report **page-issues classify `ui`** and their
+  authoring runs the `design-reviewer` (states + `DataTable` + 30/page directive
+  cited from `project/conventions.md`); the auth / data-model / API issues classify
+  `logic`.
+
+## MUST — empty fan-out: single-milestone collapse is a valid outcome, not an error  (✅ preview)
+
+- **Asserted alternate:** if the split **collapses to a single milestone** (the
+  splitter returns fewer than two entries — e.g. were the brief reduced to just
+  *Accounts & access*), then **NO manifest is written**, `build-roadmap` returns no
+  manifest path, and `plan` **falls back to its single-milestone pipeline on the
+  whole brief, unchanged** — zero roadmap artifacts (no manifest, no fan-out). This
+  is an **asserted success outcome, not an error** and not a park.
+- The equivalent guard holds at the fan-out (`plan` Step 3.7.a): **N = 0 → no probe,
+  no dispatch, no plan files**, surfaced as empty, not aborted.
+
+## MUST — degenerate: an undecided product call PARKS one issue and siblings continue  (✅ preview)
+
+- The **Payments & billing** slice carries a product call with **no conventional
+  default** — the brief names no payment provider, no currency, no fee/tax policy,
+  and `project/conventions.md` supplies none (it fixes only the integer-minor-units
+  storage representation). The issue that needs that decision must **PARK** to the
+  **needs-product-input** report — **never invent** a provider, currency, or fee
+  rule.
+- **Parking is scoped, not fatal:** the park drops only the issue(s) that depend on
+  the undecided call (and their dependents). **Sibling issues in the same milestone
+  that the conventions DO ground continue to plan** — e.g. the `Payment` data model,
+  the payment→invoice association, the "paid" status flip / badge. The park does
+  **not** abort the Payments milestone, and **does not abort the roadmap**: the other
+  milestones plan normally (`plan` Step 3.7.g — one milestone's trouble never aborts
+  the roadmap; a failed-to-plan milestone is recorded, siblings continue).
+- The needs-product-input report itemizes the parked decision with its blocking
+  reason and brief reference; the manifest/plan artifacts for the unaffected work
+  still emit.
+
+## MUST — artifact class 3: the create deploy-loop  (SANDBOX follow-up — designed, not run now)
+
+Designed here; **run later against a throwaway sandbox repo** (this makes real
+GitHub writes, excluded from the preview run per `tests/README.md` lines 33–35):
+
+- `create` Step 1R finds the manifest and runs the **outer loop** over its milestones
+  **in build order (position 1 → N)**: for each, resolve the recorded `Plan file:`
+  path, deploy via Step 3 passes a–e (labels / create-or-adopt milestone by exact
+  title / open surviving issues / slug→`#n` rewrite + Wave PATCH / route report), and
+  PATCH a single canonical `build order: milestone X of N` line into its description.
+- **Idempotent / non-destructive:** create-or-adopt per milestone — never deletes,
+  never duplicates a same-title open issue; a mid-loop failure **stops and reports**
+  which milestones deployed, which failed and at which pass, which remain — and a
+  re-run **resumes** (already-deployed milestones adopted by exact title).
+- **Parked issues are never created**; they route to the needs-input report.
+
+## MUST — artifact class 3 (cont.): the brief-coverage VERIFICATION punch-list  (SANDBOX follow-up — designed)
+
+`create`'s closing step (Step 3V) reads back **all N** deployed milestones + issues
+and dispatches `milestone-feeder:brief-coverage-verifier` against the manifest's
+`## Original brief`, returning `COVERAGE_VERDICT / UNCOVERED / DUPLICATED /
+DISTORTED / READ_ERRORS`. Always-on, **non-blocking**, **never auto-fixes**. Two
+asserted outcomes:
+
+- **Clean verification:** when nothing is missing / duplicated / distorted (all four
+  lists `none`), the punch-list is **empty** and the run reports
+  **`coverage verified — nothing missed`** — and routes nothing.
+- **Non-empty punch-list:** when a brief item is **uncovered, duplicated, or
+  distorted** (e.g. the brief's weekly owner-summary email is covered by no deployed
+  issue, or two milestones both claim the revenue report), the verifier returns a
+  **NON-empty** block that **itemizes the fix** (the uncovered/duplicated/distorted
+  item + where), routed to the local `.milestone-feeder/coverage-<slug>.md` (file/
+  inline brief) or as an epic comment (`epic #<n>` brief). It is **advisory** —
+  `create` changes nothing on GitHub to resolve it.
+
+## Disabled / edge — bash/pwsh parity
+
+- The plan-side preview portion (split → confirm → parallel-plan) is **prose-only**:
+  the only scripted twins it touches are the scratch-dir self-ignore
+  (`.milestone-feeder/.gitignore` ← `*`) writes, which carry no scenario-specific
+  finding. **Parity is recorded N/A for the preview portion.**
+- The cross-platform-parity obligation therefore **lands on the sandbox create-loop
+  run**: where the deploy-loop / read-back `gh` twins (Step 1R, Step 3V — bash +
+  PowerShell 7+) are exercised, the sandbox run MUST assert the two twins produce
+  **identical** deploy receipts and identical coverage findings on the same inputs.
+  (Cross-platform parity is itself a test obligation — `nonNegotiables`;
+  `.project/conventions.md#Test patterns`.)
+
+## SHOULD
+
+- Convention citations point at the provided `project/conventions.md` (real
+  grounding) — REST shape, `requireRole()` / owner-scope, `useToast()`, required
+  states, `DataTable` + 30/page — not invented.
+- The milestone split mirrors real build dependencies (one milestone per coherent
+  release boundary), not an arbitrary even slicing of the author sections.
+
+## FAIL if
+
+- The oversized brief is **not routed** — `plan` plans it as one single milestone
+  (no manifest, no fan-out) when the brief plainly spans several releases.
+- The manifest is **not a strict partition** (an author section dropped or
+  double-assigned; positions with a gap/repeat), or omits the `## Original brief`
+  full persist, or any milestone entry is missing name / slice / position /
+  `Plan file:` / change-rationale.
+- Fewer than **N plan files** are emitted (a milestone the manifest names is never
+  planned), or a `Plan file:` field is left PENDING after the fan-out for a milestone
+  that planned successfully.
+- The single-milestone-collapse case is treated as an **error** (or papered over with
+  a fabricated extra milestone) instead of a clean fall-back to single-milestone
+  planning.
+- The undecided payment product call is **invented** (a provider/currency/fee value
+  guessed) instead of parked; or the park **aborts** the Payments milestone or the
+  whole roadmap instead of dropping only the blocked issue and continuing siblings.
+- The page-issues (portal / dashboard / report) classify `logic` (uiSurfaceGlobs
+  ignored) so the design lens never runs, or drop the `DataTable` / 30-per-page
+  directive.
+- The sandbox create-loop / verification assertions are **silently dropped** rather
+  than designed-and-labeled; or the bash/pwsh parity obligation is neither recorded
+  N/A (preview) nor owed to the sandbox run.

--- a/tests/scenarios/11-roadmap-fan-out/feeder-env.md
+++ b/tests/scenarios/11-roadmap-fan-out/feeder-env.md
@@ -1,0 +1,25 @@
+# Test environment — 11 roadmap fan-out (what the run assumes)
+
+This is an **oversized whole-app brief** — many features, a data model, auth, and
+billing — so it spans **several milestones** and `plan`'s front-door (Step 3.6)
+routes it into the `build-roadmap` flow instead of the single-milestone pipeline.
+
+- `feeder.json`: defaults (`reviewer: "milestone-driver"`, `projectDocs: project/`).
+- Driver shared keys (as if from `.milestone-config/driver.json`):
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`  ← **set**, so the
+    portal / dashboard / report page-issues classify as **UI** and the
+    `design-reviewer` engages (as in scenario 06)
+  - `integrationBranch`: `"develop"`
+  - `nonNegotiables`: `["Python 3.11 + FastAPI backend; React 18 + TypeScript frontend"]`
+- Project docs dir for this scenario: `project/`
+
+> The brief is grouped into author sections (Accounts & access / Data model /
+> Client management / Invoicing / Payments & billing / Client portal / Admin
+> dashboard / Notifications). The roadmap split partitions these into a sequenced
+> set of milestones and records, per milestone, how it changed the author's
+> grouping (merged / split / reordered / unchanged) — so the split has a real diff
+> to record. The fixture's `project/conventions.md` grounds the design and
+> implementation calls (REST shape, auth guard, owner scoping, toast, states,
+> `DataTable`); it deliberately does **not** name a payment provider, currency, or
+> fee/tax policy — that is a product call with no conventional default.

--- a/tests/scenarios/11-roadmap-fan-out/project/conventions.md
+++ b/tests/scenarios/11-roadmap-fan-out/project/conventions.md
@@ -1,0 +1,19 @@
+# Engineering conventions
+
+- **API:** REST endpoints under `/api/v1/`; JSON bodies; auth required on every
+  route; errors return `{ "error": "..." }` with the correct HTTP status.
+- **Auth:** session cookies; sessions expire; role checks via the shared
+  `requireRole()` guard (`src/middleware/auth.py`). Two roles: `owner`, `staff`.
+- **Owner scoping:** every query is scoped to the current owner via the shared
+  `owner_scope()` helper — records never leak across owners.
+- **User-facing actions:** show a success/error toast via the shared `useToast()`
+  hook; disable the trigger control while the action is in flight.
+- **States:** empty and error states are required on every user-facing surface;
+  list screens also show a loading skeleton.
+- **Data tables:** reuse the shared `DataTable` component
+  (`src/components/DataTable.tsx`) — columns sortable and filterable except an
+  Actions column; server-side pagination at **30 rows per page**. Do not
+  hand-roll tables.
+- **Money:** store monetary amounts as integer minor units; never floats.
+  (This fixes the storage representation only — it states no payment provider,
+  currency, or fee/tax policy; those are product calls, not engineering ones.)


### PR DESCRIPTION
## Summary
Wave-7 final piece of the v0.6.0 roadmap capability (#160). Adds e2e test scenario `11-roadmap-fan-out/` exercising the full roadmap path (split → confirm → parallel-plan → create-loop → verification).

## What's in it
- **brief.md** — an oversized whole-app brief (auth, data model, clients, invoicing, payments+billing, portal/dashboard screens, notifications) seeded from its own headings so the split has a real merge/reorder diff; buries one ungrounded product call (payment provider/currency/fee policy) so park-continues-siblings is demonstrable.
- **project/** fixture (sets `uiSurfaceGlobs`), **feeder-env.md**, **expected.md**.
- **expected.md** asserts partition PROPERTIES (≥2 strict partition, foundation-first order, non-trivial merge/reorder rationale) — NOT a pinned split (no teaching-to-the-test) — plus the manifest / N plan files / verification punch-list artifacts, the empty-fan-out collapse, the product-gap park, and clean + non-empty verification. Plan-side is preview-runnable now; the create-loop + live-GitHub verification is labeled a sandbox follow-up.
- **tests/README.md** — row 11 + Layout entry + the sandbox-deferral prose updated.

## Code Review
- /code-review run: yes (scenario accuracy vs built behavior + harness conformance)
- **Pass on all priority angles** — every `expected.md` assertion cross-checked against the built skills (manifest/plan-files/Step-3V verifier shapes all match); fixture shape matches 01/06/10; brief genuinely triggers the split + the park; no teaching-to-the-test; preview-vs-sandbox split correct.
- Findings: 1 low-severity (Execution-model prose enumerated only 07–09 as sandbox) → re-dispatched and resolved (added scenario 11's create-side).
- Version-free PR — plugin.json already at 0.6.0. `tests/` is outside sourceGlobs.

Gates: `validate-plugin-structure.py` PASS · `check-vocabulary.sh` PASS.

Closes #160