### PR TITLE
refactor(plan): trim Step 7 — point templates + contract at the shared reference (#202)

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -824,21 +824,7 @@ New-Item -ItemType Directory -Force -Path .milestone-feeder | Out-Null
 if (-not (Test-Path .milestone-feeder/.gitignore)) { Set-Content -LiteralPath .milestone-feeder/.gitignore -Value '*' -Encoding utf8NoBOM }
 ```
 
-**The plan-file contract.** The plan file is the load-bearing build artifact: `create` and `update` read it and write GitHub from it — they regenerate nothing. It MUST carry every field below, unambiguously (`SPEC.md` §3):
-
-| Field | Requirement |
-|---|---|
-| **Milestone title (exact)** | The exact milestone title, on its own labeled line — **distinct** from the one-line goal. Now **user-owned** and carrying the resolved **semver inside the string** (no separate version field), resolved at Step 5.1 by the version ladder and **surfaced for the user to confirm or override BEFORE `create`** (`docs/specs/v0.3.1-driver-handoff.md` §3, §6). `create` / `update` still resolve the milestone by this exact title (creating it if absent, adopting it if it already exists), and the driver parses the version from it — this remains the load-bearing identity field; the one-line goal is descriptive only. |
-| **Version provenance** | One line, one of `explicit` \| `declaration` \| `inferred from <tag/milestone>` \| `prompted` (the Step 5.1 ladder rung that resolved the title — `docs/specs/v0.3.1-driver-handoff.md` §6 "Version provenance" row). It makes the surfaced default **legible** so the user can trust or correct it. |
-| **Multi-milestone advisory** | **ADDITIVE and OPTIONAL** — present **ONLY** on the **retained** path: the architect raised `SCOPE_SPANS_MULTIPLE_MILESTONES` (Step 3) **AND** the front-door (Step 3.6) did **NOT** route this brief into `build-roadmap` (`roadmapRouteTaken` false — the signal was raised but the route degraded, was declined, or resolved to a single milestone). On that path it carries the flag + the proposed split (milestone names + their candidate tags) **VERBATIM** from the architect — `plan` does not re-partition. **OMITTED entirely** when the signal is `none` (single-milestone plan byte-for-byte unchanged) **OR** when the front-door **took the route** (`roadmapRouteTaken` true — the confirmed roadmap was surfaced in its place, so this passive advisory is **SUPERSEDED**; on the route path the single-milestone Steps 4–7 do not run for the whole brief anyway). **Non-blocking** — it does not change what gets deployed; the plan stays a deployable single-milestone plan. Sourced from the architect's structural read of `CANDIDATES`, so on the retained path it is written even if every candidate is parked/dropped (Step 6). Grounding: `docs/specs/v0.3.1-driver-handoff.md` §6 (the additive plan-file field) and §5. |
-| **One-line goal** | The milestone goal in one line — the header. |
-| **Milestone description (Wave order)** | The Step 5 build-order / Wave description, verbatim, with local slugs (`#A`/`#B`). This is what `create` PATCHes onto the milestone after issue numbers exist. |
-| **Per surviving issue** | For each surviving (gate-clean / Advisory-only) issue: its slug, title, the FULL §4 `ISSUE_BODY` verbatim, its labels, and its surface/risk. `create` reads these — no regeneration. An `implied` candidate (architect `disposition: implied`) additionally carries the `[implied — review / trim / augment]` marker on its issue heading (the `## Issues` template below); a grounded candidate renders without it. |
-| **Parked issues** | Each parked issue: slug, title, and kind (`product-gap` \| `needs-human-direction`). Marked, never created. |
-| **Dropped issues** | Each dropped issue: slug, title, and the parked dependency that dropped it. Marked, never created. |
-| **Self-check verdict line** | The Step 6 outcome (PASS / INTERNAL / PARKED / SKIPPED(reviewer:false)). `create` trusts it; no re-vet. |
-| **Source brief reference** | `inline` \| `file:<path>` \| `epic #<n>` — drives the downstream report routing and the brief↔plan match. Record `epicIssueNumber` here when the brief was an epic. |
-| **Original brief (full text)** | The **full** brief text this plan run received — persisted verbatim and multi-line as the `## Original brief` … `## End original brief` delimited section below (a brief is multi-line, so a SECTION, not a `Label: value` header line; `Source brief reference` records only the form token; the paired end-delimiter keeps a brief that contains its own `## ` headings intact for the consumer, never truncated at its first internal heading). It is the durable single-milestone fallback `create`'s closing brief-coverage verification reads to audit the deploy against the original brief (`skills/create/SKILL.md` Step 3V — the brief-resolution ladder). Mirrors the roadmap manifest's `## Original brief`, which persists the whole-app brief for a roadmap run (`skills/build-roadmap/SKILL.md` "Manifest format"). |
+**The plan-file contract.** The plan file is the load-bearing build artifact: `create` and `update` read it and write GitHub from it — they regenerate nothing. It MUST carry every field defined in the **Plan-file field table** (`docs/plan-file-contract.md#plan-file-field-table`), unambiguously (`SPEC.md` §3) — that table is normative: render every field exactly as it specifies.
 
 **Surface the resolved identity for confirm/override.** Both the resolved `Milestone title (exact)` (carrying the semver per the Step 5.1 ladder) **and** its `Version provenance` line are written to the plan file and **surfaced for the user to confirm or override BEFORE running `create`** — `plan` never silently finalizes a milestone identity the user cannot see or change (`docs/specs/v0.3.1-driver-handoff.md` §2, §3, §6). On an infer rung the title carries the **reference version verbatim**, and this surfaced line is **where the user adjusts the patch / minor / major bump** before `create` deploys it.
 
@@ -867,85 +853,9 @@ When `rcpt` is non-empty, write it verbatim into the new plan file as the siblin
 
 **Persist the original brief in full (the durable coverage-verification copy).** Write the **full** brief text this plan run received into a multi-line `## Original brief` section of the plan file — verbatim, every section the author wrote, NOT a single `Label: value` header line (a brief is multi-line; the `Source brief:` header records only the *form* token). **Close the section with a literal `## End original brief` line emitted immediately after the brief text** — the paired opening/closing delimiters let the downstream consumer read strictly between them, so a brief that contains its own `## ` headings is captured intact and is never truncated at its first internal heading (`skills/create/SKILL.md` Step 3V, rung 2). For a `file:<path>` or `epic #<n>` brief, persist the resolved text `plan` already read to do its work; for an inline brief, the argument text. This mirrors the roadmap manifest's `## Original brief` section (`skills/build-roadmap/SKILL.md` "Manifest format") and is the **durable single-milestone fallback** `create`'s closing brief-coverage verification reads when the in-session brief is unavailable (`skills/create/SKILL.md` Step 3V — the brief-resolution ladder, rung 2; `.project/design-philosophy.md#Layering & boundaries` — the plan file is the build artifact downstream consumers read). On a **roadmap run** this per-milestone plan persists the **brief-slice** the inner routine received; the whole-app brief lives in the manifest's `## Original brief`, which is what `create` reads for a roadmap run. **Never fabricate** — persist what was received; if the brief text genuinely cannot be captured, omit the section rather than inventing one (the downstream verification degrades gracefully on an absent copy).
 
-**Plan-file format.** Write the file in this shape — the **Milestone title (exact)** line is its own labeled field, separate from the goal in the header:
+**Plan-file format.** Write the file in the shape defined by the **Plan-file output template** (`docs/plan-file-contract.md#plan-file-output-template`) — instantiate that scaffold byte-exact (the **Milestone title (exact)** line is its own labeled field, separate from the goal in the header). The template is normative: the rendered plan file matches it exactly, including each optional section's presence condition and every canonical marker it carries.
 
-```markdown
-# Milestone plan — <milestone goal, one line>
-
-Milestone title (exact): <the exact milestone title — carries the resolved semver INSIDE the string; create/update resolve the milestone by THIS string. SURFACED for the user to confirm/override before `create`; on an infer rung it carries the reference version verbatim — adjust the patch/minor/major bump on this line>
-Version provenance: <explicit | declaration | inferred from <tag/milestone> | prompted>
-Self-check: <the Step 6 outcome — one of:
-  PASS — all <N> issues GAPS: none (milestone-driver reviewers)
-  INTERNAL — all <N> issues GAPS: none (internal checklist; milestone-driver reviewers did not resolve)
-  PARKED — <M> issue(s) → needs product input; <K> issue(s) → needs human direction (still-Blocker after 2 retries)
-  SKIPPED (reviewer:false) — 🔴 gate disabled; generated issues were NOT vetted>
-Source brief: <inline | file:<path> | epic #<n>>
-Milestone number (GitHub): <n>   # OPTIONAL sibling header line — carried forward verbatim from a prior plan file if present; omitted on first plan (create writes it post-deploy, skills/create/SKILL.md Step 3 pass (b))
-
-## Original brief
-<The full brief text this plan run received, persisted verbatim and multi-line — every
- section the author wrote, in full. A brief is multi-line, so this is a SECTION, not a
- `Label: value` header line. `create`'s closing brief-coverage verification reads it to
- audit the deploy against the original brief (the durable single-milestone fallback —
- `skills/create/SKILL.md` Step 3V brief-resolution ladder). Mirrors the roadmap manifest's
- `## Original brief` (`skills/build-roadmap/SKILL.md` "Manifest format"). On a roadmap run
- this persists the per-milestone brief-slice; the whole-app brief lives in the manifest.
- The brief is delimited by the paired `## Original brief` … `## End original brief` markers
- (the literal closing line below), so a brief that contains its OWN `## ` headings is
- captured intact — the consumer reads strictly between the markers and is NOT truncated at
- the first internal `## ` heading.>
-## End original brief
-
-## Milestone description (Wave order)
-<the Step 5 Wave-ordered description, verbatim — the §4 template with local slugs>
-
-## Issues
-### #A — <title>   [<ui|logic>, <risk:*>]   [self-check: PASS]
-<the full §4 ISSUE_BODY for #A>
-
-### #F — <title>   [<ui|logic>, <risk:*>]   [self-check: PASS]   [implied — review / trim / augment]
-<the full §4 ISSUE_BODY for #F — a `disposition: implied` candidate (architect clause 8) renders DISTINCTLY, carrying the `[implied — review / trim / augment]` marker (the verbatim words `implied — review / trim / augment` inside the brackets) alongside the [ui|logic, risk:*] / self-check tags; a grounded candidate (#A above) omits the marker and renders exactly as today>
-
-### #B — <title>   [parked — needs product input]
-<marker only; no fabricated body — see the needs-product-input report>
-
-### #C — <title>   [parked — needs human direction (self-check Blocker, non-converging after 2 retries)]
-<marker only; the issue did not clear the self-check gate — see the report>
-
-### #D — <title>   [dropped — depends on parked #B]
-<marker only; a dependent of a parked issue cannot build, so it is not carried (Step 6 §6.6)>
-
-### … (one block per surviving candidate, in Wave order; only PASS / Advisory-only issues carry a full body; a `disposition: implied` candidate additionally carries the `[implied — review / trim / augment]` marker on its heading, as #F above)
-
-## Multi-milestone advisory   <!-- OPTIONAL section — written ONLY on the retained path: the architect raised SCOPE_SPANS_MULTIPLE_MILESTONES (Step 3) AND the front-door did NOT route into build-roadmap (Step 3.6, roadmapRouteTaken false). OMITTED ENTIRELY when the signal is `none` (file byte-for-byte the pre-#61 shape) OR when the front-door took the route (roadmapRouteTaken true — superseded by the confirmed roadmap). Advisory only — does not change what gets deployed; the plan stays a deployable single-milestone plan. -->
-🔴 This brief looks like ~<N> milestones. Deploy the one big milestone below, or split the brief and re-run. Proposed split (carried verbatim from the architect):
-- <proposed milestone 1 name>: #A, #C
-- <proposed milestone 2 name>: #B
-
-## Project-docs grounding
-- <each design call carried forward> — grounded in <.project/<doc>.md#<section> | sibling file:line>
-- Degradations: <e.g. "uiSurfaceGlobs absent → all candidates treated as logic"; "none" otherwise>
-
-## Needs human input
-<pointer: "see .milestone-feeder/needs-product-input-<slug>.md" when productGaps is non-empty OR the self-check parked any issue as needs-human-direction; "none" otherwise>
-
----
-This plan file is the build artifact — run `/milestone-feeder:create` to deploy it to GitHub (it ensures the labels, creates-or-adopts the milestone by the exact title above, opens each surviving issue, rewrites the slug references to real issue numbers, and patches the milestone description with the Wave order). `plan` wrote no GitHub state.
-```
-
-If `productGaps[]` is **non-empty** OR the self-check parked any issue as **needs-human-direction** (§6.5), also write a **"needs product input" report** to `.milestone-feeder/needs-product-input-<slug>.md` (same deterministic slug). The scratch dir already self-ignores by now (the plan-file write above ensured `.milestone-feeder/.gitignore` contains `*`), so this report is git-invisible too. The report carries a **Kind** column so the human can tell a product decision (no conventional default — decide and record it) from a non-converging self-check Blocker (the candidate's design is likely wrong — redirect it):
-
-```markdown
-🔴 Needs human input — <milestone goal, one line>
-
-These items blocked the milestone and were NOT guessed. Resolve each, then re-run plan.
-
-| # | Kind | Item | Why blocked | Blocks |
-|---|---|---|---|---|
-| 1 | product-gap | <the product decision with no conventional default> | <why the project docs / a convention cannot answer it> | <which candidate(s) / the whole scope> |
-| 2 | needs-human-direction | <the self-check Blocker that did not clear in 2 retries> | <the reviewer's `description` / `to_clear`> | <which candidate(s) + any dropped dependents> |
-| … | … | … | … | … |
-```
+If `productGaps[]` is **non-empty** OR the self-check parked any issue as **needs-human-direction** (§6.5), also write a **"needs product input" report** to `.milestone-feeder/needs-product-input-<slug>.md` (same deterministic slug). The scratch dir already self-ignores by now (the plan-file write above ensured `.milestone-feeder/.gitignore` contains `*`), so this report is git-invisible too. The report carries a **Kind** column so the human can tell a product decision (no conventional default — decide and record it) from a non-converging self-check Blocker (the candidate's design is likely wrong — redirect it). Write it in the shape defined by the **Needs-product-input report template** (`docs/plan-file-contract.md#needs-product-input-report-template`) — instantiate that scaffold byte-exact.
 
 The plan file and the report are local scratch. **Nothing is posted to GitHub** — no milestone is created, no issue is opened, no label is applied, no comment is added to any epic. The `create` skill is the only thing that writes GitHub state, reading this plan file.
 


### PR DESCRIPTION
Closes #202.

## What
Behavior-neutral relocate-and-dedupe of plan **Step 7**. The three reference-heavy blocks — the plan-file **field table**, the full plan-file **output template** scaffold, and the **needs-product-input report** template — already live byte-exact in `docs/plan-file-contract.md` (created by #198). Each is removed from Step 7 and replaced with a one-level **normative** pointer (anchor-linked) directing the writer to instantiate the shared scaffold/table byte-exact.

## Why behavior-neutral
- The three removed blocks were verified **byte-identical** to the doc's `#plan-file-field-table`, `#plan-file-output-template`, and `#needs-product-input-report-template` sections before the edit.
- The SKILL.md prose is never itself rendered into the plan file — only the scaffold is instantiated. With the scaffold in the doc instantiated byte-exact, the **resolved plan file is byte-for-byte unchanged**.
- `tests/scenarios/` is **untouched** (byte-identical before/after).

## Retained inline verbatim
Slug derivation incl. the optional `assignedSlug` ADOPT branch; the `.milestone-feeder/.gitignore` self-ignore write; the receipt-line preservation read + its bash/PowerShell twins; the report-write **condition**; and every canonical marker the retained procedure references — `[implied — review / trim / augment]`, the `## Original brief` / `## End original brief` delimiters, the `Milestone number (GitHub):` receipt line, and the implied anti-fixation string `this is a starting set for YOUR app — what's missing?`.

## Scope + verification
- Edits confined to the Step 7 region; only `skills/plan/SKILL.md` changed (3 insertions, 93 deletions).
- Anchors validated against the doc's own table of contents.
- CI gates green: `python3 scripts/validate-plugin-structure.py` (exit 0) and `./scripts/check-vocabulary.sh` (exit 0).
- Depends on #198 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Code Review
- /code-review run: yes — **no findings**. The three removed Step-7 blocks were proven byte-identical to the `docs/plan-file-contract.md` sections before the pointer-swap; retained inline prose + every canonical marker verified present; tests/scenarios untouched. Both CI gates pass.
