### PR TITLE
refactor(create): relocate heavy deploy mechanics to docs/create-deploy-sequence.md (#205)

### DIFF
--- a/docs/create-deploy-sequence.md
+++ b/docs/create-deploy-sequence.md
@@ -1,0 +1,360 @@
+# create deploy sequence — the relocated deploy mechanics
+
+This is the create-scoped reference holding the **full mechanics** of `create`'s heavy deploy steps. The skill `skills/create/SKILL.md` keeps a lean orchestration skeleton — the step names, their fixed order, the gates, and one-level pointers — and `create` reads this reference **on demand** when it needs the mechanics. Each section below was relocated **byte-for-byte** from `skills/create/SKILL.md` (its Step 1R, the Step 3 write-sequence passes a–d, Step 3V, and Step 4), so **nothing here changes what `create` deploys** — the relocation is behavior-neutral. Read each section as the verbatim procedure for the step the skill names; `create`'s own pass (e) (the needs-input report) and its invariants stay in the skill.
+
+- [Step 1R — Resolve the deploy target](#step-1r--resolve-the-deploy-target-a-single-plan-or-a-roadmap-of-n-milestones)
+- [Step 3 — deploy write-sequence (passes a-d)](#step-3--deploy-write-sequence-passes-a-d)
+- [Step 3V — Verify the deploy covers the original brief](#step-3v--verify-the-deploy-covers-the-original-brief-creates-closing-action)
+- [Step 4 — Offer the driver handoff](#step-4--offer-the-driver-handoff-clean-run-only)
+
+### Step 1R — Resolve the deploy target: a single plan, or a roadmap of N milestones
+
+Before resolving a plan file, check whether `plan`'s roadmap flow left a **roadmap manifest** for this brief. Derive `<slug>` **exactly as Step 1 does** (the same deterministic rule, `skills/plan/SKILL.md` Step 7 — the slug-derivation rule), then resolve the manifest at the path `build-roadmap` writes — the cross-milestone build artifact `create` deploys (`skills/build-roadmap/SKILL.md` "Manifest format"; `.project/design-philosophy.md#Layering & boundaries` — the plan file / manifest is the build artifact):
+
+```
+.milestone-feeder/roadmap-<slug>.md
+```
+
+| Resolution | Action |
+|---|---|
+| **Absent** (no manifest) | **Single-plan path — UNCHANGED.** Fall through to **Step 1** below and run **Steps 1 → 4 once, exactly as today**. This is the **N=1** case; the single-plan path sees zero behavior change. Skip the rest of this section. |
+| **Found** (a manifest) | **Multi-milestone roadmap deploy.** Read the manifest and run the **outer loop** below. The manifest is **read, never regenerated** — `create` re-dispatches no agent and re-runs no gate on the found path, exactly as for a plan file (`SPEC.md` §3.1). Do **NOT** also run the single-plan Step 1 resolution for the whole brief: the roadmap replaces it — each of its milestones has its own `plan-<slug>.md`, and there is no whole-brief plan file. |
+
+**The outer loop (manifest found) — loop the per-plan deploy over the manifest's milestones.** The manifest's `## Milestones (in build order)` section lists the milestones, each `### <position>. <milestone name>` with a `Build-order position: <position>` line **and a `Plan file:` path** (the exact plan-file handle the planning fan-out recorded, `skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 3.7.g), in build order. Let **N** be that milestone count. Only the **outer loop** is added — the per-milestone deploy is **Step 3 passes a–e reused unchanged**. **For each milestone, in build order (position 1 → N):**
+
+| Per-milestone step | What runs |
+|---|---|
+| **i. Resolve this milestone's plan file** | **Read the recorded `Plan file:` path from this manifest entry** — the exact `.milestone-feeder/plan-<assignedSlug>.md` the planning fan-out populated (`skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 3.7.g). **Do NOT re-derive a slug from the milestone name** — the plan-file slug is goal-derived with an `-m<index>` collision tiebreaker the manifest name does not encode (`skills/plan/SKILL.md` Step 3.7.d), so a name-derived path would miss. Read that plan file and treat it as Step 1's **Found** row, then deploy it. If the entry's `Plan file:` is **pending/empty**, or the file at that path is **absent** (this milestone never finished planning), STOP the loop and report it as a mid-loop failure (🔴, Partial-failure path below) — do **NOT** re-plan from `create`. |
+| **ii. Read its plan-file contract** | **Step 2**, unchanged. |
+| **iii. Deploy it** | **Step 3 passes a–e**, entirely unchanged — ensure labels (a) / create-or-adopt the milestone by exact title (b) / create-or-reuse each surviving issue by exact title (c) / slug→`#n` rewrite + Wave-description PATCH (d) / route the needs-input report (e). Per-milestone idempotency is the existing **create-or-adopt**, inherited per iteration: never delete a milestone or issue, never duplicate a same-title open issue. |
+| **iv. Record the build-order line** | When pass (d) PATCHes this milestone's description, include the canonical `build order: milestone X of N` line in the PATCHed description, alongside the `## Waves` block (see "The build-order line" below). |
+
+After the loop deploys all N, report each milestone's deploy receipt (`#`) and the recorded build order, then continue to **Step 3V** (verify the deploy covers the whole-app brief — reading between the manifest's paired `## Original brief` … `## End original brief` markers) and **Step 4** (its multi-milestone note).
+
+**The build-order line (the cross-milestone metadata).** Pin **one** canonical literal — `build order: milestone X of N` — where **X** is this milestone's `Build-order position` (1..N) and **N** is the manifest's milestone count. It extends the Wave-order-in-description convention (`SPEC.md` §4): the description already encodes the *intra*-milestone Wave order (`## Waves`); this single line encodes the *cross*-milestone position the driver reads to build the roadmap in sequence. Place it as a standalone line directly under the one-paragraph milestone goal and above the `## Waves` block, so milestone X's PATCHed description reads:
+
+```markdown
+<one-paragraph milestone goal>
+
+build order: milestone X of N
+
+## Waves
+- Wave 1 (parallel): #A, #B, ...
+- ...
+```
+
+**Idempotency is INHERITED from pass (d), not re-implemented.** Pass (d) PATCHes the description with the **REPLACE form** (`gh api --method PATCH .../milestones/<number> -f description=...`, Step 3 pass d) — it replaces the whole description every run. The build-order line rides **inside that one REPLACE payload**, so a re-run over an already-deployed manifest **overwrites** the line in place; the line count never grows (the same overwrite guarantee pass (d) already makes for the Wave order). **No new read-modify-write of the description is added** — only pass (d)'s payload gains the one canonical line. Assemble the augmented description (bash + PowerShell 7+ twins), then PATCH it with pass (d)'s existing REPLACE-form command:
+
+```bash
+# bash — assemble milestone X's description: goal + the ONE canonical build-order line + the
+# slug-rewritten Waves block, then PATCH via pass (d)'s REPLACE form. X = Build-order position; N = count.
+# $goal and $waves are the two halves of the description pass (d) already builds (slugs rewritten to #n).
+desc="$(printf '%s\n\nbuild order: milestone %s of %s\n\n%s\n' "$goal" "$X" "$N" "$waves")"
+gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
+```
+
+```powershell
+# PowerShell 7+ — same assembly + pass (d)'s REPLACE-form PATCH; the ONE canonical line.
+$desc = @"
+$goal
+
+build order: milestone $X of $N
+
+$waves
+"@
+gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
+```
+
+Re-PATCHing on a re-run overwrites the line — idempotent by construction, so the `build order: milestone X of N` count stays exactly one per milestone, never growing.
+
+### Step 3 — deploy write-sequence (passes a-d)
+
+The full mechanics of the deploy write-sequence passes **a, b, c, d** — every `gh` form with its bash + PowerShell 7+ twin, the create-or-adopt resolution table, the deploy-receipt back-write, the slug→`#n` map, and the substring-safe rewrite rule. Pass **e** (the needs-input report) stays in `skills/create/SKILL.md` Step 3. (`create`'s Step 3 skeleton names all five passes in fixed order and points here for a–d.)
+
+This is the v0.2.0 apply write-sequence, moved wholesale into `create` and preserved verbatim — only the **source** of the issue bodies / labels / waves / milestone title / verdict / source-brief reference changes: `create` reads them **from the plan file** (Step 2), it regenerates nothing (`docs/specs/v0.3.0-humanize-the-surface.md` §3: *"What changes is only the source of the issue bodies/labels/waves: read from the plan file, not regenerated"*; §4: the write sequence is *"unchanged"*). All `gh` invocations below are run **by the skill itself**, not by any dispatched agent — the agent-read-only invariant holds. The commands are shell-neutral (`gh` is cross-platform); where a read-modify-write needs a variable, both a bash and a PowerShell 7+ form are given, consistent with the rest of the suite.
+
+#### a. Ensure labels idempotently (BEFORE creating any issue)
+
+Run the four `gh label create … --force` commands **first**, so the labels exist before any `gh issue create --label` references them. `--force` **upserts** (creates if absent, updates color/description if present) — re-runs produce no duplicates. These are the canonical four (the same taxonomy `setup` provisions, `skills/setup/SKILL.md`); run them as a **flat list — no shell loop** — so they are portable across bash and PowerShell 7+:
+
+```
+gh label create "ui"          --color 5319E7 --description "UI-surface issue (design review applies)" --force
+gh label create "logic"       --color 0E8A16 --description "Logic / non-UI issue" --force
+gh label create "risk:light"  --color C2E0C6 --description "Reduced-ceremony build profile (driver override)" --force
+gh label create "risk:heavy"  --color B60205 --description "Full-ceremony build profile (driver override)" --force
+```
+
+These four lines are identical on bash and PowerShell 7+.
+
+#### b. Create-or-adopt the milestone (by EXACT title)
+
+Resolve the milestone by the **exact** `Milestone title (exact)` line from the plan file (Step 2), against all existing milestones. Pass the title via an **environment variable** `t` that `gh`'s embedded jq reads as `env.t` — **NEVER string-interpolate the title into the jq filter literal**. `gh api` has **no `--arg` flag** (that belongs to standalone `jq`), and a title containing a `"` would break an inlined filter and yield a spurious no-match (→ a duplicate milestone). Reading `env.t` from the process environment is the portable, quote-safe approach:
+
+```
+# bash — title read from the environment (quote-safe; no --arg, which gh api does not support)
+t="<milestone-title>" gh api "repos/{owner}/{repo}/milestones?state=all&per_page=100" --paginate \
+  --jq '.[] | select(.title==env.t) | {number, state}'
+```
+
+PowerShell 7+ is the same form — set `$env:t = "<milestone-title>"` first, then run `gh api … --jq '.[] | select(.title==env.t) | {number, state}'` — keep the title in the environment, never inlined into the filter.
+
+| Result | Action |
+|---|---|
+| **No title match** | **Create:** `gh api --method POST "repos/{owner}/{repo}/milestones" -f title="<milestone-title>" -f description="<placeholder>"`. Capture the returned `.number`. The description is a placeholder — it is rewritten with the real Wave order in pass (d), once the slug→`#n` numbers exist. |
+| **Exactly one title match, `state: open`** | **Adopt:** record its `.number`. Re-use it; never delete it or its issues. |
+| **Exactly one title match, `state: closed`** | **Adopt + reopen:** `gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f state=open`, then record its `.number`. **Never delete** the milestone or any of its issues. |
+| **Multiple title matches** (GitHub permits same-title milestones) | **Adopt the FIRST returned**, reopen it if closed, and log a notice — `create: multiple milestones titled "<t>" — adopted first returned (#<n>)`. Never delete the others. |
+
+**Write the deploy receipt (the concluding action of pass b).** As soon as pass (b) has resolved the milestone `.number` — **any** outcome above (created / adopted-open / adopted-reopened / first-of-multiple) — write that number back into the **same plan file Step 1 resolved** (`.milestone-feeder/plan-<slug>.md`, `skills/create/SKILL.md` Step 1) as a single labeled receipt field. This is the stable handle `update` will resolve by after a later title change (`docs/specs/v0.3.1-driver-handoff.md` §4 *"The deploy receipt — a stable handle for rename"*; the plan-file additive-fields row, §6: *"`Milestone number (GitHub):` `<n>` — the deploy receipt … `create` writes it post-deploy"*). The receipt is the create-SIDE back-write only — the `update`-side READ is a separate issue and is **not** part of `create`.
+
+- **Field shape.** Exactly one labeled line, a **sibling to the plan file's existing header lines** (`Milestone title (exact):`, `Self-check:`, `Source brief:` near the top — the format block at `skills/plan/SKILL.md` Step 7 — "Plan-file format"):
+
+  ```
+  Milestone number (GitHub): <n>
+  ```
+
+- **Guard — write ONLY when a real number was resolved.** If pass (b) resolved **no** `.number` (it neither created nor adopted a milestone), write **nothing** — no receipt line, no placeholder. Prior absence of the line is normal: a first deploy has none, and a plan file that never receives a receipt stays valid and deployable (the field is additive; `docs/specs/v0.3.1-driver-handoff.md` §6: *"A v0.3.0 plan file lacking them still parses (the consumers degrade gracefully)"*).
+- **Idempotent read-modify-write.** Read the plan file; if a `Milestone number (GitHub):` line **already exists**, **rewrite its number in place** — exactly one such line, **never** a duplicate; if it is **absent**, **insert** one (as a sibling header line). This is a read-modify-write that **converges to exactly one receipt line carrying the current number**, so it is safe to re-run: a second `create` on an already-adopted milestone rewrites the same line to the same number (no duplicate, no second insert) — unlike pass (d)'s no-op idempotency (where re-applying changes nothing), the receipt actively overwrites, but the line count never grows. (Re-running `create` is safe and produces no duplicates — the same guarantee pass (d) makes for issue bodies, `skills/create/SKILL.md` "Partial-failure path".) Both shells below are idempotent by construction: the presence branch rewrites the existing line in place (exactly one), and the absent branch inserts exactly once.
+
+  ```bash
+  # bash — rewrite the receipt in place if present, else insert it after the header lines.
+  # Uses awk (portable across BSD/macOS and GNU sed/awk); avoids GNU-sed-only `a`,
+  # which exits 1 on BSD/macOS sed. n is the milestone number captured above; plan is
+  # the path Step 1 resolved. On any write error, emit the notice and continue (don't block).
+  plan=".milestone-feeder/plan-<slug>.md"
+  n="<resolved-milestone-number>"
+  notice="create: deployed milestone #$n but could not write the receipt to $plan — re-run to record it"
+  tmp="$(mktemp)" || { echo "$notice"; }
+  if [ -n "$tmp" ]; then
+    if grep -q '^Milestone number (GitHub):' "$plan"; then
+      # present → rewrite the FIRST receipt line in place (exactly one line; never a duplicate)
+      awk -v n="$n" '!done && /^Milestone number \(GitHub\):/ { print "Milestone number (GitHub): " n; done=1; next } { print }' "$plan" > "$tmp" \
+        && mv "$tmp" "$plan" || echo "$notice"
+    elif grep -q '^Source brief:' "$plan"; then
+      # absent, anchor present → insert exactly once after the Source brief header line
+      awk -v n="$n" '{ print } !done && /^Source brief:/ { print "Milestone number (GitHub): " n; done=1 }' "$plan" > "$tmp" \
+        && mv "$tmp" "$plan" || echo "$notice"
+    else
+      # absent AND no anchor (malformed/hand-edited plan) → degrade VISIBLY:
+      # append the receipt at EOF (still exactly one line; the present-branch finds it next run)
+      awk -v n="$n" '{ print } END { print "Milestone number (GitHub): " n }' "$plan" > "$tmp" \
+        && mv "$tmp" "$plan" || echo "$notice"
+    fi
+  fi
+  ```
+
+  ```powershell
+  # PowerShell 7+ — same idempotent rewrite-or-insert; write UTF-8 without a BOM.
+  # On any write error, emit the notice and continue (don't block the deploy).
+  $plan = ".milestone-feeder/plan-<slug>.md"
+  $n    = "<resolved-milestone-number>"
+  $notice = "create: deployed milestone #$n but could not write the receipt to $plan — re-run to record it"
+  try {
+    $lines = Get-Content -LiteralPath $plan
+    if ($lines -match '^Milestone number \(GitHub\):') {
+      # present → rewrite the number in place (exactly one line; never a duplicate)
+      $out = $lines -replace '^Milestone number \(GitHub\):.*', "Milestone number (GitHub): $n"
+    } elseif ($lines -match '^Source brief:') {
+      # absent, anchor present → insert as a sibling after the Source brief header line
+      $out = $lines | ForEach-Object {
+        $_
+        if ($_ -match '^Source brief:') { "Milestone number (GitHub): $n" }
+      }
+    } else {
+      # absent AND no anchor (malformed/hand-edited plan) → degrade VISIBLY:
+      # append the receipt at EOF (still exactly one line; the present branch finds it next run)
+      $out = @($lines) + "Milestone number (GitHub): $n"
+    }
+    Set-Content -LiteralPath $plan -Value $out -Encoding utf8NoBOM -ErrorAction Stop
+  } catch {
+    Write-Output $notice
+  }
+  ```
+
+- **Failure semantics — report, don't block.** A plan-file back-write failure is **REPORTED as a notice but does NOT block** — by this point the GitHub deploy already succeeded (the milestone exists; pass c is about to create the issues), and the plan file is **gitignored per-run scratch** (`docs/specs/v0.3.1-driver-handoff.md` §4: *"The plan file is gitignored per-run scratch, so this back-write is low-stakes"*). The receipt rewrites the **existing** plan file in place, so the scratch dir already self-ignores (`plan` ensured `.milestone-feeder/.gitignore` contains `*` when it first wrote the plan; `skills/plan/SKILL.md` Step 7) — the receipt write adds no new visible file. On a write error, emit a notice — `create: deployed milestone #<n> but could not write the receipt to <plan> — re-run to record it` — and continue to pass (c). Never abort the deploy over the receipt.
+
+#### c. Create each surviving issue; build the slug→`#n` map
+
+Create **only the SURVIVING** issues recorded in the plan file's `## Issues` section — the gate-clean / Advisory-only, **non-parked, non-dropped** issues (Step 2). **Parked and dropped issues recorded in the plan file are NEVER created** (the report still routes the parked ones at pass e; dropped dependents are simply omitted).
+
+On **CREATE** (the milestone had no prior issues), create every surviving issue. On **ADOPT** (the milestone already had issues), first list its existing OPEN issues so a re-run does not duplicate them — match each surviving issue against them **by exact title**:
+
+```
+gh issue list --milestone "<milestone-title>" --state open --json number,title
+```
+
+For each surviving issue, **in Wave order** (the plan file's Wave order):
+
+| On adopt, title match? | Action |
+|---|---|
+| **Yes** — an open issue with the same title already exists | **Reuse** its number — do NOT create a duplicate. Map `slug → #<existing-n>`. Its body is **left as-is** (see body policy below). |
+| **No** (or this is the create path) | **Create:** `gh issue create --title "<title>" --body "<the §4 ISSUE_BODY from the plan file, verbatim>" --milestone "<milestone-title>" --label <ui\|logic> --label <risk:light\|risk:heavy>`. Capture the returned number. Map `slug → #<new-n>`. |
+
+Apply each issue's **labels exactly as recorded in the plan file** (its `ui`/`logic` label and its `risk:*` label — Step 2). Accumulate the full **slug→`#n` map** across every surviving issue (created or reused). The `--body` here still carries the **local slug** references from the plan file; they are rewritten in the second pass (d), once the full map exists.
+
+**Adopted-issue body policy.** Adopted (title-matched) issues are **NOT** body-rewritten — their bodies are preserved as-is. A prior `create` run already resolved their slug→`#n` references, and any manual human edits are respected. **ONLY newly-CREATED issues** receive the slug→`#n` body rewrite in pass (d). This non-clobber behavior is intentional, not a gap.
+
+**Re-run title-match constraint (stated limitation).** De-dup on re-run relies on **stable, exact, OPEN titles** — it matches each surviving issue's title against the milestone's open issues. If a title was edited on GitHub between runs, or a prior issue was **closed** (the list is `--state open`), the match misses and a **new** issue may be created. Titles must stay stable for idempotent re-run — a stated constraint, not a silent bug.
+
+#### d. Second pass — rewrite slug→`#n` (the load-bearing two-pass mechanic)
+
+Two passes are required: issue numbers do not exist until (c) creates them, and `gh issue create --milestone` cannot set the Wave-encoded milestone description. With the **complete** slug→`#n` map from (c):
+
+**Substring-safe rewrite rule (load-bearing).** The architect rolls tags `#A`, `#B`, … `#Z`, then doubles to `#AA`, `#AB`, … past 26 (`agents/architect.md`). A naive string replace of `#A`→`#42` would corrupt `#AB` into `#42B`, and could also hit `#A` inside a word. So **every** slug→`#n` rewrite (issue bodies AND the milestone description) MUST:
+  1. **Replace in descending slug-length order** (longest slug first — **all double-letter tags before any single-letter tag**), so a longer tag is consumed before a shorter prefix of it can match.
+  2. **Match each `#<tag>` only at a token boundary** — the tag must be followed by a non-tag character (whitespace, punctuation, end-of-string), not by another tag-letter, and never be a substring inside a longer tag or a word. `#A` therefore never matches inside `#AB`.
+
+Apply this rule to **every** slug occurrence, wherever it appears (both targets below) — it is the mechanic that keeps the rewrite correct.
+
+1. **Each newly-CREATED issue** (adopted issues are skipped — see the pass-(c) body policy): rewrite **every slug occurrence in the issue's FULL body** to its mapped `#n` — `## Summary`, `## Design` prose, **and** `## Dependencies` (including the reason text after a dependency, e.g. "Depends on #A — references SyncStatusViewModel, introduced by #A" → **both** `#A` rewritten; `agents/issue-author.md`) — using the substring-safe rule, then `gh issue edit <n> --body "<rewritten body>"`. (A created issue whose full body contains no slug reference needs no edit.) Rewriting **only** `## Dependencies` would leave sibling-slug references in Summary/Design/reason text dangling — GitHub would auto-link them to whatever real issue happens to hold that number.
+2. **The milestone description:** rewrite **every slug occurrence** in the plan file's Wave-order description from local slugs to real numbers (same substring-safe rule) and PATCH it onto the milestone (REPLACE form — both shells):
+
+```
+# bash
+gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" \
+  -f description="<Wave description with slugs rewritten to #n>"
+```
+
+```powershell
+# PowerShell 7+ — assign the multi-line description to a variable first, then pass it;
+# avoid the `=@` adjacency so gh's -f reads it as a literal string, not @file.
+# -f/--raw-field always takes the value literally; @file applies only to -F.
+$desc = @"
+<Wave description with slugs rewritten to #n>
+"@
+gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
+```
+
+After (d), every `#n` on GitHub is a real issue number and the milestone description encodes the Wave order in real numbers — exactly the ordering source the driver's `solve-milestone` / `triage` read (`SPEC.md` §4).
+
+### Step 3V — Verify the deploy covers the original brief (create's closing action)
+
+After the deploy loop completes — **single-plan path:** Step 3 passes a–e; **roadmap path (Step 1R):** the outer loop over all N milestones — run this **closing verification** before the optional Step-4 handoff. It is **always-on** (every `create`, single-milestone included) — **not** gated like the Step-4 handoff — and **best-effort / non-blocking**: it reads the live deployed state back, audits it against the **original** brief, and surfaces a coverage punch-list, but it **never** blocks `create`'s completion, the Step-4 handoff, or any merge, and **never** auto-fixes, edits, reopens, or comments-to-fix any deployed issue or milestone (`.project/design-philosophy.md#One-way doors` — surfaced for the human, never auto-applied; `#Error & failure philosophy` — degrade gracefully, never abort). **Announce the step, and at the end its outcome, flatly.**
+
+**Skip conditions (a non-blocking notice, NOT an error).** Before resolving the brief, skip the whole step — print the stated notice and continue to Step 4 — when either holds:
+
+| Condition | Notice |
+|---|---|
+| **Nothing was deployed to read back** — the deploy created no surviving issue (all candidates parked / dropped) | `coverage not verified — nothing was deployed to read back` |
+| **The verifier agent does not resolve** — `milestone-feeder:brief-coverage-verifier` (#156) is not available in this session (detect by the **same optional soft-dependency convention Step 4 Gate 2 uses**: attempt the dispatch; "does not resolve" = absent) | `coverage not verified — brief-coverage-verifier not installed` |
+
+**1. Resolve the ORIGINAL brief — the resolution ladder (first-match-wins).** The audit is against the **original** brief, never the per-milestone plan slices:
+
+| Rung | Source |
+|---|---|
+| **1. In-session** | The original brief `create` already holds — the `create` argument (resolved to text if it is a `file:<path>` / `epic #<n>` reference `create` can still read). |
+| **2. Persisted durable copy** | The `## Original brief` … `## End original brief` delimited section of the persisted artifact: the **roadmap manifest** (`.milestone-feeder/roadmap-<slug>.md`, `skills/build-roadmap/SKILL.md` "Manifest format") on a **roadmap run**; the **plan file** (`.milestone-feeder/plan-<slug>.md` — the `## Original brief` section `plan` persists, `skills/plan/SKILL.md` Step 7) on a **single-milestone run**. Extract the lines **strictly between** the paired markers (the extractor below) so a brief containing its own `## ` headings is read intact, not truncated at its first internal `## `. |
+| **3. Fallback** | Neither resolved (e.g. a `file:<path>` brief that no longer resolves and no persisted copy exists) → emit the non-blocking notice `original brief unavailable — coverage not verified`, **never fabricate a brief**, and let `create` complete. |
+
+**Extract the rung-2 copy between the paired delimiters.** The persisted `## Original brief` section is bounded by a paired end-marker: both producers emit a literal `## End original brief` line immediately after the brief text (`skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 7). Capture the lines **strictly between** `## Original brief` and the first following `## End original brief` — both delimiter lines excluded — so a brief that contains its own `## ` headings is read **intact**, never truncated at its first internal `## `. **Graceful fallback:** if the opening `## Original brief` is present but no closing `## End original brief` exists (e.g. an older scratch artifact written before the paired-delimiter convention), degrade to the prior naive behavior — read from `## Original brief` to the next top-level `## ` heading or EOF — yielding a usable, non-empty result rather than nothing. (This prior read may truncate a brief that has its own internal `## ` headings — the very reason the paired delimiter is preferred — but it never returns empty for a non-empty brief.) Step 3V already degrades gracefully on an absent copy, so it degrades gracefully on a delimiter-less one too. Extract with the artifact path in `$art` (both shells):
+
+```bash
+# bash — resolve the persisted original brief from the artifact at "$art".
+art=".milestone-feeder/<roadmap|plan>-<slug>.md"
+if grep -qxF '## End original brief' "$art"; then
+  # Primary: the lines STRICTLY BETWEEN `## Original brief` and the first following
+  # `## End original brief` (both delimiter lines excluded) — robust to a brief that
+  # contains its OWN `## ` headings; it is NOT truncated at the first internal `## `.
+  brief="$(awk '
+    $0 == "## End original brief" { inblk=0 }
+    inblk                         { print }
+    $0 == "## Original brief"     { inblk=1 }
+  ' "$art")"
+else
+  # Graceful fallback (no closing delimiter): read from `## Original brief` to the next
+  # top-level `## ` heading or EOF — the prior behavior. A usable result, never empty.
+  brief="$(awk '
+    inblk && /^## /           { inblk=0 }
+    inblk                     { print }
+    $0 == "## Original brief" { inblk=1 }
+  ' "$art")"
+fi
+```
+
+```powershell
+# PowerShell 7+ — same resolution from the artifact at $art.
+$art = ".milestone-feeder/<roadmap|plan>-<slug>.md"
+$lines = @(Get-Content -LiteralPath $art -ErrorAction SilentlyContinue)
+$start = [array]::IndexOf($lines, '## Original brief')
+$brief = ''
+if ($start -ge 0) {
+  $end = [array]::IndexOf($lines, '## End original brief', $start + 1)
+  if ($end -ge 0) {
+    # Primary: the lines STRICTLY BETWEEN the paired markers (both excluded) —
+    # robust to a brief containing its own `## ` headings.
+    if ($end -gt $start + 1) { $brief = ($lines[($start + 1)..($end - 1)] -join "`n") }
+  } else {
+    # Graceful fallback (no closing delimiter): to the next top-level `## ` heading or
+    # EOF — the prior behavior. A usable result, never empty.
+    for ($k = $start + 1; $k -lt $lines.Count -and $lines[$k] -notmatch '^## '; $k++) {
+      $brief += $lines[$k] + "`n"
+    }
+  }
+}
+```
+
+**2. Read back every deployed target — the #158→#156 input contract (`create` does the reads, #156 does none).** `create` performs the live-GitHub read-back of **every** deployed target via the **same cross-platform `gh` surface it already uses** (the milestone read of Step 3 pass b; the issue handles from pass c/d) — for **each** created milestone its title + description, and for **each** created issue its title + body. The milestone number(s) and issue numbers are already in hand from the deploy (pass b's resolved `.number`, pass c/d's slug→`#n` map; on a roadmap run, each milestone's own deploy). For **each** target record a per-target **STATUS** — the content, **or** a `read-error: <reason>` marker if its read fails — so #156 populates `READ_ERRORS` **purely from these markers** and runs **no** `gh` read of its own (`agents/brief-coverage-verifier.md` — it runs NO `gh` reads, taking provided read-back content; `.project/design-philosophy.md#Layering & boundaries` — skills do the GitHub ops, the read-only agent audits provided text). Read each target (both shells; on a non-zero `gh` exit, record the marker instead of content):
+
+```bash
+# bash — read back milestone <number> (title + description); on a non-zero gh exit, record the marker.
+m="$(gh api "repos/{owner}/{repo}/milestones/<number>" --jq '{title, description}')" \
+  || m="read-error: milestone <number> could not be read back"
+# bash — read back issue #<n> (title + body); on a non-zero gh exit, record the marker.
+i="$(gh issue view <n> --json title,body)" \
+  || i="read-error: issue #<n> could not be read back"
+```
+
+```powershell
+# PowerShell 7+ — same read-backs; on a non-zero gh exit, record the marker instead of content.
+$m = gh api "repos/{owner}/{repo}/milestones/<number>" --jq '{title, description}'
+if ($LASTEXITCODE -ne 0) { $m = "read-error: milestone <number> could not be read back" }
+$i = gh issue view <n> --json title,body
+if ($LASTEXITCODE -ne 0) { $i = "read-error: issue #<n> could not be read back" }
+```
+
+On a **roadmap run**, read back **all N** milestones and **all** their issues into one payload — the audit is against the manifest's whole-app brief (rung 2), so the read-back must cover every milestone the roadmap deployed.
+
+**3. Dispatch the brief-coverage verifier (#156), once.** Dispatch `milestone-feeder:brief-coverage-verifier`, passing (1) the **resolved original brief** (step 1) and (2) the **per-target read-back payload** (content-or-marker per milestone/issue, step 2). It audits every readable target against the original brief, populates `READ_ERRORS` from the markers alone, and returns its structured `COVERAGE_VERDICT / UNCOVERED / DUPLICATED / DISTORTED / READ_ERRORS` block (`agents/brief-coverage-verifier.md`). It opens, edits, and comments on nothing — `create` routes its output.
+
+**4. Surface / route the punch-list — exactly like the needs-input report (pass e).** Route by the recorded **Source brief reference** — the **manifest's** on a roadmap run, the **plan file's** on a single-milestone run (the same artifact the brief was resolved from at rung 2):
+
+| `COVERAGE_VERDICT` | Action |
+|---|---|
+| **`clean`** (UNCOVERED / DUPLICATED / DISTORTED / READ_ERRORS all the literal `none`) | Report `coverage verified — nothing missed`. **Route nothing.** |
+| **`punch-list`**, brief form **`epic #<n>`** | Post the block as a comment on the epic: `gh issue comment <epicIssueNumber> --body "<punch-list>"` (mirrors pass e's epic branch). |
+| **`punch-list`**, brief form **file / inline** | Write the block to the local git-invisible file `.milestone-feeder/coverage-<slug>.md` and **print a notice** that the punch-list is local (no epic to comment on) — mirrors pass e's file/inline branch. Ensure `.milestone-feeder/.gitignore` contains a single `*` first (it already does — `plan` / pass e ensured it). |
+
+The punch-list is **advisory** — `create` surfaces it for the human and **changes nothing** on GitHub (no issue opened, edited, closed, reopened, or auto-fixed; `.project/design-philosophy.md#One-way doors`).
+
+**Failure stays non-blocking.** If the verifier dispatch errors or returns no parseable block, emit a non-blocking notice (`coverage not verified — verifier did not return a usable result`) and continue — never abort, never block Step 4 (`.project/design-philosophy.md#Error & failure philosophy`). The whole step is read-only on the deployed state.
+
+### Step 4 — Offer the driver handoff (clean-run only)
+
+After the deploy completes (Step 3), `create` can hand the freshly-built milestone straight to `milestone-driver` to start building — instead of ending the run and leaving the user to invoke the driver themselves. This is **build-kickoff only**; it invokes `/milestone-driver:solve-milestone "<milestone-title>"`, which builds to the integration branch and **never** crosses the release boundary (Gate 3 below). The behavior is governed by the `autoHandoff` key (Step 0) and three gates that must **ALL** hold to offer the handoff. (Resolved design: issue #148, 2nd comment — Ken, 2026-06-24.)
+
+**Gate 1 — clean run only (no gaps/parks AND the self-check actually ran).** Offer the handoff **only** when **BOTH** conditions hold:
+
+  1. **No gaps/parks** — the plan file's `## Needs human input` pointer is **"none"** (the exact same signal pass (e) reads, `skills/create/SKILL.md` pass e, line ~232, to decide whether to route a report): no product gap AND nothing parked/dropped.
+  2. **The self-check actually ran** — the plan file's `Self-check:` verdict (already read at Step 2; the plan-file contract row) is a **real PASS or INTERNAL** verdict, **NOT** `SKIPPED(reviewer:false)`. A `reviewer: false` run **skips the self-check gate entirely** — its issues are explicitly **NOT vetted** against the driver's entry gate (`plan` records `SKIPPED(reviewer:false)` with a visible 🔴 warning; `skills/plan/SKILL.md` §6.1 — the `reviewer: false` skip-the-gate row, `docs/architecture.md` reviewer-backends table). Such a run can have no product gaps and nothing parked → pointer "none" → it would otherwise read as "clean" while harboring exactly the **unsurfaced** gaps the gate exists to catch. So a `SKIPPED(reviewer:false)` verdict is a **Gate 1 fail**.
+
+If **either** condition is not met — any candidate was parked / flagged / blocked (the pointer is NOT "none"), **OR** the self-check was skipped (`SKIPPED(reviewer:false)`) — **do NOT offer the handoff**; the existing gap-surfacing / reviewer-skipped behavior stands unchanged (pass e routes the gaps as today; the 🔴 reviewer-skipped warning already stands), and `create` ends as it does today. Handing a milestone with known gaps — or with issues that were never vetted — to an unattended build loop would build past the very gaps the feeder exists to surface; the clean-run gate (no gaps/parks AND the self-check ran) is what keeps the human in the loop.
+
+**Gate 2 — driver installed (else silently skip).** Detect whether `milestone-driver` is available in this session using the **same convention the feeder already uses** for the optional driver soft-dependency: attempt the invocation and treat "does not resolve (no such skill / agent in the session — `milestone-driver` not installed)" as **absent** (`skills/plan/SKILL.md` §6.1 — the runtime degrade-to-internal trigger: a dispatch that does not resolve = the agent is not installed; `docs/consumer-setup.md:17-20` — the optional `milestone-driver` soft-dependency **degrades silently** when absent). For the handoff, the cleanest detection is: **does `/milestone-driver:solve-milestone` resolve in this session?** If it does **NOT** resolve, **silently skip** this step — **no prompt, no error, no notice** — exactly as the optional soft-dependency degrades silently elsewhere. The handoff is a convenience on top of a clean deploy; its absence is not a failure.
+
+**Gate 3 — never crosses the release boundary.** The handoff invokes `/milestone-driver:solve-milestone "<milestone-title>"`, which **only merges to the integration branch** (`develop`) and never to the protected branch (`main`). Release (`integrationBranch` → `protectedBranch`), closing the GitHub milestone object, and deploy stay **manual and human-only** — that boundary is what makes unattended operation safe (`milestone-driver/skills/solve-milestone/SKILL.md` — the "Bounded blast radius" note: "merges only to `integrationBranch`, never to `protectedBranch`. Release … and deploy stay manual and human-only"). `create`'s handoff is **build-kickoff only**: it does not auto-merge to a protected branch, does not remove the release gate, and `develop → main` stays a manual human call. `solve-milestone` already enforces this; the handoff simply invokes it.
+
+**Behavior by `autoHandoff` (Step 0):**
+
+| `autoHandoff` | When gates 1 + 2 hold | When gate 1 OR 2 fails |
+|---|---|---|
+| `"off"` | **Never offer**, no prompt — skip this step (today's no-handoff behavior). | Skip this step (no-op either way). |
+| `"prompt"` (**default**) | **Ask:** *"milestone-driver is installed — start building this milestone now, or review it first?"* → **yes** invokes `/milestone-driver:solve-milestone "<milestone-title>"`; **no** stops (today's behavior). | **Do not offer** — Gate 1 fail (gaps/parks present, **OR** `SKIPPED(reviewer:false)` — the issues were never vetted): surface the gaps as today (pass e); the 🔴 reviewer-skipped warning already stands. Gate 2 fail: silently skip (no prompt, no error). |
+| `"auto"` | **Invoke immediately**, no prompt: `/milestone-driver:solve-milestone "<milestone-title>"`. Print a one-line notice for legibility — `create: clean run — handing "<milestone-title>" to milestone-driver to start building (autoHandoff: auto)`. (Driver-side precondition: see the numeric-title caveat below.) | **Do not invoke** — Gate 1 fail (gaps/parks present, **OR** `SKIPPED(reviewer:false)` — the issues were never vetted, so auto-firing would build past un-vetted design): surface the gaps as today (pass e); the 🔴 reviewer-skipped warning already stands. Gate 2 fail: silently skip. |
+
+**Numeric-title caveat (`"auto"` defers to the driver's own preconditions).** `autoHandoff: "auto"` kicks off the driver with no prompt, but it does **not** override the driver's own entry preconditions. If the deployed milestone title is **purely numeric**, `/milestone-driver:solve-milestone` **halts and prompts the human for a rename** regardless of `autoHandoff: "auto"` — it interprets a bare number as single-issue mode and refuses to drive a numeric-titled milestone unattended (`milestone-driver/skills/solve-milestone/SKILL.md` — the numeric-title precondition: "if it is purely numeric, halt immediately and prompt the human … do not proceed to Phase 0"). So auto mode's "no question asked" contract ends at the driver boundary: auto kicks off the driver, but the driver enforces a non-numeric-title precondition for unattended operation. This is **narrow** — a feeder-deployed milestone normally carries the user-owned semver in its title (non-numeric), so the caveat rarely bites; no special handling is added here, the doc is simply honest that auto defers to the driver's preconditions.
+
+**The exact milestone title.** The invocation passes the **exact** `Milestone title (exact)` line from the plan file — the same identity string `create` deployed at pass (b) (Step 2; the plan-file `Milestone title (exact)` field). Never a re-derived or goal-derived name — the title carries the user-owned semver and is the handle the driver resolves the milestone by. Pass it verbatim to `solve-milestone "<milestone-title>"`.
+
+**This is a skill invocation, not a shell command.** `/milestone-driver:solve-milestone` is invoked as a Claude Code skill (the same way `create` runs `plan` first on the absent path) — there is no bash/pwsh form to ship for the invocation itself. The `autoHandoff` value is already in hand from Step 0; this step needs no additional config read.
+
+**Multi-milestone roadmap note (Step 1R).** When a **roadmap manifest** drove the deploy (Step 1R, multi-milestone path), this single-plan handoff is **not** auto-fired across the roadmap. `create`'s roadmap responsibility ends at deploying all N milestones and recording each one's `build order: milestone X of N` line — which is exactly the cross-milestone order the driver reads. A roadmap deploy therefore completes by reporting the N deploy receipts and the recorded build order; starting the build stays a human call. The single-plan handoff above (Gates 1–3, `autoHandoff`) is **unchanged** for the N=1 / no-manifest path.

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -35,63 +35,9 @@ Read `.milestone-config/feeder.json`. **Absent → invoke `milestone-feeder:setu
 
 ### Step 1R — Resolve the deploy target: a single plan, or a roadmap of N milestones
 
-Before resolving a plan file, check whether `plan`'s roadmap flow left a **roadmap manifest** for this brief. Derive `<slug>` **exactly as Step 1 does** (the same deterministic rule, `skills/plan/SKILL.md` Step 7 — the slug-derivation rule), then resolve the manifest at the path `build-roadmap` writes — the cross-milestone build artifact `create` deploys (`skills/build-roadmap/SKILL.md` "Manifest format"; `.project/design-philosophy.md#Layering & boundaries` — the plan file / manifest is the build artifact):
+Check for a **roadmap manifest** at `.milestone-feeder/roadmap-<slug>.md` (slug derived as in Step 1). **Absent → single-plan path, UNCHANGED:** fall through to Step 1 and run Steps 1 → 4 once (the **N=1** case). **Found → roadmap deploy:** read the manifest (**never** regenerate it) and loop the per-plan deploy (Step 2 → Step 3 passes a–e) over its milestones in build order, resolving each by its recorded `Plan file:` path and recording its `build order: milestone X of N` line **inside** pass (d)'s description PATCH (idempotent), then run Step 3V over the whole-app brief. A mid-loop failure stops, deletes nothing, and re-runs resume.
 
-```
-.milestone-feeder/roadmap-<slug>.md
-```
-
-| Resolution | Action |
-|---|---|
-| **Absent** (no manifest) | **Single-plan path — UNCHANGED.** Fall through to **Step 1** below and run **Steps 1 → 4 once, exactly as today**. This is the **N=1** case; the single-plan path sees zero behavior change. Skip the rest of this section. |
-| **Found** (a manifest) | **Multi-milestone roadmap deploy.** Read the manifest and run the **outer loop** below. The manifest is **read, never regenerated** — `create` re-dispatches no agent and re-runs no gate on the found path, exactly as for a plan file (`SPEC.md` §3.1). Do **NOT** also run the single-plan Step 1 resolution for the whole brief: the roadmap replaces it — each of its milestones has its own `plan-<slug>.md`, and there is no whole-brief plan file. |
-
-**The outer loop (manifest found) — loop the per-plan deploy over the manifest's milestones.** The manifest's `## Milestones (in build order)` section lists the milestones, each `### <position>. <milestone name>` with a `Build-order position: <position>` line **and a `Plan file:` path** (the exact plan-file handle the planning fan-out recorded, `skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 3.7.g), in build order. Let **N** be that milestone count. Only the **outer loop** is added — the per-milestone deploy is **Step 3 passes a–e reused unchanged**. **For each milestone, in build order (position 1 → N):**
-
-| Per-milestone step | What runs |
-|---|---|
-| **i. Resolve this milestone's plan file** | **Read the recorded `Plan file:` path from this manifest entry** — the exact `.milestone-feeder/plan-<assignedSlug>.md` the planning fan-out populated (`skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 3.7.g). **Do NOT re-derive a slug from the milestone name** — the plan-file slug is goal-derived with an `-m<index>` collision tiebreaker the manifest name does not encode (`skills/plan/SKILL.md` Step 3.7.d), so a name-derived path would miss. Read that plan file and treat it as Step 1's **Found** row, then deploy it. If the entry's `Plan file:` is **pending/empty**, or the file at that path is **absent** (this milestone never finished planning), STOP the loop and report it as a mid-loop failure (🔴, Partial-failure path below) — do **NOT** re-plan from `create`. |
-| **ii. Read its plan-file contract** | **Step 2**, unchanged. |
-| **iii. Deploy it** | **Step 3 passes a–e**, entirely unchanged — ensure labels (a) / create-or-adopt the milestone by exact title (b) / create-or-reuse each surviving issue by exact title (c) / slug→`#n` rewrite + Wave-description PATCH (d) / route the needs-input report (e). Per-milestone idempotency is the existing **create-or-adopt**, inherited per iteration: never delete a milestone or issue, never duplicate a same-title open issue. |
-| **iv. Record the build-order line** | When pass (d) PATCHes this milestone's description, include the canonical `build order: milestone X of N` line in the PATCHed description, alongside the `## Waves` block (see "The build-order line" below). |
-
-After the loop deploys all N, report each milestone's deploy receipt (`#`) and the recorded build order, then continue to **Step 3V** (verify the deploy covers the whole-app brief — reading between the manifest's paired `## Original brief` … `## End original brief` markers) and **Step 4** (its multi-milestone note).
-
-**The build-order line (the cross-milestone metadata).** Pin **one** canonical literal — `build order: milestone X of N` — where **X** is this milestone's `Build-order position` (1..N) and **N** is the manifest's milestone count. It extends the Wave-order-in-description convention (`SPEC.md` §4): the description already encodes the *intra*-milestone Wave order (`## Waves`); this single line encodes the *cross*-milestone position the driver reads to build the roadmap in sequence. Place it as a standalone line directly under the one-paragraph milestone goal and above the `## Waves` block, so milestone X's PATCHed description reads:
-
-```markdown
-<one-paragraph milestone goal>
-
-build order: milestone X of N
-
-## Waves
-- Wave 1 (parallel): #A, #B, ...
-- ...
-```
-
-**Idempotency is INHERITED from pass (d), not re-implemented.** Pass (d) PATCHes the description with the **REPLACE form** (`gh api --method PATCH .../milestones/<number> -f description=...`, Step 3 pass d) — it replaces the whole description every run. The build-order line rides **inside that one REPLACE payload**, so a re-run over an already-deployed manifest **overwrites** the line in place; the line count never grows (the same overwrite guarantee pass (d) already makes for the Wave order). **No new read-modify-write of the description is added** — only pass (d)'s payload gains the one canonical line. Assemble the augmented description (bash + PowerShell 7+ twins), then PATCH it with pass (d)'s existing REPLACE-form command:
-
-```bash
-# bash — assemble milestone X's description: goal + the ONE canonical build-order line + the
-# slug-rewritten Waves block, then PATCH via pass (d)'s REPLACE form. X = Build-order position; N = count.
-# $goal and $waves are the two halves of the description pass (d) already builds (slugs rewritten to #n).
-desc="$(printf '%s\n\nbuild order: milestone %s of %s\n\n%s\n' "$goal" "$X" "$N" "$waves")"
-gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
-```
-
-```powershell
-# PowerShell 7+ — same assembly + pass (d)'s REPLACE-form PATCH; the ONE canonical line.
-$desc = @"
-$goal
-
-build order: milestone $X of $N
-
-$waves
-"@
-gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
-```
-
-Re-PATCHing on a re-run overwrites the line — idempotent by construction, so the `build order: milestone X of N` count stays exactly one per milestone, never growing.
+Full mechanics — the resolution table, the outer-loop per-milestone steps, and the build-order-line assembly twins — live in **`docs/create-deploy-sequence.md` → "Step 1R — Resolve the deploy target"**.
 
 ### Step 1 — Resolve the plan file for the brief
 
@@ -116,181 +62,35 @@ This is the only staleness behavior; there is no flag and no prompt — a matchi
 
 ### Step 2 — Read the plan-file contract
 
-The plan file is the **load-bearing build artifact** — `create` reads it and writes GitHub from it, regenerating nothing (`docs/specs/v0.3.0-humanize-the-surface.md` §3). Parse every field below by name (the format is `skills/plan/SKILL.md` Step 7; the field requirements are its plan-file-contract table and `docs/specs/v0.3.0-humanize-the-surface.md` §3):
+The plan file is the **load-bearing build artifact** — `create` reads it and writes GitHub from it, regenerating nothing (`docs/specs/v0.3.0-humanize-the-surface.md` §3). Parse every field below by name (the format is `skills/plan/SKILL.md` Step 7; the field requirements are the `docs/plan-file-contract.md` Plan-file field table and `docs/specs/v0.3.0-humanize-the-surface.md` §3):
 
 | Plan-file field | What `create` reads it for |
 |---|---|
 | **Milestone title (exact)** | The load-bearing identity field — `create` resolves the milestone by THIS exact string (pass b). Distinct from the one-line goal (descriptive only). |
 | **Milestone description (Wave order)** | The Step-5 build-order description, verbatim, with **local slugs** (`#A`/`#B`). `create` rewrites the slugs to real `#n` and PATCHes it onto the milestone (pass d). |
 | **Per surviving issue** — slug, title, the FULL §4 `ISSUE_BODY` verbatim, labels (`ui`\|`logic` + `risk:*`), surface/risk | The issues to create — read verbatim, **no regeneration** (pass c). Only the **surviving** (gate-clean / Advisory-only) issues in the plan file's `## Issues` section are created. |
-| **Parked issues** — read from the **bracketed marker on the `### #X — <title>` heading** (`[parked — needs product input]` or `[parked — needs human direction …]`, `skills/plan/SKILL.md` Step 7 format), not a discrete `kind:` field | Marked in the plan file, **NEVER created**. Routed to the needs-input report (pass e). |
-| **Dropped issues** — read from the **bracketed marker on the `### #X — <title>` heading** (`[dropped — depends on parked #X]`, `skills/plan/SKILL.md` Step 7 format) | Marked in the plan file, **NEVER created** (a dependent of a parked issue can't build). |
-| **Self-check verdict** — the plan file's `Self-check:` line (the literal label `plan` writes, `skills/plan/SKILL.md` Step 7) | `create` reports its recorded token (PASS / INTERNAL / PARKED / SKIPPED(reviewer:false)) and **trusts it — no re-vet** (`docs/specs/v0.3.0-humanize-the-surface.md` §4). |
+| **Parked issues** — read from the **bracketed marker on the `### #X — <title>` heading** (`[parked — needs product input]` or `[parked — needs human direction …]`, `docs/plan-file-contract.md` Plan-file output template), not a discrete `kind:` field | Marked in the plan file, **NEVER created**. Routed to the needs-input report (pass e). |
+| **Dropped issues** — read from the **bracketed marker on the `### #X — <title>` heading** (`[dropped — depends on parked #X]`, `docs/plan-file-contract.md` Plan-file output template) | Marked in the plan file, **NEVER created** (a dependent of a parked issue can't build). |
+| **Self-check verdict** — the plan file's `Self-check:` line (the literal label `plan` writes, `docs/plan-file-contract.md` Plan-file field table) | `create` reports its recorded token (PASS / INTERNAL / PARKED / SKIPPED(reviewer:false)) and **trusts it — no re-vet** (`docs/specs/v0.3.0-humanize-the-surface.md` §4). |
 | **Source brief reference** — `inline` \| `file:<path>` \| `epic #<n>` | Drives the report routing (pass e). An `epic #<n>` reference is the `epicIssueNumber` for the epic-comment branch. |
 
 `create` does **not** re-derive any of these — it does not re-dispatch the architect for the candidates, the issue-author for the bodies/labels, or the reviewer for the verdict. It reads the recorded values and deploys them.
 
 ### Step 3 — Deploy (the write sequence, in this fixed order)
 
-This is the v0.2.0 apply write-sequence, moved wholesale into `create` and preserved verbatim — only the **source** of the issue bodies / labels / waves / milestone title / verdict / source-brief reference changes: `create` reads them **from the plan file** (Step 2), it regenerates nothing (`docs/specs/v0.3.0-humanize-the-surface.md` §3: *"What changes is only the source of the issue bodies/labels/waves: read from the plan file, not regenerated"*; §4: the write sequence is *"unchanged"*). All `gh` invocations below are run **by the skill itself**, not by any dispatched agent — the agent-read-only invariant holds. The commands are shell-neutral (`gh` is cross-platform); where a read-modify-write needs a variable, both a bash and a PowerShell 7+ form are given, consistent with the rest of the suite.
+Deploy the plan file's recorded issue set to GitHub in this **fixed pass order** — every `gh` write performed **by the skill itself**, never a dispatched agent (the v0.2.0 apply write-sequence, preserved verbatim; only the *source* of the bodies / labels / waves / title / verdict changed — `create` reads them from the plan file, regenerating nothing; `docs/specs/v0.3.0-humanize-the-surface.md` §3, §4). Full mechanics for passes **a–d** — each `gh` form with its bash + PowerShell 7+ twin, the create-or-adopt table, the deploy-receipt back-write, the slug→`#n` map, and the substring-safe rewrite rule — live in **`docs/create-deploy-sequence.md` → "Step 3 — deploy write-sequence (passes a-d)"**:
 
-#### a. Ensure labels idempotently (BEFORE creating any issue)
-
-Run the four `gh label create … --force` commands **first**, so the labels exist before any `gh issue create --label` references them. `--force` **upserts** (creates if absent, updates color/description if present) — re-runs produce no duplicates. These are the canonical four (the same taxonomy `setup` provisions, `skills/setup/SKILL.md`); run them as a **flat list — no shell loop** — so they are portable across bash and PowerShell 7+:
-
-```
-gh label create "ui"          --color 5319E7 --description "UI-surface issue (design review applies)" --force
-gh label create "logic"       --color 0E8A16 --description "Logic / non-UI issue" --force
-gh label create "risk:light"  --color C2E0C6 --description "Reduced-ceremony build profile (driver override)" --force
-gh label create "risk:heavy"  --color B60205 --description "Full-ceremony build profile (driver override)" --force
-```
-
-These four lines are identical on bash and PowerShell 7+.
-
-#### b. Create-or-adopt the milestone (by EXACT title)
-
-Resolve the milestone by the **exact** `Milestone title (exact)` line from the plan file (Step 2), against all existing milestones. Pass the title via an **environment variable** `t` that `gh`'s embedded jq reads as `env.t` — **NEVER string-interpolate the title into the jq filter literal**. `gh api` has **no `--arg` flag** (that belongs to standalone `jq`), and a title containing a `"` would break an inlined filter and yield a spurious no-match (→ a duplicate milestone). Reading `env.t` from the process environment is the portable, quote-safe approach:
-
-```
-# bash — title read from the environment (quote-safe; no --arg, which gh api does not support)
-t="<milestone-title>" gh api "repos/{owner}/{repo}/milestones?state=all&per_page=100" --paginate \
-  --jq '.[] | select(.title==env.t) | {number, state}'
-```
-
-PowerShell 7+ is the same form — set `$env:t = "<milestone-title>"` first, then run `gh api … --jq '.[] | select(.title==env.t) | {number, state}'` — keep the title in the environment, never inlined into the filter.
-
-| Result | Action |
+| Pass | What it does |
 |---|---|
-| **No title match** | **Create:** `gh api --method POST "repos/{owner}/{repo}/milestones" -f title="<milestone-title>" -f description="<placeholder>"`. Capture the returned `.number`. The description is a placeholder — it is rewritten with the real Wave order in pass (d), once the slug→`#n` numbers exist. |
-| **Exactly one title match, `state: open`** | **Adopt:** record its `.number`. Re-use it; never delete it or its issues. |
-| **Exactly one title match, `state: closed`** | **Adopt + reopen:** `gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f state=open`, then record its `.number`. **Never delete** the milestone or any of its issues. |
-| **Multiple title matches** (GitHub permits same-title milestones) | **Adopt the FIRST returned**, reopen it if closed, and log a notice — `create: multiple milestones titled "<t>" — adopted first returned (#<n>)`. Never delete the others. |
-
-**Write the deploy receipt (the concluding action of pass b).** As soon as pass (b) has resolved the milestone `.number` — **any** outcome above (created / adopted-open / adopted-reopened / first-of-multiple) — write that number back into the **same plan file Step 1 resolved** (`.milestone-feeder/plan-<slug>.md`, `skills/create/SKILL.md` Step 1) as a single labeled receipt field. This is the stable handle `update` will resolve by after a later title change (`docs/specs/v0.3.1-driver-handoff.md` §4 *"The deploy receipt — a stable handle for rename"*; the plan-file additive-fields row, §6: *"`Milestone number (GitHub):` `<n>` — the deploy receipt … `create` writes it post-deploy"*). The receipt is the create-SIDE back-write only — the `update`-side READ is a separate issue and is **not** part of `create`.
-
-- **Field shape.** Exactly one labeled line, a **sibling to the plan file's existing header lines** (`Milestone title (exact):`, `Self-check:`, `Source brief:` near the top — the format block at `skills/plan/SKILL.md` Step 7 — "Plan-file format"):
-
-  ```
-  Milestone number (GitHub): <n>
-  ```
-
-- **Guard — write ONLY when a real number was resolved.** If pass (b) resolved **no** `.number` (it neither created nor adopted a milestone), write **nothing** — no receipt line, no placeholder. Prior absence of the line is normal: a first deploy has none, and a plan file that never receives a receipt stays valid and deployable (the field is additive; `docs/specs/v0.3.1-driver-handoff.md` §6: *"A v0.3.0 plan file lacking them still parses (the consumers degrade gracefully)"*).
-- **Idempotent read-modify-write.** Read the plan file; if a `Milestone number (GitHub):` line **already exists**, **rewrite its number in place** — exactly one such line, **never** a duplicate; if it is **absent**, **insert** one (as a sibling header line). This is a read-modify-write that **converges to exactly one receipt line carrying the current number**, so it is safe to re-run: a second `create` on an already-adopted milestone rewrites the same line to the same number (no duplicate, no second insert) — unlike pass (d)'s no-op idempotency (where re-applying changes nothing), the receipt actively overwrites, but the line count never grows. (Re-running `create` is safe and produces no duplicates — the same guarantee pass (d) makes for issue bodies, `skills/create/SKILL.md` "Partial-failure path".) Both shells below are idempotent by construction: the presence branch rewrites the existing line in place (exactly one), and the absent branch inserts exactly once.
-
-  ```bash
-  # bash — rewrite the receipt in place if present, else insert it after the header lines.
-  # Uses awk (portable across BSD/macOS and GNU sed/awk); avoids GNU-sed-only `a`,
-  # which exits 1 on BSD/macOS sed. n is the milestone number captured above; plan is
-  # the path Step 1 resolved. On any write error, emit the notice and continue (don't block).
-  plan=".milestone-feeder/plan-<slug>.md"
-  n="<resolved-milestone-number>"
-  notice="create: deployed milestone #$n but could not write the receipt to $plan — re-run to record it"
-  tmp="$(mktemp)" || { echo "$notice"; }
-  if [ -n "$tmp" ]; then
-    if grep -q '^Milestone number (GitHub):' "$plan"; then
-      # present → rewrite the FIRST receipt line in place (exactly one line; never a duplicate)
-      awk -v n="$n" '!done && /^Milestone number \(GitHub\):/ { print "Milestone number (GitHub): " n; done=1; next } { print }' "$plan" > "$tmp" \
-        && mv "$tmp" "$plan" || echo "$notice"
-    elif grep -q '^Source brief:' "$plan"; then
-      # absent, anchor present → insert exactly once after the Source brief header line
-      awk -v n="$n" '{ print } !done && /^Source brief:/ { print "Milestone number (GitHub): " n; done=1 }' "$plan" > "$tmp" \
-        && mv "$tmp" "$plan" || echo "$notice"
-    else
-      # absent AND no anchor (malformed/hand-edited plan) → degrade VISIBLY:
-      # append the receipt at EOF (still exactly one line; the present-branch finds it next run)
-      awk -v n="$n" '{ print } END { print "Milestone number (GitHub): " n }' "$plan" > "$tmp" \
-        && mv "$tmp" "$plan" || echo "$notice"
-    fi
-  fi
-  ```
-
-  ```powershell
-  # PowerShell 7+ — same idempotent rewrite-or-insert; write UTF-8 without a BOM.
-  # On any write error, emit the notice and continue (don't block the deploy).
-  $plan = ".milestone-feeder/plan-<slug>.md"
-  $n    = "<resolved-milestone-number>"
-  $notice = "create: deployed milestone #$n but could not write the receipt to $plan — re-run to record it"
-  try {
-    $lines = Get-Content -LiteralPath $plan
-    if ($lines -match '^Milestone number \(GitHub\):') {
-      # present → rewrite the number in place (exactly one line; never a duplicate)
-      $out = $lines -replace '^Milestone number \(GitHub\):.*', "Milestone number (GitHub): $n"
-    } elseif ($lines -match '^Source brief:') {
-      # absent, anchor present → insert as a sibling after the Source brief header line
-      $out = $lines | ForEach-Object {
-        $_
-        if ($_ -match '^Source brief:') { "Milestone number (GitHub): $n" }
-      }
-    } else {
-      # absent AND no anchor (malformed/hand-edited plan) → degrade VISIBLY:
-      # append the receipt at EOF (still exactly one line; the present branch finds it next run)
-      $out = @($lines) + "Milestone number (GitHub): $n"
-    }
-    Set-Content -LiteralPath $plan -Value $out -Encoding utf8NoBOM -ErrorAction Stop
-  } catch {
-    Write-Output $notice
-  }
-  ```
-
-- **Failure semantics — report, don't block.** A plan-file back-write failure is **REPORTED as a notice but does NOT block** — by this point the GitHub deploy already succeeded (the milestone exists; pass c is about to create the issues), and the plan file is **gitignored per-run scratch** (`docs/specs/v0.3.1-driver-handoff.md` §4: *"The plan file is gitignored per-run scratch, so this back-write is low-stakes"*). The receipt rewrites the **existing** plan file in place, so the scratch dir already self-ignores (`plan` ensured `.milestone-feeder/.gitignore` contains `*` when it first wrote the plan; `skills/plan/SKILL.md` Step 7) — the receipt write adds no new visible file. On a write error, emit a notice — `create: deployed milestone #<n> but could not write the receipt to <plan> — re-run to record it` — and continue to pass (c). Never abort the deploy over the receipt.
-
-#### c. Create each surviving issue; build the slug→`#n` map
-
-Create **only the SURVIVING** issues recorded in the plan file's `## Issues` section — the gate-clean / Advisory-only, **non-parked, non-dropped** issues (Step 2). **Parked and dropped issues recorded in the plan file are NEVER created** (the report still routes the parked ones at pass e; dropped dependents are simply omitted).
-
-On **CREATE** (the milestone had no prior issues), create every surviving issue. On **ADOPT** (the milestone already had issues), first list its existing OPEN issues so a re-run does not duplicate them — match each surviving issue against them **by exact title**:
-
-```
-gh issue list --milestone "<milestone-title>" --state open --json number,title
-```
-
-For each surviving issue, **in Wave order** (the plan file's Wave order):
-
-| On adopt, title match? | Action |
-|---|---|
-| **Yes** — an open issue with the same title already exists | **Reuse** its number — do NOT create a duplicate. Map `slug → #<existing-n>`. Its body is **left as-is** (see body policy below). |
-| **No** (or this is the create path) | **Create:** `gh issue create --title "<title>" --body "<the §4 ISSUE_BODY from the plan file, verbatim>" --milestone "<milestone-title>" --label <ui\|logic> --label <risk:light\|risk:heavy>`. Capture the returned number. Map `slug → #<new-n>`. |
-
-Apply each issue's **labels exactly as recorded in the plan file** (its `ui`/`logic` label and its `risk:*` label — Step 2). Accumulate the full **slug→`#n` map** across every surviving issue (created or reused). The `--body` here still carries the **local slug** references from the plan file; they are rewritten in the second pass (d), once the full map exists.
-
-**Adopted-issue body policy.** Adopted (title-matched) issues are **NOT** body-rewritten — their bodies are preserved as-is. A prior `create` run already resolved their slug→`#n` references, and any manual human edits are respected. **ONLY newly-CREATED issues** receive the slug→`#n` body rewrite in pass (d). This non-clobber behavior is intentional, not a gap.
-
-**Re-run title-match constraint (stated limitation).** De-dup on re-run relies on **stable, exact, OPEN titles** — it matches each surviving issue's title against the milestone's open issues. If a title was edited on GitHub between runs, or a prior issue was **closed** (the list is `--state open`), the match misses and a **new** issue may be created. Titles must stay stable for idempotent re-run — a stated constraint, not a silent bug.
-
-#### d. Second pass — rewrite slug→`#n` (the load-bearing two-pass mechanic)
-
-Two passes are required: issue numbers do not exist until (c) creates them, and `gh issue create --milestone` cannot set the Wave-encoded milestone description. With the **complete** slug→`#n` map from (c):
-
-**Substring-safe rewrite rule (load-bearing).** The architect rolls tags `#A`, `#B`, … `#Z`, then doubles to `#AA`, `#AB`, … past 26 (`agents/architect.md`). A naive string replace of `#A`→`#42` would corrupt `#AB` into `#42B`, and could also hit `#A` inside a word. So **every** slug→`#n` rewrite (issue bodies AND the milestone description) MUST:
-  1. **Replace in descending slug-length order** (longest slug first — **all double-letter tags before any single-letter tag**), so a longer tag is consumed before a shorter prefix of it can match.
-  2. **Match each `#<tag>` only at a token boundary** — the tag must be followed by a non-tag character (whitespace, punctuation, end-of-string), not by another tag-letter, and never be a substring inside a longer tag or a word. `#A` therefore never matches inside `#AB`.
-
-Apply this rule to **every** slug occurrence, wherever it appears (both targets below) — it is the mechanic that keeps the rewrite correct.
-
-1. **Each newly-CREATED issue** (adopted issues are skipped — see the pass-(c) body policy): rewrite **every slug occurrence in the issue's FULL body** to its mapped `#n` — `## Summary`, `## Design` prose, **and** `## Dependencies` (including the reason text after a dependency, e.g. "Depends on #A — references SyncStatusViewModel, introduced by #A" → **both** `#A` rewritten; `agents/issue-author.md`) — using the substring-safe rule, then `gh issue edit <n> --body "<rewritten body>"`. (A created issue whose full body contains no slug reference needs no edit.) Rewriting **only** `## Dependencies` would leave sibling-slug references in Summary/Design/reason text dangling — GitHub would auto-link them to whatever real issue happens to hold that number.
-2. **The milestone description:** rewrite **every slug occurrence** in the plan file's Wave-order description from local slugs to real numbers (same substring-safe rule) and PATCH it onto the milestone (REPLACE form — both shells):
-
-```
-# bash
-gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" \
-  -f description="<Wave description with slugs rewritten to #n>"
-```
-
-```powershell
-# PowerShell 7+ — assign the multi-line description to a variable first, then pass it;
-# avoid the `=@` adjacency so gh's -f reads it as a literal string, not @file.
-# -f/--raw-field always takes the value literally; @file applies only to -F.
-$desc = @"
-<Wave description with slugs rewritten to #n>
-"@
-gh api --method PATCH "repos/{owner}/{repo}/milestones/<number>" -f "description=$desc"
-```
-
-After (d), every `#n` on GitHub is a real issue number and the milestone description encodes the Wave order in real numbers — exactly the ordering source the driver's `solve-milestone` / `triage` read (`SPEC.md` §4).
+| **a. Ensure labels** | Upsert the four canonical labels (`gh label create … --force`) **FIRST**, so every later `--label` resolves; re-runs never duplicate. |
+| **b. Create-or-adopt the milestone (by EXACT title)** | Resolve by the exact title — create / adopt (reopen if closed) / **never delete** — then write the deploy receipt (`Milestone number (GitHub): <n>`) back to the plan file (quote-safe `env.t` resolve; the back-write **reports, never blocks**). |
+| **c. Create each surviving issue; build the slug→`#n` map** | Create **only** the non-parked / non-dropped issues; on adopt, reuse by exact title (no duplicates), adopted bodies left as-is; apply each issue's recorded labels. |
+| **d. Second pass — rewrite slug→`#n`** | With the **complete** map, rewrite every slug occurrence (newly-created issue bodies + the milestone description) **substring-safe** — descending slug-length order, token-boundary match — then PATCH the description (REPLACE form; idempotent). |
+| **e. File the needs-input report** | Retained inline below — routes only when the `## Needs human input` pointer is not "none". |
 
 #### e. File the needs-input report
 
-The plan file records the **Source brief reference** (`inline` \| `file:<path>` \| `epic #<n>`) and its `## Needs human input` pointer (Step 2). Route the report whenever the plan file's `## Needs human input` section points to a report (its pointer is NOT "none") — equivalently, whenever the plan recorded **any product gap OR any parked issue** (`skills/plan/SKILL.md` Step 7 writes that pointer under the broader condition: `productGaps[]` non-empty OR the self-check parked any issue; a carried-forward product gap can set it with zero parked issues). Route by the recorded brief form. The report **body already exists** in the `plan` run's output (`.milestone-feeder/needs-product-input-<slug>.md`, `skills/plan/SKILL.md` Step 7); `create` **routes** it — it does not regenerate the gaps:
+The plan file records the **Source brief reference** (`inline` \| `file:<path>` \| `epic #<n>`) and its `## Needs human input` pointer (Step 2). Route the report whenever the plan file's `## Needs human input` section points to a report (its pointer is NOT "none") — equivalently, whenever the plan recorded **any product gap OR any parked issue** (`skills/plan/SKILL.md` Step 7 writes that pointer under the broader condition: `productGaps[]` non-empty OR the self-check parked any issue; a carried-forward product gap can set it with zero parked issues). Route by the recorded brief form. The report **body already exists** in the `plan` run's output (`.milestone-feeder/needs-product-input-<slug>.md`, `docs/plan-file-contract.md` Needs-product-input report template); `create` **routes** it — it does not regenerate the gaps:
 
 | Brief form (from the plan file's Source brief reference) | Where the report goes |
 |---|---|
@@ -303,135 +103,21 @@ If the plan file's `## Needs human input` pointer is "none" (no product gap and 
 
 ### Step 3V — Verify the deploy covers the original brief (create's closing action)
 
-After the deploy loop completes — **single-plan path:** Step 3 passes a–e; **roadmap path (Step 1R):** the outer loop over all N milestones — run this **closing verification** before the optional Step-4 handoff. It is **always-on** (every `create`, single-milestone included) — **not** gated like the Step-4 handoff — and **best-effort / non-blocking**: it reads the live deployed state back, audits it against the **original** brief, and surfaces a coverage punch-list, but it **never** blocks `create`'s completion, the Step-4 handoff, or any merge, and **never** auto-fixes, edits, reopens, or comments-to-fix any deployed issue or milestone (`.project/design-philosophy.md#One-way doors` — surfaced for the human, never auto-applied; `#Error & failure philosophy` — degrade gracefully, never abort). **Announce the step, and at the end its outcome, flatly.**
+After the deploy loop (single-plan Step 3 passes a–e; roadmap Step 1R's loop over all N milestones), `create` runs an **always-on, best-effort, non-blocking** closing verification: resolve the **original** brief (in-session, else the persisted copy read **strictly between** the paired `## Original brief` … `## End original brief` markers, else a non-blocking `original brief unavailable` notice — **never** fabricated), read **every** deployed milestone + issue back via `gh` (content or a `read-error` marker), dispatch the brief-coverage verifier (`milestone-feeder:brief-coverage-verifier`, #156) **once** with that payload, and route the returned punch-list exactly like pass (e) (epic → comment; file / inline → local git-invisible file + notice; clean → "nothing missed", route nothing). It **never** blocks completion / the handoff / any merge and **never** auto-fixes; it skips with a notice when nothing was deployed to read back or #156 is not installed.
 
-**Skip conditions (a non-blocking notice, NOT an error).** Before resolving the brief, skip the whole step — print the stated notice and continue to Step 4 — when either holds:
-
-| Condition | Notice |
-|---|---|
-| **Nothing was deployed to read back** — the deploy created no surviving issue (all candidates parked / dropped) | `coverage not verified — nothing was deployed to read back` |
-| **The verifier agent does not resolve** — `milestone-feeder:brief-coverage-verifier` (#156) is not available in this session (detect by the **same optional soft-dependency convention Step 4 Gate 2 uses**: attempt the dispatch; "does not resolve" = absent) | `coverage not verified — brief-coverage-verifier not installed` |
-
-**1. Resolve the ORIGINAL brief — the resolution ladder (first-match-wins).** The audit is against the **original** brief, never the per-milestone plan slices:
-
-| Rung | Source |
-|---|---|
-| **1. In-session** | The original brief `create` already holds — the `create` argument (resolved to text if it is a `file:<path>` / `epic #<n>` reference `create` can still read). |
-| **2. Persisted durable copy** | The `## Original brief` … `## End original brief` delimited section of the persisted artifact: the **roadmap manifest** (`.milestone-feeder/roadmap-<slug>.md`, `skills/build-roadmap/SKILL.md` "Manifest format") on a **roadmap run**; the **plan file** (`.milestone-feeder/plan-<slug>.md` — the `## Original brief` section `plan` persists, `skills/plan/SKILL.md` Step 7) on a **single-milestone run**. Extract the lines **strictly between** the paired markers (the extractor below) so a brief containing its own `## ` headings is read intact, not truncated at its first internal `## `. |
-| **3. Fallback** | Neither resolved (e.g. a `file:<path>` brief that no longer resolves and no persisted copy exists) → emit the non-blocking notice `original brief unavailable — coverage not verified`, **never fabricate a brief**, and let `create` complete. |
-
-**Extract the rung-2 copy between the paired delimiters.** The persisted `## Original brief` section is bounded by a paired end-marker: both producers emit a literal `## End original brief` line immediately after the brief text (`skills/build-roadmap/SKILL.md` "Manifest format"; `skills/plan/SKILL.md` Step 7). Capture the lines **strictly between** `## Original brief` and the first following `## End original brief` — both delimiter lines excluded — so a brief that contains its own `## ` headings is read **intact**, never truncated at its first internal `## `. **Graceful fallback:** if the opening `## Original brief` is present but no closing `## End original brief` exists (e.g. an older scratch artifact written before the paired-delimiter convention), degrade to the prior naive behavior — read from `## Original brief` to the next top-level `## ` heading or EOF — yielding a usable, non-empty result rather than nothing. (This prior read may truncate a brief that has its own internal `## ` headings — the very reason the paired delimiter is preferred — but it never returns empty for a non-empty brief.) Step 3V already degrades gracefully on an absent copy, so it degrades gracefully on a delimiter-less one too. Extract with the artifact path in `$art` (both shells):
-
-```bash
-# bash — resolve the persisted original brief from the artifact at "$art".
-art=".milestone-feeder/<roadmap|plan>-<slug>.md"
-if grep -qxF '## End original brief' "$art"; then
-  # Primary: the lines STRICTLY BETWEEN `## Original brief` and the first following
-  # `## End original brief` (both delimiter lines excluded) — robust to a brief that
-  # contains its OWN `## ` headings; it is NOT truncated at the first internal `## `.
-  brief="$(awk '
-    $0 == "## End original brief" { inblk=0 }
-    inblk                         { print }
-    $0 == "## Original brief"     { inblk=1 }
-  ' "$art")"
-else
-  # Graceful fallback (no closing delimiter): read from `## Original brief` to the next
-  # top-level `## ` heading or EOF — the prior behavior. A usable result, never empty.
-  brief="$(awk '
-    inblk && /^## /           { inblk=0 }
-    inblk                     { print }
-    $0 == "## Original brief" { inblk=1 }
-  ' "$art")"
-fi
-```
-
-```powershell
-# PowerShell 7+ — same resolution from the artifact at $art.
-$art = ".milestone-feeder/<roadmap|plan>-<slug>.md"
-$lines = @(Get-Content -LiteralPath $art -ErrorAction SilentlyContinue)
-$start = [array]::IndexOf($lines, '## Original brief')
-$brief = ''
-if ($start -ge 0) {
-  $end = [array]::IndexOf($lines, '## End original brief', $start + 1)
-  if ($end -ge 0) {
-    # Primary: the lines STRICTLY BETWEEN the paired markers (both excluded) —
-    # robust to a brief containing its own `## ` headings.
-    if ($end -gt $start + 1) { $brief = ($lines[($start + 1)..($end - 1)] -join "`n") }
-  } else {
-    # Graceful fallback (no closing delimiter): to the next top-level `## ` heading or
-    # EOF — the prior behavior. A usable result, never empty.
-    for ($k = $start + 1; $k -lt $lines.Count -and $lines[$k] -notmatch '^## '; $k++) {
-      $brief += $lines[$k] + "`n"
-    }
-  }
-}
-```
-
-**2. Read back every deployed target — the #158→#156 input contract (`create` does the reads, #156 does none).** `create` performs the live-GitHub read-back of **every** deployed target via the **same cross-platform `gh` surface it already uses** (the milestone read of Step 3 pass b; the issue handles from pass c/d) — for **each** created milestone its title + description, and for **each** created issue its title + body. The milestone number(s) and issue numbers are already in hand from the deploy (pass b's resolved `.number`, pass c/d's slug→`#n` map; on a roadmap run, each milestone's own deploy). For **each** target record a per-target **STATUS** — the content, **or** a `read-error: <reason>` marker if its read fails — so #156 populates `READ_ERRORS` **purely from these markers** and runs **no** `gh` read of its own (`agents/brief-coverage-verifier.md` — it runs NO `gh` reads, taking provided read-back content; `.project/design-philosophy.md#Layering & boundaries` — skills do the GitHub ops, the read-only agent audits provided text). Read each target (both shells; on a non-zero `gh` exit, record the marker instead of content):
-
-```bash
-# bash — read back milestone <number> (title + description); on a non-zero gh exit, record the marker.
-m="$(gh api "repos/{owner}/{repo}/milestones/<number>" --jq '{title, description}')" \
-  || m="read-error: milestone <number> could not be read back"
-# bash — read back issue #<n> (title + body); on a non-zero gh exit, record the marker.
-i="$(gh issue view <n> --json title,body)" \
-  || i="read-error: issue #<n> could not be read back"
-```
-
-```powershell
-# PowerShell 7+ — same read-backs; on a non-zero gh exit, record the marker instead of content.
-$m = gh api "repos/{owner}/{repo}/milestones/<number>" --jq '{title, description}'
-if ($LASTEXITCODE -ne 0) { $m = "read-error: milestone <number> could not be read back" }
-$i = gh issue view <n> --json title,body
-if ($LASTEXITCODE -ne 0) { $i = "read-error: issue #<n> could not be read back" }
-```
-
-On a **roadmap run**, read back **all N** milestones and **all** their issues into one payload — the audit is against the manifest's whole-app brief (rung 2), so the read-back must cover every milestone the roadmap deployed.
-
-**3. Dispatch the brief-coverage verifier (#156), once.** Dispatch `milestone-feeder:brief-coverage-verifier`, passing (1) the **resolved original brief** (step 1) and (2) the **per-target read-back payload** (content-or-marker per milestone/issue, step 2). It audits every readable target against the original brief, populates `READ_ERRORS` from the markers alone, and returns its structured `COVERAGE_VERDICT / UNCOVERED / DUPLICATED / DISTORTED / READ_ERRORS` block (`agents/brief-coverage-verifier.md`). It opens, edits, and comments on nothing — `create` routes its output.
-
-**4. Surface / route the punch-list — exactly like the needs-input report (pass e).** Route by the recorded **Source brief reference** — the **manifest's** on a roadmap run, the **plan file's** on a single-milestone run (the same artifact the brief was resolved from at rung 2):
-
-| `COVERAGE_VERDICT` | Action |
-|---|---|
-| **`clean`** (UNCOVERED / DUPLICATED / DISTORTED / READ_ERRORS all the literal `none`) | Report `coverage verified — nothing missed`. **Route nothing.** |
-| **`punch-list`**, brief form **`epic #<n>`** | Post the block as a comment on the epic: `gh issue comment <epicIssueNumber> --body "<punch-list>"` (mirrors pass e's epic branch). |
-| **`punch-list`**, brief form **file / inline** | Write the block to the local git-invisible file `.milestone-feeder/coverage-<slug>.md` and **print a notice** that the punch-list is local (no epic to comment on) — mirrors pass e's file/inline branch. Ensure `.milestone-feeder/.gitignore` contains a single `*` first (it already does — `plan` / pass e ensured it). |
-
-The punch-list is **advisory** — `create` surfaces it for the human and **changes nothing** on GitHub (no issue opened, edited, closed, reopened, or auto-fixed; `.project/design-philosophy.md#One-way doors`).
-
-**Failure stays non-blocking.** If the verifier dispatch errors or returns no parseable block, emit a non-blocking notice (`coverage not verified — verifier did not return a usable result`) and continue — never abort, never block Step 4 (`.project/design-philosophy.md#Error & failure philosophy`). The whole step is read-only on the deployed state.
+Full mechanics — the skip-condition table, the brief-resolution ladder, the paired-delimiter extractor twins, the read-back twins, and the routing table — live in **`docs/create-deploy-sequence.md` → "Step 3V — Verify the deploy covers the original brief"**.
 
 ### Step 4 — Offer the driver handoff (clean-run only)
 
-After the deploy completes (Step 3), `create` can hand the freshly-built milestone straight to `milestone-driver` to start building — instead of ending the run and leaving the user to invoke the driver themselves. This is **build-kickoff only**; it invokes `/milestone-driver:solve-milestone "<milestone-title>"`, which builds to the integration branch and **never** crosses the release boundary (Gate 3 below). The behavior is governed by the `autoHandoff` key (Step 0) and three gates that must **ALL** hold to offer the handoff. (Resolved design: issue #148, 2nd comment — Ken, 2026-06-24.)
+After the deploy, `create` can hand the milestone to `milestone-driver` to start building — **build-kickoff only**, governed by `autoHandoff` (Step 0) and **three gates that must ALL hold**:
 
-**Gate 1 — clean run only (no gaps/parks AND the self-check actually ran).** Offer the handoff **only** when **BOTH** conditions hold:
+- **Gate 1 — clean run only:** the `## Needs human input` pointer is **"none"** **AND** the self-check actually ran — a real PASS / INTERNAL verdict, **not** `SKIPPED(reviewer:false)` (its issues were never vetted → Gate 1 fail).
+- **Gate 2 — driver installed (else silently skip):** if `/milestone-driver:solve-milestone` does **not** resolve in this session, skip silently — no prompt, no error.
+- **Gate 3 — never crosses the release boundary:** the handoff merges **only** to the integration branch; `develop → main`, closing the milestone, and deploy stay manual and human-only.
 
-  1. **No gaps/parks** — the plan file's `## Needs human input` pointer is **"none"** (the exact same signal pass (e) reads, `skills/create/SKILL.md` pass e, line ~232, to decide whether to route a report): no product gap AND nothing parked/dropped.
-  2. **The self-check actually ran** — the plan file's `Self-check:` verdict (already read at Step 2; the plan-file contract row) is a **real PASS or INTERNAL** verdict, **NOT** `SKIPPED(reviewer:false)`. A `reviewer: false` run **skips the self-check gate entirely** — its issues are explicitly **NOT vetted** against the driver's entry gate (`plan` records `SKIPPED(reviewer:false)` with a visible 🔴 warning; `skills/plan/SKILL.md` §6.1 — the `reviewer: false` skip-the-gate row, `docs/architecture.md` reviewer-backends table). Such a run can have no product gaps and nothing parked → pointer "none" → it would otherwise read as "clean" while harboring exactly the **unsurfaced** gaps the gate exists to catch. So a `SKIPPED(reviewer:false)` verdict is a **Gate 1 fail**.
+`autoHandoff` (default `"prompt"`) selects prompt / auto / off (an unrecognized value → `"prompt"`); the invocation passes the **exact** `Milestone title (exact)` line. On a **roadmap** run the single-plan handoff is **not** auto-fired across the roadmap.
 
-If **either** condition is not met — any candidate was parked / flagged / blocked (the pointer is NOT "none"), **OR** the self-check was skipped (`SKIPPED(reviewer:false)`) — **do NOT offer the handoff**; the existing gap-surfacing / reviewer-skipped behavior stands unchanged (pass e routes the gaps as today; the 🔴 reviewer-skipped warning already stands), and `create` ends as it does today. Handing a milestone with known gaps — or with issues that were never vetted — to an unattended build loop would build past the very gaps the feeder exists to surface; the clean-run gate (no gaps/parks AND the self-check ran) is what keeps the human in the loop.
-
-**Gate 2 — driver installed (else silently skip).** Detect whether `milestone-driver` is available in this session using the **same convention the feeder already uses** for the optional driver soft-dependency: attempt the invocation and treat "does not resolve (no such skill / agent in the session — `milestone-driver` not installed)" as **absent** (`skills/plan/SKILL.md` §6.1 — the runtime degrade-to-internal trigger: a dispatch that does not resolve = the agent is not installed; `docs/consumer-setup.md:17-20` — the optional `milestone-driver` soft-dependency **degrades silently** when absent). For the handoff, the cleanest detection is: **does `/milestone-driver:solve-milestone` resolve in this session?** If it does **NOT** resolve, **silently skip** this step — **no prompt, no error, no notice** — exactly as the optional soft-dependency degrades silently elsewhere. The handoff is a convenience on top of a clean deploy; its absence is not a failure.
-
-**Gate 3 — never crosses the release boundary.** The handoff invokes `/milestone-driver:solve-milestone "<milestone-title>"`, which **only merges to the integration branch** (`develop`) and never to the protected branch (`main`). Release (`integrationBranch` → `protectedBranch`), closing the GitHub milestone object, and deploy stay **manual and human-only** — that boundary is what makes unattended operation safe (`milestone-driver/skills/solve-milestone/SKILL.md` — the "Bounded blast radius" note: "merges only to `integrationBranch`, never to `protectedBranch`. Release … and deploy stay manual and human-only"). `create`'s handoff is **build-kickoff only**: it does not auto-merge to a protected branch, does not remove the release gate, and `develop → main` stays a manual human call. `solve-milestone` already enforces this; the handoff simply invokes it.
-
-**Behavior by `autoHandoff` (Step 0):**
-
-| `autoHandoff` | When gates 1 + 2 hold | When gate 1 OR 2 fails |
-|---|---|---|
-| `"off"` | **Never offer**, no prompt — skip this step (today's no-handoff behavior). | Skip this step (no-op either way). |
-| `"prompt"` (**default**) | **Ask:** *"milestone-driver is installed — start building this milestone now, or review it first?"* → **yes** invokes `/milestone-driver:solve-milestone "<milestone-title>"`; **no** stops (today's behavior). | **Do not offer** — Gate 1 fail (gaps/parks present, **OR** `SKIPPED(reviewer:false)` — the issues were never vetted): surface the gaps as today (pass e); the 🔴 reviewer-skipped warning already stands. Gate 2 fail: silently skip (no prompt, no error). |
-| `"auto"` | **Invoke immediately**, no prompt: `/milestone-driver:solve-milestone "<milestone-title>"`. Print a one-line notice for legibility — `create: clean run — handing "<milestone-title>" to milestone-driver to start building (autoHandoff: auto)`. (Driver-side precondition: see the numeric-title caveat below.) | **Do not invoke** — Gate 1 fail (gaps/parks present, **OR** `SKIPPED(reviewer:false)` — the issues were never vetted, so auto-firing would build past un-vetted design): surface the gaps as today (pass e); the 🔴 reviewer-skipped warning already stands. Gate 2 fail: silently skip. |
-
-**Numeric-title caveat (`"auto"` defers to the driver's own preconditions).** `autoHandoff: "auto"` kicks off the driver with no prompt, but it does **not** override the driver's own entry preconditions. If the deployed milestone title is **purely numeric**, `/milestone-driver:solve-milestone` **halts and prompts the human for a rename** regardless of `autoHandoff: "auto"` — it interprets a bare number as single-issue mode and refuses to drive a numeric-titled milestone unattended (`milestone-driver/skills/solve-milestone/SKILL.md` — the numeric-title precondition: "if it is purely numeric, halt immediately and prompt the human … do not proceed to Phase 0"). So auto mode's "no question asked" contract ends at the driver boundary: auto kicks off the driver, but the driver enforces a non-numeric-title precondition for unattended operation. This is **narrow** — a feeder-deployed milestone normally carries the user-owned semver in its title (non-numeric), so the caveat rarely bites; no special handling is added here, the doc is simply honest that auto defers to the driver's preconditions.
-
-**The exact milestone title.** The invocation passes the **exact** `Milestone title (exact)` line from the plan file — the same identity string `create` deployed at pass (b) (Step 2; the plan-file `Milestone title (exact)` field). Never a re-derived or goal-derived name — the title carries the user-owned semver and is the handle the driver resolves the milestone by. Pass it verbatim to `solve-milestone "<milestone-title>"`.
-
-**This is a skill invocation, not a shell command.** `/milestone-driver:solve-milestone` is invoked as a Claude Code skill (the same way `create` runs `plan` first on the absent path) — there is no bash/pwsh form to ship for the invocation itself. The `autoHandoff` value is already in hand from Step 0; this step needs no additional config read.
-
-**Multi-milestone roadmap note (Step 1R).** When a **roadmap manifest** drove the deploy (Step 1R, multi-milestone path), this single-plan handoff is **not** auto-fired across the roadmap. `create`'s roadmap responsibility ends at deploying all N milestones and recording each one's `build order: milestone X of N` line — which is exactly the cross-milestone order the driver reads. A roadmap deploy therefore completes by reporting the N deploy receipts and the recorded build order; starting the build stays a human call. The single-plan handoff above (Gates 1–3, `autoHandoff`) is **unchanged** for the N=1 / no-manifest path.
+Full mechanics — the gate write-ups, the `autoHandoff` behavior table, and the numeric-title caveat — live in **`docs/create-deploy-sequence.md` → "Step 4 — Offer the driver handoff"**.
 
 ### Partial-failure path (resume on re-run)
 


### PR DESCRIPTION
Closes #205.

## What this does
`skills/create/SKILL.md` had grown to ~4× the skill-authoring size standard. This relocates its four heavy mechanical regions **byte-for-byte** into a new create-scoped reference, `docs/create-deploy-sequence.md`, and leaves `skills/create/SKILL.md` a lean orchestration skeleton — step names, fixed order, gates, and one-level pointers into the reference (and into #198's `docs/plan-file-contract.md`). `create` reads the reference on demand. **Nothing about what `create` deploys changes.**

Relocated (byte-exact): **Step 1R** (deploy-target resolution), the **Step 3 write-sequence passes a–d** (labels / create-or-adopt + deploy-receipt / create-issues + slug→`#n` map / substring-safe rewrite + description PATCH), **Step 3V** (brief-coverage verification), **Step 4** (driver handoff). Kept inline: frontmatter + intro, Announce, Step 0, Step 1, Step 2, the **Step 3 skeleton naming passes a–e**, **pass (e)**, Partial-failure path, Output style, Non-negotiables.

Repointed (not relocated): Step 2's plan-file-contract table + pass (e)'s plan-file-field references now point at #198's `docs/plan-file-contract.md` (the merged dependency) — 4 swaps in Step 2, 1 in pass (e).

## Behavior-neutral — how it was verified
- **Byte-identity:** each of the four relocated regions diffs IDENTICAL against its source; `cmp` confirmed the installed files match the staged content.
- **Every `gh` write preserved character-for-character:** all `gh` forms + their bash/PowerShell-7+ twins survive in the union of the new skill + new doc; **17 code blocks conserved** (1 in the skill — the retained Step 1 plan-path block — + 16 in the doc).
- **`tests/scenarios/` untouched** (no test asserts on create's file structure).
- **CI gates pass locally:** `validate-plugin-structure.py` (13 files, 0 warnings) and `check-vocabulary.sh` (clean). No new `SKILL.md:NNN` cross-file line citations (the #165 guard stays green). New doc is LF-only, no BOM, single trailing newline, with a TOC (>100 lines).
- **External named-anchor citations still resolve:** other skills cite create by name (`Step 3 pass (b)`, `Step 1R`, `Step 3V`, `Step 4 Gate 2`, `pass (e)`); every named anchor is retained in the skeleton, which points onward to the reference.

## Size
`skills/create/SKILL.md`: **9,329 → 4,053 words (~57%)**. A strict ≤2k landing is **not** claimed — the retained regions are create's procedure/invariants, not relocatable mechanics, and gutting them would break create's legibility as a procedure (per the re-authored #205 spec).

## Review notes
- **Code review:** three independent finder passes (relocation fidelity, cross-reference resolution, skeleton accuracy + conventions) returned **zero correctness defects**.
- **One pre-existing nit, intentionally preserved:** the relocated Step 4 prose carries a stale `skills/create/SKILL.md pass e, line ~232` hint (already wrong in the base; pass e was at ~291). Under #205's explicit "relocated byte-exact / a diff shows relocation only" acceptance criteria, the relocation carried it verbatim. Fixing it would alter the relocated text, so it is left for a trivial follow-up: convert `pass e, line ~232` → the stable `pass (e)` named anchor (per the #165 named-anchor convention).

## Dependency
Depended on #198 (`docs/plan-file-contract.md`), which is merged — the repoints target real anchors there (`Plan-file field table`, `Plan-file output template`, `Needs-product-input report template`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Code Review
- /code-review run: yes — three independent finder passes (relocation fidelity, cross-reference resolution, skeleton accuracy + conventions) returned **zero correctness defects**. The four relocated regions diff byte-identical to source; every `gh` write byte-identical; 17 code blocks conserved; tests untouched. Both CI gates pass.
- Advisory (non-blocking, follow-up): relocated Step 4 carries a pre-existing stale `pass e, line ~232` hint verbatim (the byte-exact constraint forbade editing relocated text) — a trivial follow-up can convert it to the stable `pass (e)` named anchor (#165 convention).
