### PR TITLE
docs: document the size/heaviness multi-milestone detection (#235)

### DIFF
--- a/docs/specs/v0.3.1-driver-handoff.md
+++ b/docs/specs/v0.3.1-driver-handoff.md
@@ -183,8 +183,14 @@ The feeder stays **one brief → one milestone** in v0.3.1, but it stops being
 - **Detection — the architect flags it.** The architect already reasons about the
   brief's structure and builds the dependency graph, so it emits a new
   **`SCOPE_SPANS_MULTIPLE_MILESTONES`** signal (a sibling to `PRODUCT_GAPS`) when
-  a brief reads as distinct phased deliverables / release boundaries, with a
-  **proposed split** (the candidate milestones and which issues fall under each).
+  a brief reads as distinct phased deliverables / release boundaries, **or** when
+  a single-theme breakdown comes out large/heavy enough — many candidates and/or
+  several `risk:heavy` items — to read as more than one milestone's worth of work
+  *and* a clean dependency seam exists to split on, with a **proposed split** (the
+  candidate milestones and which issues fall under each). The size/heaviness path
+  is qualitative — no numeric threshold, mirroring the phase trigger — and a
+  large/heavy breakdown with no clean seam stays `none` rather than forcing a
+  bogus split.
 - **Behavior — advisory + proposed split, non-blocking.** `plan` still writes a
   **deployable single-milestone plan**, but **prominently flags** *"this looks
   like ~N milestones"* and shows the proposed split (A / B / C), surfaced up front


### PR DESCRIPTION
## Summary
Docs-sweep for #233 (merged): records the size/heaviness case in the multi-milestone guardrail's canonical spec. Extends `docs/specs/v0.3.1-driver-handoff.md` §5's detection-trigger description to name the oversized/heavy single-theme breakdown (with a clean dependency seam), qualitatively — no numeric threshold — matching `agents/architect.md` clause 7.

Closes #235.

## Design
- Only §5 needed the trigger extension. `docs/architecture.md` already frames the signal as the "sole arbiter of 'oversized'" and never enumerates a phased/release-only trigger; `docs/one-time-notices.md#roadmap-routing-notice` already announces "an oversized brief now routes into a roadmap flow" — both stay consistent with the widened trigger, so left untouched (least-code, no fabricated enumeration, twin byte-parity preserved).

## Code Review
Reviewed the single-file §5 diff: qualitative wording, no numeric threshold, consistent with the merged clause 7. Clean. Both required CI gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)