### PR TITLE
chore(v0.11.0): md-epic probe finding + bump to 0.11.0 (closes #242)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly — the driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/docs/specs/v0.11.0-md-epic-parent-issue.md
+++ b/docs/specs/v0.11.0-md-epic-parent-issue.md
@@ -1,0 +1,211 @@
+# v0.11.0 — md-epic parent issue (the feeder produces the driver's cross-milestone parent)
+
+**Status:** design brief, pending dogfood (`/milestone-feeder:plan`).
+**Source contract:** driver v1.15.0, `milestone-driver/docs/superpowers/specs/2026-07-04-md-epic-driver-fanout-design.md` (its *The read-contract* and *Feeder → driver integration: verification gate* sections).
+**Date:** 2026-07-04.
+
+> This is a *brief* — the human-authored input. The buildable issue set (the §4
+> specs) is produced by dogfooding the feeder (architect → issue-author →
+> self-check), not hand-authored here.
+
+---
+
+## The problem
+
+The suite is feeder (plans + creates milestones/issues) plus driver (builds them).
+When a brief is too large for one milestone, the feeder's roadmap path already
+splits it into N sequenced milestones. But today those N milestones deploy to
+GitHub as N *independent* objects: each carries a free-text
+`build order: milestone X of N` line in its description, and nothing else ties
+them together. There is no GitHub object a tool can query to say "these N
+milestones are one feature, build them in this order." The only cross-milestone
+record is a local, gitignored scratch manifest the driver never sees.
+
+Driver v1.15.0 built the consuming half. It introduced a **parent issue**: an
+ordinary GitHub issue, marked with the `md-epic` label, whose body carries the
+ordered milestone list. The driver's `solve-issue` sees the label, reads the
+order, and drives each milestone in sequence via `solve-milestone --driven`. The
+driver is a **reader only** — it never creates the parent. Its own spec says so
+and hands the feeder the producing half:
+
+> "The feeder half (creating the parent issue, applying the label, writing the
+> ordered list, linking sub-issues) ... are separate specs, written later. This
+> document defines the contract the driver reads — the feeder must write to this
+> contract."
+
+This feature is that producing half.
+
+## The scope boundary (keystone)
+
+**Feeder-only, roadmap path only.** The work attaches where the feeder already
+produces multiple milestones (`build-roadmap` → `plan` step 3.6/3.7 → `create`'s
+multi-milestone deploy loop). A single-milestone plan/create has nothing to fan
+out to and stays **byte-unchanged**.
+
+Out of scope, deliberately:
+
+- **Driver** — already built and shipped on driver v1.15.0 develop. We produce;
+  it consumes. No driver-side change here.
+- **Bootstrapper** — adding `md-epic` to a fresh repo's scaffolded label set is a
+  separate effort owned in that repo. The feeder self-provisions the `md-epic`
+  label the same way it already self-provisions its other four labels
+  (`gh label create --force`), so this feature does not depend on the bootstrapper.
+
+## What it does
+
+On the roadmap path, when N>1 milestones deploy, the feeder also produces the
+driver's parent issue. **No new config key** — this is the default behavior of the
+roadmap path (a driver that predates `md-epic` simply ignores the extra labeled
+issue, so producing it is always safe).
+
+| Command | Change |
+|---|---|
+| `build-roadmap` + `roadmap-splitter` | Author the parent issue's human-facing text — a title (the roadmap's one-line goal) and a short intro paragraph — into the roadmap manifest, so it is reviewed before deploy alongside the milestone split. |
+| `create` | New deploy pass, after the N milestones + their issues exist: ensure the `md-epic` label; create-or-adopt the parent issue with its reviewed title/intro plus the generated `md-epic-order` block; link each milestone's issues as native GitHub sub-issues of the parent; re-assert each linked issue's own milestone; write a `Parent issue (GitHub): #<n>` receipt into the manifest for idempotent re-runs. |
+| `update` | On a re-planned roadmap: rewrite the `md-epic-order` block to the current build order, link the issues of any newly-added milestone, and reconcile the parent (create-or-adopt, never delete), keeping it consistent with the current plan. |
+
+The parent's block uses **`number:` entries** (create already holds the deployed
+milestone numbers, which sidesteps title-uniqueness and the numeric-title trap in
+the contract). The per-milestone `build order: milestone X of N` line **stays**
+for humans and pre-`md-epic` drivers; the parent's ordered block is the
+authoritative cross-milestone order.
+
+## The read-contract (ground truth — the parent issue must satisfy this exactly)
+
+Reproduced from the driver spec so this brief is self-contained. The feeder
+writes to it; it does not reinterpret it.
+
+**The label.** `md-epic`, exact and case-sensitive, applied to the parent issue
+only — never to a milestone's own issue.
+
+**The ordered milestone list block.** A fenced code block in the parent issue's
+body. Opening fence is exactly ```` ```md-epic-order ```` (three backticks
+immediately followed by the string, **no leading or trailing space**), closed by a
+line that is exactly a closing fence. Inside:
+
+- One milestone reference per non-blank line. **Line order is build order**, top
+  to bottom. No ordinal prefix.
+- Each non-blank line is `number: <integer>` — the milestone's own number. This
+  feature always emits this form. (`title: <text>` is also legal in the contract
+  but we do not use it.)
+- Blank lines are allowed and ignored. No other line shape is valid inside the
+  block. A bare `#<n>` is forbidden (it autolinks to *issue* n, a different
+  namespace).
+
+Worked shape (parent issue body):
+
+`````
+This issue anchors <feature> across <N> milestones, in build order:
+
+```md-epic-order
+number: 42
+number: 43
+number: 51
+```
+
+Build these milestones in the order above.
+`````
+
+**The sub-issue links.** Each milestone's own issues are linked to the parent as
+native GitHub sub-issues (`POST /repos/{owner}/{repo}/issues/{parent}/sub_issues`).
+The driver never reads this graph (it exists for GitHub's own UI progress), but
+the contract's Precondition requires it. GitHub caps this at **100 sub-issues per
+parent** and 8 nesting levels.
+
+**The parent issue itself** carries no milestone and no code. It is a pure
+grouping node.
+
+## Required verification gate (explicit acceptance criteria — do not skip)
+
+The driver spec makes this a *required* gate the feeder spec must carry forward
+verbatim. Both checks must pass before feeder output is trusted by the driver:
+
+1. **Milestone-inheritance probe.** GitHub's Sept-2025 change says a sub-issue
+   "inherits the Project and Milestone of its parent by default." The parent here
+   has *no* milestone. On a throwaway repo, confirm that linking an
+   already-milestoned issue as a sub-issue of a milestone-less parent **preserves
+   the sub-issue's own milestone**. This feature neutralizes the risk structurally
+   by re-asserting each issue's milestone right after linking; the probe confirms
+   and documents the actual behavior. **This is the first build step** — if GitHub
+   behaves unexpectedly, the design adapts before any skill is edited.
+2. **End-to-end conformance.** A real feeder-produced parent issue must satisfy
+   every read-contract clause (label present; block parses; every entry resolves
+   to a real milestone; each milestone's issues linked as sub-issues and sitting
+   on their own milestone) and drive to completion through the driver's fan-out
+   loop.
+
+## Constraints & edge cases
+
+- **Idempotent, create-or-adopt, never delete** — the discipline every existing
+  `create` write already follows. Re-running `create`/`update` adopts the existing
+  parent by its manifest receipt, rewrites the block and links in place, and never
+  duplicates or deletes.
+- **No nested parents.** The driver has no cycle detection and explicitly asks the
+  feeder never to produce a nested `md-epic` (a parent whose milestone's issues are
+  themselves under another `md-epic`). The feeder produces exactly one flat parent
+  per roadmap; a milestone's own issues are never themselves parents.
+- **Sub-issue cap.** A roadmap whose total issue count across all milestones
+  exceeds 100 cannot be fully linked — warn clearly, do not fail silently or
+  half-link without saying so.
+- **Sub-issue on own milestone.** After linking, every child issue must remain on
+  its own milestone, never the parent's (null) one. The re-assert step guarantees
+  this regardless of GitHub's inheritance behavior.
+- **Ordering source of truth.** The parent's `md-epic-order` block is
+  authoritative; the `build order: X of N` description line is a human-facing echo,
+  kept consistent but not read by the driver.
+
+## Non-goals
+
+- Any driver-side change (shipped in driver v1.15.0).
+- The bootstrapper's label-scaffolding half (separate, owned in that repo).
+- Using GitHub native issue dependencies for ordering (the ordered block is the
+  sole source of truth).
+- Parallelizing across milestones (the driver's fan-out is sequential by design;
+  only existing within-milestone Wave parallelism is unaffected).
+- A configurable label name (the contract fixes `md-epic` as a literal; no second
+  consumer needs it configurable).
+
+## Acceptance criteria (consolidated)
+
+- A roadmap deploy (N>1 milestones) produces exactly one `md-epic`-labeled parent
+  issue whose body contains a valid `md-epic-order` block of `number:` entries in
+  build order.
+- Each milestone's issues are linked as native sub-issues of the parent and remain
+  on their own milestone.
+- The parent's title + intro are authored at plan time and reviewable before deploy.
+- `create` and `update` are idempotent (create-or-adopt via a manifest receipt;
+  never delete or duplicate).
+- Single-milestone plan/create is byte-unchanged.
+- Both verification-gate checks pass before ship; the milestone-inheritance probe
+  is the first build step.
+- A >100-issue roadmap warns rather than fails silently.
+- No nested `md-epic` structures are ever produced.
+
+## Verification probe finding (gate check 1)
+
+Ran 2026-07-04 on a throwaway private repo (issue #242). Outcome: **PRESERVED** —
+gate check 1 PASS.
+
+**Setup.** Throwaway repo → milestone `Probe milestone` (#1) → child issue #1
+assigned that milestone → parent issue #2 with **no** milestone.
+
+**Action.** Linked the child as a native sub-issue of the milestone-less parent:
+`POST /repos/{owner}/{repo}/issues/2/sub_issues` with body
+`{"sub_issue_id": <child's numeric id>}` (the REST database `id`, e.g. `4809291792`,
+**not** the issue number). Link succeeded.
+
+**Result.** Child #1's own milestone — read before linking and again immediately
+after — stayed `Probe milestone` both times. GitHub's Sept-2025 "sub-issues
+inherit the parent's Project and Milestone by default" did **NOT** clear the
+child's milestone when the parent carries none. Re-asserting the milestone
+afterward (`PATCH .../issues/1` with the same milestone) is a confirmed no-op.
+
+**Implication for #246 (`create` sub-issue linking).** The re-assert-after-link
+step is **defense-in-depth**, not strictly required in the observed case — but the
+design keeps it: it is cheap, idempotent, and guards against the behavior the
+driver spec flagged as under-documented, so a future GitHub change can't silently
+strand a child on the wrong milestone. End-to-end conformance (gate check 2)
+still runs at build time.
+
+(Cleanup note: the probe's `gh repo delete` failed because the session token
+lacked the `delete_repo` scope; the throwaway repo was removed by hand.)


### PR DESCRIPTION
Opens milestone #19 (v0.11.0 — md-epic parent issue).

- **#242 probe (gate check 1): PRESERVED.** Linking a milestoned child as a native sub-issue of a milestone-less parent keeps the child on its own milestone; GitHub did not clear it. Recorded in `docs/specs/v0.11.0-md-epic-parent-issue.md`. #246's re-assert-after-link is therefore defense-in-depth (kept for robustness).
- Bumps `plugin.json` to `0.11.0`.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)