### PR TITLE
refactor(build-roadmap): extract manifest-format scaffold to docs reference (#206)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is checked against the driver's own triage reviewers before anything is written. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/docs/roadmap-manifest-format.md
+++ b/docs/roadmap-manifest-format.md
@@ -1,0 +1,46 @@
+# Roadmap manifest format
+
+`build-roadmap` writes the roadmap manifest to `.milestone-feeder/roadmap-<slug>.md` on confirmation — the authoritative cross-milestone build artifact that records WHICH milestones to plan and in WHAT order, plus the full original brief. This reference is its exact shape: `build-roadmap` Step 4 reads it on demand to write the manifest, and the downstream consumers read the manifest this shape produces (`skills/plan/SKILL.md` Step 3.7; `skills/create/SKILL.md` Step 1R / Step 3V).
+
+Write the manifest in this shape. It carries the source-brief reference, the **full** original brief (persisted in full — required downstream by the brief-coverage verification, #158), the cross-milestone build order, and one entry per confirmed milestone. It does **NOT** carry the per-milestone §4 issue bodies or Wave order — those live in each milestone's own `plan-<slug>.md` (`.project/design-philosophy.md#Layering & boundaries`):
+
+```markdown
+# Milestone roadmap — <whole-app brief one-line goal>
+
+Source brief: <inline | file:<path> | epic #<n>>
+Confirmed: yes — this roadmap is the USER-CONFIRMED split. Any merge / split / reorder the user asked for at the confirmation checkpoint is already applied here; this is NOT the raw splitter proposal.
+Build order: <milestone 1 name> → <milestone 2 name> → … → <milestone N name>
+
+## Original brief
+<The FULL original whole-app brief text, persisted verbatim and multi-line — every
+ section the author wrote, in full. This is a MULTI-LINE section, NOT a single
+ header line: the downstream brief-coverage verification (#158) reads it to confirm
+ the roadmap covers everything the brief asked for. Persisting it here is the manifest
+ owner's contract, shared with #158 / #157. The brief is delimited by the paired
+ `## Original brief` … `## End original brief` markers (the literal closing line below),
+ so a brief that contains its OWN `## ` headings is captured intact — the consumer reads
+ strictly between the two markers and is NOT truncated at the brief's first internal
+ `## ` heading (`skills/create/SKILL.md` Step 3V, rung 2).>
+## End original brief
+
+## Milestones (in build order)
+
+### 1. <milestone name>
+- Brief slice: <the portion of the brief this milestone owns — the author sections / scope it covers, verbatim or closely paraphrased>
+- Build-order position: 1
+- Plan file: <pending — `build-roadmap` leaves this EMPTY; the roadmap planning fan-out (`plan` Step 3.7) populates it with `.milestone-feeder/plan-<assignedSlug>.md` after it plans this milestone>
+- Change-rationale: <merged | split | reordered | unchanged vs the author's headings, and why — the sections involved and the dependency, if any>
+
+### 2. <milestone name>
+- Brief slice: <…>
+- Build-order position: 2
+- Plan file: <pending — populated by the fan-out (`plan` Step 3.7) after it plans this milestone>
+- Change-rationale: <…>
+
+### … (one block per confirmed milestone, in build order; positions run 1..N)
+
+---
+This roadmap manifest is the cross-milestone build artifact. It records WHICH milestones to plan and in WHAT order, plus the full original brief — NOT each milestone's §4 issue bodies or Wave order, which `plan` produces into that milestone's own `.milestone-feeder/plan-<slug>.md` when it runs the single-milestone pipeline per milestone above. `build-roadmap` wrote no GitHub state.
+```
+
+**The `Plan file:` field — the deterministic per-milestone handle, written in two stages.** Each milestone entry carries a `Plan file:` field, but `build-roadmap` writes it **PENDING (empty)**: at manifest-write time it has confirmed only the milestone *names* and *build order* — it has planned **no** milestone, so it does **not** yet know the disambiguated `assignedSlug` that names the plan file (that slug is goal-derived with an `-m<index>` collision tiebreaker the milestone *name* does not encode; `plan` Step 3.7.d owns it). The **roadmap planning fan-out** (`plan` Step 3.7) **populates** each entry's `Plan file:` with that milestone's real path — `.milestone-feeder/plan-<assignedSlug>.md` — **after** it plans that milestone (`plan` Step 3.7.g). Once the fan-out finishes, every planned milestone's entry carries its real plan-file path, and that path is the **deterministic handle `create`'s deploy-loop resolves each milestone's plan file by** (`skills/create/SKILL.md` Step 1R) — **never** a slug re-derived from the milestone name. `build-roadmap` itself reserves the field and plans nothing; populating it is the fan-out's job.

--- a/skills/build-roadmap/SKILL.md
+++ b/skills/build-roadmap/SKILL.md
@@ -101,54 +101,13 @@ if (-not (Test-Path .milestone-feeder/.gitignore)) { Set-Content -LiteralPath .m
 
 **Derive the manifest slug deterministically.** Write the manifest to `.milestone-feeder/roadmap-<slug>.md`, where `<slug>` is derived from the **whole-app brief's one-line goal / title** by the **same deterministic rule the plan file uses** (`.project/conventions.md#Naming`; `skills/plan/SKILL.md` Step 7): take the one-line goal, lowercase it, replace every run of non-alphanumeric characters with a single hyphen, strip any leading/trailing hyphens, and cap the length at a reasonable bound (trimming a trailing hyphen if the cut lands on one). A roadmap has no single milestone goal, so the slug derives from the whole-app brief's one-line goal/title; the manifest header carries the source-brief reference for the brief↔manifest match.
 
-**Write the manifest** (format below). **A failed scratch-write is surfaced, not swallowed** — if the write fails, tell the user and **do not advance control** as if a manifest existed (`.project/design-philosophy.md#Error & failure philosophy` — surfaced, never silently dropped). Never leave a partial or corrupt manifest: on any write failure, the manifest must be absent, not half-written.
+**Write the manifest** (format in `docs/roadmap-manifest-format.md` — read it on demand). **A failed scratch-write is surfaced, not swallowed** — if the write fails, tell the user and **do not advance control** as if a manifest existed (`.project/design-philosophy.md#Error & failure philosophy` — surfaced, never silently dropped). Never leave a partial or corrupt manifest: on any write failure, the manifest must be absent, not half-written.
 
 **Return control + the manifest path to `plan`.** On a successful write, return the manifest path so `plan` resumes and runs its single-milestone pipeline once per milestone the roadmap names, in build order. On the single-milestone (Step 2) or reject (Step 3) paths, return with **no** manifest path — signalling `plan` to proceed with its existing single-milestone pipeline on the whole brief, unchanged.
 
 ## Manifest format
 
-Write the manifest in this shape. It carries the source-brief reference, the **full** original brief (persisted in full — required downstream by the brief-coverage verification, #158), the cross-milestone build order, and one entry per confirmed milestone. It does **NOT** carry the per-milestone §4 issue bodies or Wave order — those live in each milestone's own `plan-<slug>.md` (`.project/design-philosophy.md#Layering & boundaries`):
-
-```markdown
-# Milestone roadmap — <whole-app brief one-line goal>
-
-Source brief: <inline | file:<path> | epic #<n>>
-Confirmed: yes — this roadmap is the USER-CONFIRMED split. Any merge / split / reorder the user asked for at the confirmation checkpoint is already applied here; this is NOT the raw splitter proposal.
-Build order: <milestone 1 name> → <milestone 2 name> → … → <milestone N name>
-
-## Original brief
-<The FULL original whole-app brief text, persisted verbatim and multi-line — every
- section the author wrote, in full. This is a MULTI-LINE section, NOT a single
- header line: the downstream brief-coverage verification (#158) reads it to confirm
- the roadmap covers everything the brief asked for. Persisting it here is the manifest
- owner's contract, shared with #158 / #157. The brief is delimited by the paired
- `## Original brief` … `## End original brief` markers (the literal closing line below),
- so a brief that contains its OWN `## ` headings is captured intact — the consumer reads
- strictly between the two markers and is NOT truncated at the brief's first internal
- `## ` heading (`skills/create/SKILL.md` Step 3V, rung 2).>
-## End original brief
-
-## Milestones (in build order)
-
-### 1. <milestone name>
-- Brief slice: <the portion of the brief this milestone owns — the author sections / scope it covers, verbatim or closely paraphrased>
-- Build-order position: 1
-- Plan file: <pending — `build-roadmap` leaves this EMPTY; the roadmap planning fan-out (`plan` Step 3.7) populates it with `.milestone-feeder/plan-<assignedSlug>.md` after it plans this milestone>
-- Change-rationale: <merged | split | reordered | unchanged vs the author's headings, and why — the sections involved and the dependency, if any>
-
-### 2. <milestone name>
-- Brief slice: <…>
-- Build-order position: 2
-- Plan file: <pending — populated by the fan-out (`plan` Step 3.7) after it plans this milestone>
-- Change-rationale: <…>
-
-### … (one block per confirmed milestone, in build order; positions run 1..N)
-
----
-This roadmap manifest is the cross-milestone build artifact. It records WHICH milestones to plan and in WHAT order, plus the full original brief — NOT each milestone's §4 issue bodies or Wave order, which `plan` produces into that milestone's own `.milestone-feeder/plan-<slug>.md` when it runs the single-milestone pipeline per milestone above. `build-roadmap` wrote no GitHub state.
-```
-
-**The `Plan file:` field — the deterministic per-milestone handle, written in two stages.** Each milestone entry carries a `Plan file:` field, but `build-roadmap` writes it **PENDING (empty)**: at manifest-write time it has confirmed only the milestone *names* and *build order* — it has planned **no** milestone, so it does **not** yet know the disambiguated `assignedSlug` that names the plan file (that slug is goal-derived with an `-m<index>` collision tiebreaker the milestone *name* does not encode; `plan` Step 3.7.d owns it). The **roadmap planning fan-out** (`plan` Step 3.7) **populates** each entry's `Plan file:` with that milestone's real path — `.milestone-feeder/plan-<assignedSlug>.md` — **after** it plans that milestone (`plan` Step 3.7.g). Once the fan-out finishes, every planned milestone's entry carries its real plan-file path, and that path is the **deterministic handle `create`'s deploy-loop resolves each milestone's plan file by** (`skills/create/SKILL.md` Step 1R) — **never** a slug re-derived from the milestone name. `build-roadmap` itself reserves the field and plans nothing; populating it is the fan-out's job.
+The roadmap manifest is the **authoritative cross-milestone build artifact** — its exact shape (every field, the paired `## Original brief` … `## End original brief` markers, the `## Milestones (in build order)` entries, and the two-stage `Plan file:` handle) is defined in `docs/roadmap-manifest-format.md`. Step 4 reads that reference on demand to write the manifest; consumers cite this contract by section name as `skills/build-roadmap/SKILL.md "Manifest format"` (`skills/plan/SKILL.md` Step 3.7; `skills/create/SKILL.md` Step 1R / Step 3V).
 
 ## Output style
 


### PR DESCRIPTION
Closes #206.

Behavior-neutral progressive-disclosure trim of `skills/build-roadmap/SKILL.md`. The `## Manifest format` section inlined the full roadmap-manifest scaffold; this relocates that scaffold into an on-demand reference file and leaves a lean pointer, with **zero behavior change**.

## What changed
- **NEW `docs/roadmap-manifest-format.md`** — the manifest scaffold's new home: title + one-line purpose + the original section preamble (verbatim) + the **byte-exact** fenced manifest block + the **byte-exact** trailing `Plan file:` paragraph. 46 lines, UTF-8, LF-only, no BOM (the repo's reference home is `docs/`; sibling precedent `docs/implied-surfaces.md`).
- **`skills/build-roadmap/SKILL.md`** — the `## Manifest format` body replaced with a lean pointer that (a) still names the manifest the authoritative cross-milestone build artifact and (b) directs the reader to the reference; Step 4's `(format below)` repointed to `(format in docs/roadmap-manifest-format.md — read it on demand)`. The `## Manifest format` **heading is preserved verbatim**.
- **`.claude-plugin/plugin.json`** — version bumped to the milestone target **0.8.0**.

## Why it's behavior-neutral
- **Citation anchor preserved.** Consumers cite the contract by section name `skills/build-roadmap/SKILL.md "Manifest format"` — plan Step 3.7 (601/664/677/895/945) and create Step 1R/3V (12/38/49/53/320/323). The heading survives, so all citations resolve with **no edit to plan or create**.
- **Byte-exact relocation.** The fence (orig lines 112–149), the trailing paragraph (orig line 151), and the preamble (orig line 110) are byte-identical in the new file (verified by `diff` against `HEAD`). The manifest that `build-roadmap` writes is unchanged.
- **Regression gate green.** `tests/scenarios/11-roadmap-fan-out` is byte-identical before/after (all four fixture checksums unchanged); the splitter dispatch (Step 1), the surface-for-confirm checkpoint (Step 3), and the manifest write (Step 4) are unchanged.

## Word budget — judgment call (see `judgment call` label)
The issue's gate is `~1,500–2,000` words via `wc -w`. The executed locked scope (relocate the scaffold + dedupe the rationale) lands the **prose body at 1983 words — under 2000**. The mechanical `wc -w` is **2101** (~5% over); the entire residual is legitimately-present code-fence scaffolds (the bash/pwsh self-ignore twins and the `ROADMAP:` return block) that the skill-authoring body-word standard does not measure. Accepted as within the criterion's explicit "~2,000" budget rather than relocating a second, un-authorized region or parking on a soft-ceiling artifact. Reversible: if true mechanical ≤2000 is required, a follow-up can relocate one more scaffold region.

## Decision Log
| Choice | Rationale | Citation | Rejected alternative |
|---|---|---|---|
| Relocate to `docs/`, not skill-scoped `references/` | `docs/` is the repo's reference home; no `skills/**/references/` exists | `.project/conventions.md#File & folder layout`; sibling `docs/implied-surfaces.md` | skill-scoped `references/` (non-existent here) |
| Extract relocated regions programmatically | guarantees byte-for-byte identity so behavior is provably unchanged | verified: `diff` empty vs `HEAD` | hand-retype (unverifiable) |
| Keep `## Manifest format` heading verbatim | consumers cite by section-name anchor; preserving it = zero consumer edits | plan Step 3.7; create Step 1R/3V | rename/remove (breaks anchors) |
| Repoint only the Step 4 `(format below)` parenthetical | the format moved, but the written manifest must stay byte-identical | `.project/design-philosophy.md#Error & failure philosophy` | rewriting Step 4 (out of scope) |
| Accept mechanical 2101 (prose 1983) | prose body under 2000; residual is code-fence scaffolds; "~2,000" gate | issue acceptance criterion "~1,500–2,000" | park / unauthorized 2nd relocation |

## Code Review
- /code-review run: yes (medium effort)
- Findings: 0 in-scope finding(s) at medium effort
  - none
- No park-triggering findings.
- Version note: version-bump to 0.8.0 (milestone target) — no logic change.