### PR TITLE
test: add e2e scenario 12 exercising the implied-surfaces planning path (#185)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,7 @@ tests/
     06-cross-cutting-consistency/ { ... }
     10-nested-layout/             { brief.md, project/, feeder-env.md, expected.md }
     11-roadmap-fan-out/           { brief.md, project/, feeder-env.md, expected.md }
+    12-implied-surfaces/          { brief.md, project/, feeder-env.md, expected.md }
   RESULTS.md                      # scorecard + claim→evidence map (the metric)
 ```
 
@@ -77,6 +78,7 @@ loaded as plugin skills.
 | 09 | slug→#n at scale | >26 candidates | substring-safe slug rewrite (`#A` not corrupting `#AB`) | sandbox follow-up |
 | 10 | nested layout | a nested monorepo (`siteroot/{web,api}`) where source lives only under app roots, never the repo root | bootstrapper-v0.2.0-baked nested `sourceGlobs` route issue file scope into the nested app roots, never the repo root | ✅ |
 | 11 | roadmap fan-out | an oversized whole-app brief (auth, data model, invoicing, billing, screens) that spans several milestones, seeded from its own author sections | a whole-app brief routes into `build-roadmap`: **split → confirm → parallel-plan** emits the roadmap manifest + N per-milestone plan files; the **create deploy-loop + brief-coverage verification** deploy and audit them back; single-milestone collapse falls back cleanly; an undecided product call parks one issue and siblings continue | plan-side ✅ now / create-loop + verification sandbox follow-up |
+| 12 | implied surfaces | a terse brief names a capability (admins emailing members) but never spells out its companion surfaces; one companion (suppression/unsubscribe) is a genuine product-call with no conventional default | the architect consults the implied-surfaces reference, fans the conventional companions (delivery-failure log + retry + audit) out as **`implied`-labeled review candidates**, **parks** the genuine product-call to needs-product-input instead of inventing it, and `plan` surfaces the implied set with the verbatim anti-fixation prompt — no auto-dump, no invented scope; a control slice with no capability/entity triggers neither | ✅ |
 
 ### 06 — the flagship, in detail
 

--- a/tests/scenarios/12-implied-surfaces/brief.md
+++ b/tests/scenarios/12-implied-surfaces/brief.md
@@ -1,0 +1,11 @@
+# Brief: Admin → member messaging
+
+Let admins send an email message to members. An admin composes a message
+(a subject and a body) and sends it to a selected set of members.
+
+In scope:
+- An admin compose-and-send screen: pick the member recipients, write a subject
+  and body, send.
+
+Out of scope:
+- Redesigning the member directory.

--- a/tests/scenarios/12-implied-surfaces/expected.md
+++ b/tests/scenarios/12-implied-surfaces/expected.md
@@ -1,0 +1,121 @@
+# Expected contract — 12 implied-surfaces  (GRADER ONLY)
+
+A terse brief names **one capability** — admins emailing members — and lists only
+the literal compose-and-send action. The capability name quietly commits to a set
+of companion surfaces the brief never spells out. The fixture's
+`project/conventions.md` grounds the stack's email-sending defaults (provider config
++ retry, a delivery-failure log with resend, audit) so the **conventional**
+companions have a conventional default; it leaves the suppression / unsubscribe
+(opt-out) policy **undecided** — the one genuine product call.
+
+The claim under test: **`plan` consults the implied-surfaces reference for a named
+capability, fans the conventional companions out as `implied`-labeled review
+candidates, parks the genuine product-call to the needs-product-input report instead
+of inventing one, and surfaces the implied set with the anti-fixation prompt** —
+without auto-dumping every conceivable surface and without inventing product scope.
+
+This is a **plan-side, preview-only** scenario (zero GitHub writes), mirroring the
+plan-side portion of scenario 11.
+
+---
+
+## MUST — (a) the reference is consulted for the email capability
+
+- The architect **concept-matches** the brief to the **Email / outbound messaging**
+  capability (`docs/implied-surfaces.md#named-capabilities`) and consults the
+  implied-surfaces reference for it — even though the brief says "email" only in the
+  literal compose/send action and never names its companions (`agents/architect.md`
+  clause 8; the consult is **per named capability or new entity**, concept-matched,
+  not keyword-matched).
+- The consult is **observable in the breakdown**: the companion surfaces the
+  capability implies appear as candidates that were not in the brief's literal text
+  (the delivery-failure log, provider config + retry, the send audit) — evidence the
+  reference was read, not skipped.
+
+## MUST — (b) the conventional companions fan out as `implied`-labeled candidates
+
+- The conventional companions — at minimum the **delivery-failure log** (with
+  resend), and the **provider configuration + retry** and **send audit** surfaces —
+  ride `CANDIDATES` with the architect's **`disposition: implied`**
+  (`agents/architect.md` clause 8, the conventional-surface branch).
+- Each `implied` candidate renders **distinctly** in the plan's `## Issues`,
+  carrying the **verbatim** marker `[implied — review / trim / augment]` on its
+  heading (`skills/plan/SKILL.md` — the bracketed marker; #180 as-built). The
+  literal words `implied — review / trim / augment` must appear inside the brackets.
+- These companions are grounded on the fixture's conventions (the delivery-failure
+  log, retry, and audit defaults `project/conventions.md` states) — so they are
+  proposed because they have a **conventional default**, but they are **proposed for
+  review**, not silently pre-included: an `implied` candidate is reversible (trim the
+  line before approving) and is **not** rendered as a plain grounded candidate that
+  hides its implied origin.
+- The implied set is presented as a **floor, not a ceiling** — a short, conceptual
+  start, never framed as the complete or exhaustive set of companions.
+
+## MUST — (c) the genuine product-call PARKS, never invented
+
+- The **suppression / unsubscribe (opt-out) policy** has **no conventional default**
+  in the fixture (`project/conventions.md` explicitly leaves it undecided). The
+  candidate that needs that decision must **PARK** to the **needs-product-input**
+  report via the architect's `PRODUCT_GAPS` (`agents/architect.md` clause 8, the
+  genuine-product-call branch; clause 2 never-invent floor).
+- The report names the undecided decision precisely (the suppression / unsubscribe
+  policy — who may opt out, what an opt-out suppresses, which message classes it
+  covers), why it has no conventional default, and what it blocks.
+- The opt-out policy is **never pre-included** as an `implied` candidate and **never
+  invented** as a plausible-sounding default (no silent "members can unsubscribe via
+  a link in the footer"). A surface with no conventional default parks — it never
+  proceeds as an implied guess.
+
+## MUST — (d) plan surfaces the implied set with the anti-fixation prompt
+
+- Because the plan carries one or more `implied` candidates, `plan` fires the
+  structural **anti-fixation prompt** at the milestone-identity confirm/override
+  moment, with the **verbatim** string `this is a starting set for YOUR app — what's missing?`
+  (`skills/plan/SKILL.md` — the implied-surfaces review prompt; #180 as-built). It is
+  **advisory and non-blocking** — it never gates the run; the plan stays fully
+  deployable as-is.
+
+## MUST — CONTROL / negative: no capability, no entity → no fan-out, no prompt
+
+- **Asserted alternate.** A brief slice that names **no capability and introduces no
+  new entity** — e.g. "reword the copy on the existing admin settings page" or
+  "rename a label" — triggers **NO** implied fan-out: the architect's clause-8
+  consult is a **no-op**, **no** candidate carries `disposition: implied`, no
+  `[implied — review / trim / augment]` marker is rendered, and `plan` surfaces **NO**
+  anti-fixation prompt. Plan behaves **byte-for-byte as today**. This is an asserted
+  success outcome, not an error and not a park.
+
+## METRIC for this scenario
+
+- Conventional companions correctly fanned out as `implied`-labeled candidates
+  (target: the delivery-failure log + provider/retry + audit all present, all
+  marked). Record which companions surfaced and whether each carried the marker.
+- The opt-out policy parked (yes/no) and named precisely in the report.
+- The anti-fixation prompt present, verbatim (yes/no).
+
+## FAIL if
+
+- The product-call (suppression / unsubscribe policy) is **silently pre-included** —
+  authored as a candidate (implied or grounded) instead of parked — or **invented**
+  with a fabricated opt-out default.
+- The anti-fixation prompt is **absent** when the plan carries `implied` candidates,
+  or its string is not verbatim `this is a starting set for YOUR app — what's missing?`.
+- The implied candidates are **unlabeled** (no `[implied — review / trim / augment]`
+  marker) or rendered as plain grounded candidates hiding their implied origin; or
+  the implied set is framed as **complete / exhaustive / a ceiling** rather than a
+  floor.
+- An **exhaustive auto-dump** of every conceivable surface is emitted (false
+  completeness) — the reference is over-listed instead of read as a short, conceptual
+  prompt.
+- The CONTROL slice (no capability, no new entity) nonetheless triggers an implied
+  fan-out or the anti-fixation prompt.
+
+## Disabled / edge — bash/pwsh parity
+
+- This scenario is **plan-side, preview-only** and **prose-direct** — the implied
+  consult / fan-out / anti-fixation flow is prose the runner follows; it touches no
+  scenario-specific scripted (bash/pwsh) twin. **Cross-platform parity is recorded
+  N/A** for this scenario (mirroring scenario 11's plan-side preview portion).
+- `expected.md` is **grader-only** (the runner never sees it). Appended at **NN=12**
+  (on-disk 01–06, 10, 11; 07–09 reserved for the sandbox `create` / `update`
+  scenarios).

--- a/tests/scenarios/12-implied-surfaces/feeder-env.md
+++ b/tests/scenarios/12-implied-surfaces/feeder-env.md
@@ -1,0 +1,16 @@
+# Test environment — 12 implied-surfaces (what the run assumes)
+
+The brief names a single capability — admins emailing members — and lists only the
+literal compose-and-send action. Its companion surfaces are unstated. The fixture's
+`project/conventions.md` grounds the stack's email-sending defaults (provider config
++ retry, a delivery-failure log with resend, audit) so the **conventional** companions
+have a conventional default and fan out as **implied** review candidates; it
+deliberately leaves the suppression / unsubscribe (opt-out) policy **undecided** — a
+product call with no conventional default that must **park**, never be invented.
+
+- `feeder.json`: defaults (`reviewer: "milestone-driver"`, `projectDocs: project/`).
+- Driver shared keys (as if from `.milestone-config/driver.json`):
+  - `sourceGlobs`: `["src/**"]`
+  - `uiSurfaceGlobs`: `["src/pages/**", "src/components/**"]`
+  - `integrationBranch`: `"develop"`
+- Project docs dir: `project/`

--- a/tests/scenarios/12-implied-surfaces/project/conventions.md
+++ b/tests/scenarios/12-implied-surfaces/project/conventions.md
@@ -1,0 +1,27 @@
+# Engineering conventions
+
+- **Outbound messaging:** the app sends all admin and transactional email through
+  the shared `EmailService` (`src/services/EmailService.ts`), which wraps the
+  configured email provider. Provider credentials and send settings live in
+  `src/config/email.ts` — a new outbound capability configures the provider there,
+  it does not pick a new one.
+- **Delivery + retry:** every send goes through the provider via the shared
+  `sendWithRetry()` helper (`src/services/EmailService.ts`) — a transient failure
+  is retried on the standard backoff. Retry-on-failure is the conventional path
+  for an outbound send, not a per-feature decision.
+- **Delivery-failure log:** a send that exhausts its retries is recorded in the
+  shared `EmailDeliveryLog` (`src/models/EmailDeliveryLog.ts`), surfaced on an
+  admin delivery-failure screen with a **resend** action — the standard companion
+  of every outbound message in the app.
+- **Audit:** every outbound message is audited (who sent what, to whom, and when)
+  via the shared `AuditLog` (`src/models/AuditLog.ts`), the same way every other
+  admin action is audited.
+- **UI:** reuse the existing `AdminFormLayout` (`src/components/AdminFormLayout.tsx`)
+  for admin compose / edit screens.
+- **States:** empty and error states are required on every user-facing surface.
+
+> Note: this app has **not** decided a suppression / unsubscribe (opt-out) policy.
+> Whether a member may opt out of admin messages, what an opt-out suppresses, and
+> which message classes it covers are all open. There is **no conventional default**
+> for this — it is a product decision, not an engineering one. Nothing here answers
+> it, and the delivery defaults above deliberately do not imply one.


### PR DESCRIPTION
Closes #185 (closed explicitly by the milestone orchestrator — `Closes` only fires on the default branch).

## Summary

Adds the append-only e2e scenario `tests/scenarios/12-implied-surfaces/` (4 authored files) exercising the v0.7.0 implied-surfaces planning path, and registers it in `tests/README.md`.

- `brief.md` — terse; names one capability (admins emailing members), only the literal compose/send action; companions unstated.
- `project/conventions.md` — grounds the conventional email companions (delivery-failure log + retry + audit on named `src/` helpers → conventional default → `implied`) and explicitly leaves the suppression/unsubscribe policy undecided (no conventional default → parks).
- `feeder-env.md` — defaults mirroring 02/06.
- `expected.md` (grader-only) — asserts (a) reference consulted, (b) conventional companions fan out carrying the verbatim `[implied — review / trim / augment]` marker, (c) the product-call parks to needs-product-input (never pre-included/invented), (d) plan fires the verbatim anti-fixation prompt; plus a CONTROL negative (no capability/entity → no fan-out/prompt) and a FAIL-if section.

Plan-side preview-only (mirrors scenario 11), grader-only `expected.md`, NN=12.

## Decision Log

| Choice | Rationale | Citation | Rejected |
|---|---|---|---|
| Fixture grounds companions on named helpers (`EmailService`/`sendWithRetry`/`EmailDeliveryLog`/`AuditLog`) | Gives the architect a concrete conventional default per `implied` candidate (clause 8 conventional branch) | `agents/architect.md` clause 8; `docs/implied-surfaces.md` Email cluster | abstract prose (blurs conventional-vs-product-call line) |
| Suppression/unsubscribe = the single parked product-call | The architect's own canonical product-call example; tests the exact documented boundary | `agents/architect.md` clause 8; `docs/implied-surfaces.md` (omits suppression from the Email cluster) | a different invented surface |
| expected.md strings track #180 as-built, not the issue draft | The issue's recorded reconciliation step | `skills/plan/SKILL.md` (#180 as-built); verified byte-exact | the issue-draft strings |
| Run-now ✅ (not sandbox-deferred) | Entirely plan-side preview, zero GitHub writes | `tests/README.md` Execution model | sandbox follow-up |

## Code Review

- /code-review run: yes (high effort)
- Findings: 0 in-scope findings
  - Verified: all four assertions (a)-(d) + CONTROL negative + FAIL-if present; the verbatim strings `[implied — review / trim / augment]` and `this is a starting set for YOUR app — what's missing?` byte-exact-match the live `skills/plan/SKILL.md`; the fixture cleanly separates conventional companions (→ implied) from the undecided product-call (→ parks); 4 authored files (no runner-generated run-log/run-output); README lists 12 in tree + table; CI green
- No park-triggering findings.
- plugin.json unchanged at 0.7.0 milestone target — tests-only PR, no version change

🤖 Generated with [Claude Code](https://claude.com/claude-code)