### PR TITLE
docs(plan): canonical reference for the five Step-0 one-time notices (#197)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/docs/one-time-notices.md
+++ b/docs/one-time-notices.md
@@ -1,0 +1,411 @@
+# Plan Step 0 — one-time notices
+
+`plan` Step 0 prints up to five one-time notices the first time it runs in a
+clone. Each one either announces a self-heal `plan` just performed, flags a
+repo-state problem for you to fix by hand, or points you at a new or optional
+capability you can opt into. Every notice shows at most once per clone: the
+block drops a small marker file under `.milestone-config/.runtime/` the first
+time it fires, then stays silent on every later run. The self-heal in the first
+section is the one exception — it is gated on file-absence, not a marker, so it
+re-checks every run and acts only when the file it writes is missing.
+
+This file is the canonical source for those five notices. Each section records,
+for one notice: when it fires, the per-clone marker that silences it, and what
+it writes — then the notice text together with both emitter twins (a bash form
+and a PowerShell 7+ form), byte-for-byte. The blocks are reference content;
+nothing in this file runs on its own. The live emitter is
+`skills/plan/SKILL.md` Step 0.
+
+**Contents**
+
+1. [Self-heal the nested .milestone-config/.gitignore](#self-heal-the-nested-milestone-configgitignore)
+2. [Legacy-blanket root .gitignore notice](#legacy-blanket-root-gitignore-notice)
+3. [Bootstrap-nudge notice](#bootstrap-nudge-notice)
+4. [Roadmap-routing notice](#roadmap-routing-notice)
+5. [Implied-surfaces notice](#implied-surfaces-notice)
+
+## Self-heal the nested .milestone-config/.gitignore
+
+- **Gate:** file-absence only (`[ ! -f ]` / `-not (Test-Path ...)`) — create-only, NOT marker-gated.
+- **Per-clone marker:** none.
+- **Writes:** the nested `.milestone-config/.gitignore`.
+- **Safety:** best-effort; never clobbers a user-edited file; a failed self-heal never aborts the run.
+
+```gitignore
+# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.
+# Committed so per-run scratch stays out of `git status` with zero user setup.
+# Patterns are relative to this .milestone-config/ directory. Tracked config
+# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.
+preflight-notice
+trello-notice
+triage-cache.json
+tests-stamp
+.runtime/
+worktrees/
+```
+
+```bash
+# bash — create-only self-heal; never clobbers a user-edited file, never aborts plan.
+mkdir -p .milestone-config 2>/dev/null || true
+ignore_path=".milestone-config/.gitignore"
+if [ ! -f "$ignore_path" ]; then
+  printf '%s\n' \
+    '# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.' \
+    '# Committed so per-run scratch stays out of `git status` with zero user setup.' \
+    '# Patterns are relative to this .milestone-config/ directory. Tracked config' \
+    '# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.' \
+    'preflight-notice' 'trello-notice' 'triage-cache.json' 'tests-stamp' \
+    '.runtime/' 'worktrees/' > "$ignore_path" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same create-only self-heal; no-BOM UTF-8; never clobbers, never aborts.
+try {
+  New-Item -ItemType Directory -Force -Path '.milestone-config' | Out-Null
+  $ignorePath = Join-Path '.milestone-config' '.gitignore'
+  if (-not (Test-Path $ignorePath)) {
+    $ignoreBody = @(
+      '# milestone-driver / milestone-feeder per-clone scratch — git-invisible by default.'
+      '# Committed so per-run scratch stays out of `git status` with zero user setup.'
+      '# Patterns are relative to this .milestone-config/ directory. Tracked config'
+      '# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.'
+      'preflight-notice'; 'trello-notice'; 'triage-cache.json'; 'tests-stamp'
+      '.runtime/'; 'worktrees/'
+    ) -join "`n"
+    [System.IO.File]::WriteAllText($ignorePath, $ignoreBody + "`n", [System.Text.UTF8Encoding]::new($false))
+  }
+} catch {}
+```
+
+## Legacy-blanket root .gitignore notice
+
+- **Gate:** a root `.gitignore` blanket for `.milestone-config` is detected AND the per-clone marker is absent.
+- **Per-clone marker:** `.milestone-config/.runtime/legacy-blanket-notice`.
+- **Writes:** the `.runtime/` directory and the marker. Read-only on the root `.gitignore` — it never auto-edits it.
+- **Safety:** best-effort; a failed detect or marker write never aborts the run.
+
+```text
+🔴 Legacy blanket detected in your root .gitignore
+
+| What | Your root .gitignore ignores the whole .milestone-config/ directory
+|      | (a line like `.milestone-config/`, `.milestone-config/*`, or
+|      | `.milestone-config`). That hides this suite's TRACKED config —
+|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —
+|      | from git, so your config is silently dropped from version control.
+| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`
+|      | blanket line. The nested .milestone-config/.gitignore (already
+|      | written) then keeps per-run scratch invisible while feeder.json /
+|      | driver.json / the nested .gitignore stay tracked. We never edit your
+|      | root .gitignore for you — it is yours and may hold unrelated rules.
+| Note | This notice shows at most once per clone.
+```
+
+```bash
+# bash — read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts plan.
+# printf '%s\n' (NOT a heredoc): the same indent-safe construct the setup site uses, so both sites
+# emit one consistent form. The notice text is the quoted args, so it prints flush-left —
+# byte-identical to the setup site.
+marker=".milestone-config/.runtime/legacy-blanket-notice"
+if [ ! -f "$marker" ] && [ -f ".gitignore" ] \
+   && grep -Eq '^[[:space:]]*/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore \
+   && ! grep -Eq '^[[:space:]]*!/?\.milestone-config(/\*?)?[[:space:]]*$' .gitignore; then
+  printf '%s\n' \
+    '🔴 Legacy blanket detected in your root .gitignore' \
+    '' \
+    '| What | Your root .gitignore ignores the whole .milestone-config/ directory' \
+    '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or' \
+    '|      | `.milestone-config`). That hides this suite'"'"'s TRACKED config —' \
+    '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —' \
+    '|      | from git, so your config is silently dropped from version control.' \
+    '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`' \
+    '|      | blanket line. The nested .milestone-config/.gitignore (already' \
+    '|      | written) then keeps per-run scratch invisible while feeder.json /' \
+    '|      | driver.json / the nested .gitignore stay tracked. We never edit your' \
+    '|      | root .gitignore for you — it is yours and may hold unrelated rules.' \
+    '| Note | This notice shows at most once per clone.'
+  mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts plan.
+try {
+  $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'legacy-blanket-notice')
+  if ((-not (Test-Path $marker)) -and (Test-Path '.gitignore')) {
+    $lines = Get-Content -LiteralPath '.gitignore'
+    $blanket   = $lines | Where-Object { $_ -match '^\s*/?\.milestone-config(/\*?)?\s*$' }
+    $unignored = $lines | Where-Object { $_ -match '^\s*!/?\.milestone-config(/\*?)?\s*$' }
+    if ($blanket -and -not $unignored) {
+      # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
+      # @'…'@ closing terminator must sit at column 0, which breaks when nested under indented
+      # markdown. The text below is byte-identical to the bash printf args and the setup site.
+      Write-Host (@(
+        '🔴 Legacy blanket detected in your root .gitignore'
+        ''
+        '| What | Your root .gitignore ignores the whole .milestone-config/ directory'
+        '|      | (a line like `.milestone-config/`, `.milestone-config/*`, or'
+        '|      | `.milestone-config`). That hides this suite''s TRACKED config —'
+        '|      | feeder.json, driver.json, and the nested .milestone-config/.gitignore —'
+        '|      | from git, so your config is silently dropped from version control.'
+        '| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`'
+        '|      | blanket line. The nested .milestone-config/.gitignore (already'
+        '|      | written) then keeps per-run scratch invisible while feeder.json /'
+        '|      | driver.json / the nested .gitignore stay tracked. We never edit your'
+        '|      | root .gitignore for you — it is yours and may hold unrelated rules.'
+        '| Note | This notice shows at most once per clone.'
+      ) -join "`n")
+      New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+      New-Item -ItemType File -Force -Path $marker | Out-Null
+    }
+  }
+} catch {}
+```
+
+## Bootstrap-nudge notice
+
+- **Gate:** the repo is un-bootstrapped (the resolved `projectDocs` path is absent or has no readable files, OR `.milestone-config/driver.json` is missing) AND the per-clone marker is absent.
+- **Per-clone marker:** `.milestone-config/.runtime/bootstrap-nudge-notice`.
+- **Writes:** the `.runtime/` directory and the marker. Read-only — it never runs the bootstrapper and never writes `projectDocs` / `.project/` or `driver.json`.
+- **Safety:** best-effort; a failed resolve, detect, or marker write never aborts the run.
+
+```text
+🟡 This repo isn't bootstrapped — your plan's grounding will be weak
+
+| What | This repo has no .project/ standing docs and/or no
+|      | .milestone-config/driver.json. Without them, plan has no project
+|      | constitution to ground issue design on and no driver profile to
+|      | resolve shared keys from, so it falls back to thin inferred
+|      | conventions and the issues it writes are weaker.
+| Fix  | Run milestone-bootstrapper first to scaffold your .project/ docs and
+|      | driver profile, then re-run /milestone-feeder:plan. We won't do this
+|      | for you and we won't block — config is optional and plan will
+|      | continue with best-effort grounding.
+| Note | This notice shows at most once per clone.
+```
+
+```bash
+# bash — read-only detect + one-time notice; NEVER writes projectDocs/.project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
+# printf '%s\n' (NOT a heredoc): the same indent-safe construct the sibling legacy-blanket block uses, so both
+# sites emit one consistent form. The notice text is the quoted args, so it prints flush-left.
+# Resolve projectDocs in-block (the key-extraction table below has not run yet) with the SAME default the table uses,
+# so the two reads can't diverge; a non-string projectDocs (number/array), missing file / malformed JSON / missing jq
+# all fall back to .project/. Strip ALL trailing slashes for the detect operand; an empty result (e.g. "/") falls back
+# to .project so bash and PowerShell agree; the notice re-adds a single "/" so the printed path always ends in "/".
+pd="$(jq -r 'if (.projectDocs | type) == "string" then .projectDocs else ".project/" end' .milestone-config/feeder.json 2>/dev/null || echo ".project/")"
+[ -z "$pd" ] && pd=".project/"
+while [ "$pd" != "${pd%/}" ]; do pd="${pd%/}"; done
+[ -z "$pd" ] && pd=".project"
+marker=".milestone-config/.runtime/bootstrap-nudge-notice"
+if [ ! -f "$marker" ] \
+   && { [ -z "$(find -L "$pd" -type f 2>/dev/null | head -1)" ] || [ ! -f ".milestone-config/driver.json" ]; }; then
+  printf '%s\n' \
+    '🟡 This repo isn'"'"'t bootstrapped — your plan'"'"'s grounding will be weak' \
+    '' \
+    "| What | This repo has no ${pd}/ standing docs and/or no" \
+    '|      | .milestone-config/driver.json. Without them, plan has no project' \
+    '|      | constitution to ground issue design on and no driver profile to' \
+    '|      | resolve shared keys from, so it falls back to thin inferred' \
+    '|      | conventions and the issues it writes are weaker.' \
+    '| Fix  | Run milestone-bootstrapper first to scaffold your .project/ docs and' \
+    '|      | driver profile, then re-run /milestone-feeder:plan. We won'"'"'t do this' \
+    '|      | for you and we won'"'"'t block — config is optional and plan will' \
+    '|      | continue with best-effort grounding.' \
+    '| Note | This notice shows at most once per clone.'
+  mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes projectDocs/.project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
+try {
+  # Resolve projectDocs in-block (the key-extraction table below has not run yet) with the SAME default the table uses,
+  # so the two reads can't diverge; a non-string projectDocs (number/array), missing file / malformed JSON all fall
+  # back to .project/. Strip ALL trailing slashes for the detect operand; an empty result (e.g. "/") falls back to
+  # .project so PowerShell and bash agree; the notice re-adds a single "/" so the printed path always ends in "/".
+  $pd = '.project/'
+  try { $pdRaw = (Get-Content -Raw -LiteralPath (Join-Path '.milestone-config' 'feeder.json') -ErrorAction Stop | ConvertFrom-Json).projectDocs; if ($pdRaw -is [string]) { $pd = $pdRaw } } catch {}
+  $pd = $pd -replace '/+$',''
+  if (-not $pd) { $pd = '.project' }
+  $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'bootstrap-nudge-notice')
+  $projectEmpty = -not (Test-Path $pd) -or -not (Get-ChildItem -LiteralPath $pd -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $driverMissing = -not (Test-Path (Join-Path '.milestone-config' 'driver.json'))
+  if ((-not (Test-Path $marker)) -and ($projectEmpty -or $driverMissing)) {
+    # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
+    # @'…'@ closing terminator must sit at column 0, which breaks when nested under indented
+    # markdown. The text below is byte-identical to the bash printf args (same resolved $pd).
+    Write-Host (@(
+      '🟡 This repo isn''t bootstrapped — your plan''s grounding will be weak'
+      ''
+      "| What | This repo has no ${pd}/ standing docs and/or no"
+      '|      | .milestone-config/driver.json. Without them, plan has no project'
+      '|      | constitution to ground issue design on and no driver profile to'
+      '|      | resolve shared keys from, so it falls back to thin inferred'
+      '|      | conventions and the issues it writes are weaker.'
+      '| Fix  | Run milestone-bootstrapper first to scaffold your .project/ docs and'
+      '|      | driver profile, then re-run /milestone-feeder:plan. We won''t do this'
+      '|      | for you and we won''t block — config is optional and plan will'
+      '|      | continue with best-effort grounding.'
+      '| Note | This notice shows at most once per clone.'
+    ) -join "`n")
+    New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+    New-Item -ItemType File -Force -Path $marker | Out-Null
+  }
+} catch {}
+```
+
+## Roadmap-routing notice
+
+- **Gate:** the per-clone marker is absent. Otherwise unconditional — there is no repo-state condition, because the notice announces a behavior change.
+- **Per-clone marker:** `.milestone-config/.runtime/roadmap-routing-notice`.
+- **Writes:** the `.runtime/` directory and the marker. `plan` Step 0 only — there is no `setup` twin.
+- **Safety:** best-effort; a failed notice or marker write never aborts the run.
+
+```text
+🟡 New: an oversized brief now routes into a roadmap flow
+
+| What | When you give plan a whole-app brief that spans several
+|      | releases, plan now hands it to a roadmap step first: it
+|      | proposes a sequenced set of milestones and asks you to
+|      | confirm, merge, split, reorder, or reject the split before
+|      | it plans any single milestone.
+| When | Only when the brief reads as several milestones. A normal,
+|      | single-release brief is unchanged — no roadmap step, no
+|      | extra prompt.
+| Note | This notice shows at most once per clone.
+```
+
+```bash
+# bash — one-time roadmap-routing discovery notice; read-only; marker-gated; never aborts plan.
+# printf '%s\n' (NOT a heredoc): the same indent-safe construct the sibling Step-0 notices use,
+# so all three sites emit one consistent form. The notice text is the quoted args — prints flush-left.
+marker=".milestone-config/.runtime/roadmap-routing-notice"
+if [ ! -f "$marker" ]; then
+  printf '%s\n' \
+    '🟡 New: an oversized brief now routes into a roadmap flow' \
+    '' \
+    '| What | When you give plan a whole-app brief that spans several' \
+    '|      | releases, plan now hands it to a roadmap step first: it' \
+    '|      | proposes a sequenced set of milestones and asks you to' \
+    '|      | confirm, merge, split, reorder, or reject the split before' \
+    '|      | it plans any single milestone.' \
+    '| When | Only when the brief reads as several milestones. A normal,' \
+    '|      | single-release brief is unchanged — no roadmap step, no' \
+    '|      | extra prompt.' \
+    '| Note | This notice shows at most once per clone.'
+  mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same one-time roadmap-routing discovery notice; read-only; marker-gated; never aborts plan.
+try {
+  $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'roadmap-routing-notice')
+  if (-not (Test-Path $marker)) {
+    # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string; byte-identical
+    # to the bash printf args and the text template above.
+    Write-Host (@(
+      '🟡 New: an oversized brief now routes into a roadmap flow'
+      ''
+      '| What | When you give plan a whole-app brief that spans several'
+      '|      | releases, plan now hands it to a roadmap step first: it'
+      '|      | proposes a sequenced set of milestones and asks you to'
+      '|      | confirm, merge, split, reorder, or reject the split before'
+      '|      | it plans any single milestone.'
+      '| When | Only when the brief reads as several milestones. A normal,'
+      '|      | single-release brief is unchanged — no roadmap step, no'
+      '|      | extra prompt.'
+      '| Note | This notice shows at most once per clone.'
+    ) -join "`n")
+    New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+    New-Item -ItemType File -Force -Path $marker | Out-Null
+  }
+} catch {}
+```
+
+## Implied-surfaces notice
+
+- **Gate:** the overlay `.milestone-config/implied-surfaces.md` is absent AND the per-clone marker is absent.
+- **Per-clone marker:** `.milestone-config/.runtime/implied-surfaces-notice` — shared verbatim text and shared marker with the `update` Step-0 twin, so the notice shows at most once per clone across both verbs.
+- **Writes:** the `.runtime/` directory and the marker. Read-only — it never writes the overlay.
+- **Safety:** best-effort; a failed detect, notice, or marker write never aborts the run.
+
+```text
+🟡 Optional: add project-specific implied surfaces
+
+| What | You can add an optional overlay file at
+|      | .milestone-config/implied-surfaces.md. The architect reads it
+|      | alongside the plugin's bundled implied-surfaces reference when it
+|      | breaks your brief into issues.
+| Why  | The bundled reference is universal, so it can't carry capability
+|      | clusters specific to your domain (a church app's "giving", say).
+|      | Your overlay merges in additively — it can add a new capability
+|      | and extend an existing one, but never removes a surface the
+|      | bundled reference already defines.
+| How  | Create .milestone-config/implied-surfaces.md and write one
+|      | capability per ## heading with its implied surfaces beneath — the
+|      | same shape as the bundled reference. Leave it out and the bundled
+|      | reference is used as-is; an absent overlay is never an error.
+| Note | This notice shows at most once per clone.
+```
+
+```bash
+# bash — read-only detect + one-time notice; NEVER writes the overlay; never aborts plan.
+# printf '%s\n' (NOT a heredoc): indent-safe under this list item — a heredoc terminator must sit
+# at column 0, but this block is nested, so an indented EOF would be a syntax error. Mirrors the
+# plan Step-0 bootstrap-nudge form. The notice text is the quoted args, so it prints flush-left.
+marker=".milestone-config/.runtime/implied-surfaces-notice"
+if [ ! -f "$marker" ] && [ ! -f ".milestone-config/implied-surfaces.md" ]; then
+  printf '%s\n' \
+    '🟡 Optional: add project-specific implied surfaces' \
+    '' \
+    '| What | You can add an optional overlay file at' \
+    '|      | .milestone-config/implied-surfaces.md. The architect reads it' \
+    '|      | alongside the plugin'"'"'s bundled implied-surfaces reference when it' \
+    '|      | breaks your brief into issues.' \
+    '| Why  | The bundled reference is universal, so it can'"'"'t carry capability' \
+    '|      | clusters specific to your domain (a church app'"'"'s "giving", say).' \
+    '|      | Your overlay merges in additively — it can add a new capability' \
+    '|      | and extend an existing one, but never removes a surface the' \
+    '|      | bundled reference already defines.' \
+    '| How  | Create .milestone-config/implied-surfaces.md and write one' \
+    '|      | capability per ## heading with its implied surfaces beneath — the' \
+    '|      | same shape as the bundled reference. Leave it out and the bundled' \
+    '|      | reference is used as-is; an absent overlay is never an error.' \
+    '| Note | This notice shows at most once per clone.'
+  mkdir -p .milestone-config/.runtime 2>/dev/null && : > "$marker" 2>/dev/null || true
+fi
+```
+
+```powershell
+# PowerShell 7+ — same read-only detect + one-time notice; NEVER writes the overlay; never aborts plan.
+try {
+  $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'implied-surfaces-notice')
+  $overlay = Join-Path '.milestone-config' 'implied-surfaces.md'
+  if ((-not (Test-Path $marker)) -and (-not (Test-Path $overlay))) {
+    # Indent-safe array-join (the #120/#121 self-heal construct) — NOT a here-string: an
+    # @'…'@ closing terminator must sit at column 0, which breaks when nested under this
+    # indented markdown list item. The text below is byte-identical to the bash printf args.
+    Write-Host (@(
+      '🟡 Optional: add project-specific implied surfaces'
+      ''
+      '| What | You can add an optional overlay file at'
+      '|      | .milestone-config/implied-surfaces.md. The architect reads it'
+      '|      | alongside the plugin''s bundled implied-surfaces reference when it'
+      '|      | breaks your brief into issues.'
+      '| Why  | The bundled reference is universal, so it can''t carry capability'
+      '|      | clusters specific to your domain (a church app''s "giving", say).'
+      '|      | Your overlay merges in additively — it can add a new capability'
+      '|      | and extend an existing one, but never removes a surface the'
+      '|      | bundled reference already defines.'
+      '| How  | Create .milestone-config/implied-surfaces.md and write one'
+      '|      | capability per ## heading with its implied surfaces beneath — the'
+      '|      | same shape as the bundled reference. Leave it out and the bundled'
+      '|      | reference is used as-is; an absent overlay is never an error.'
+      '| Note | This notice shows at most once per clone.'
+    ) -join "`n")
+    New-Item -ItemType Directory -Force -Path (Join-Path '.milestone-config' '.runtime') | Out-Null
+    New-Item -ItemType File -Force -Path $marker | Out-Null
+  }
+} catch {}
+```


### PR DESCRIPTION
Closes #197.

## What this does
Creates one additive reference file, `docs/one-time-notices.md`, that holds the five `plan` Step-0 one-time-notice units **byte-exact, once**, as the single canonical source the skills will later point at (the `plan`/`setup`/`update` repoint is downstream in #199/#203/#204). It edits **no skill** and changes **no behavior** — the extracted text is byte-identical to today's inline blocks, and the `tests/scenarios/` e2e suite produces identical results before and after.

The five units, each a stable `##` anchor recording its gate / per-clone `.runtime/` marker (where it has one) / what it writes, then the verbatim notice text + both the bash and PowerShell 7+ emitter twins:
1. nested `.milestone-config/.gitignore` self-heal (file-absence gate, no marker — create-only)
2. legacy-blanket root `.gitignore` detect + notice
3. bootstrap-nudge notice
4. roadmap-routing notice
5. implied-surfaces notice

## Acceptance criteria — all met
- New `docs/one-time-notices.md` opens with a TOC, stays one level deep, holds all five units.
- **Byte-exactness:** each unit byte-for-byte identical to `skills/plan/SKILL.md` Step 0 — verified by five empty `diff`s of the source ranges (33–78, 85–160, 168–251, 258–318, 325–403) against the new-file ranges. Extracted by piping source bytes (`sed`), never retyped, so the 🔴/🟡 leads, em-dashes, `'"'"'` bash and `''` pwsh quote escapes, and literal `\n` all survive intact.
- Per-notice byte-exact extraction/addressing contract: one stable anchor per notice, consumable by both emitter twins.
- Self-heal recorded with its file-absence gate and **no** fabricated `.runtime/` marker.
- Anti-fixation strings `[implied — review / trim / augment]` and `this is a starting set for YOUR app — what's missing?` absent (0/0).
- Scope guard: diff touches only `docs/one-time-notices.md` (no docs index exists to update) + the version bump; no skill changed.
- LF line endings, no CRLF, no BOM.

## Decision Log
| Choice | Rationale | Citation | Rejected |
|---|---|---|---|
| Flat one-level-deep shape (H1 + intro + TOC + five `##`, no `###`) | Locked architecture mandates one level deep; matches the bundled-reference precedent | `docs/implied-surfaces.md`; `.project/conventions.md#File & folder layout` | `###` per-twin subsections (forbidden; bloats anchors) |
| TOC as a bold `**Contents**` label + numbered list, not a `## Table of contents` heading | A `##` TOC would make six `##` sections and fail the "exactly five `##` sections" shape | brief shape spec | `## Table of contents` heading |
| Descriptive (non-numbered) `##` headings carry the stable anchor; the TOC supplies 1–5 order | Downstream #199/#203/#204 source from these anchors — stable heading text beats numeric prefixes that drift | brief ("each `##` section is a stable anchor") | `## 1. …` numbered headings |
| Assemble by piping source bytes (`sed -n 'S,Ep'`), never hand-typing the code blocks | Byte-exactness mandate — `sed` copies the emoji / em-dash / quote-escape bytes with zero retyping | proven by the five empty diffs | hand-typing the blocks (drift risk) |
| Version bump 0.7.0 → 0.8.0 in this PR | milestone v0.8.0 target | step 6.4 | — |

## Code Review
- /code-review run: yes (high effort — risk:heavy)
- Findings: 0 in-scope findings at high effort
  - none
- No park-triggering findings.
- Version-bump annotation: version-bump only — no logic change (the `.claude-plugin/plugin.json` 0.7.0 → 0.8.0 edit is config, not source).

The byte-exact code blocks are already-shipped source content (out of scope for new-defect hunting); review focused on the authored surface — TOC anchor integrity (all five resolve), metadata accuracy vs the source prose, anti-fixation absence, encoding, and shape. Clean.