### PR TITLE
fix: remove dead brief-coverage-verifier from hook allowlists + reverse drift-guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly — the driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/hooks/no-source-edit.ps1
+++ b/hooks/no-source-edit.ps1
@@ -37,8 +37,8 @@
 # `name:` of every agents/*.md — enforced by the CI drift-guard in
 # scripts/validate-plugin-structure.py. Machine-parseable literal (one
 # space-separated set on the next line; keep that exact shape for the guard):
-# FEEDER_OWN_AGENTS: architect issue-author roadmap-splitter brief-coverage-verifier
-$FeederOwnAgents = @('architect', 'issue-author', 'roadmap-splitter', 'brief-coverage-verifier')
+# FEEDER_OWN_AGENTS: architect issue-author roadmap-splitter
+$FeederOwnAgents = @('architect', 'issue-author', 'roadmap-splitter')
 
 if ($env:CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT -eq '1') { exit 0 }
 

--- a/hooks/no-source-edit.sh
+++ b/hooks/no-source-edit.sh
@@ -31,8 +31,8 @@
 # `name:` of every agents/*.md — enforced by the CI drift-guard in
 # scripts/validate-plugin-structure.py. Machine-parseable literal (one
 # space-separated set on the next line; keep that exact shape for the guard):
-# FEEDER_OWN_AGENTS: architect issue-author roadmap-splitter brief-coverage-verifier
-FEEDER_OWN_AGENTS="architect issue-author roadmap-splitter brief-coverage-verifier"
+# FEEDER_OWN_AGENTS: architect issue-author roadmap-splitter
+FEEDER_OWN_AGENTS="architect issue-author roadmap-splitter"
 
 [ "${CLAUDE_HOOK_DISABLE_NO_SOURCE_EDIT:-}" = "1" ] && exit 0
 

--- a/scripts/validate-plugin-structure.py
+++ b/scripts/validate-plugin-structure.py
@@ -232,13 +232,16 @@ if commands_dir.is_dir():
 # set is the one the live gate executes, so it is the safety-relevant one to
 # cover). The comment set is also coverage-checked as belt-and-suspenders.
 #
-# The coverage check is intentionally ONE-DIRECTIONAL: it asserts every agent
-# name in agents/*.md appears in each hook's set. It does NOT flag a stale extra
-# name that is in a hook set but no longer in agents/*.md — that direction is
-# fail-CLOSED (a non-existent agent name can never match a real actor, so at worst
-# it is dead weight). The comment-vs-runtime check, by contrast, IS strict set
-# equality, because a disagreement there is exactly the false-PASS this guard
-# exists to catch. All parsing is stdlib `re` only — NO shell/pwsh execution.
+# The coverage check is BIDIRECTIONAL: it asserts every agent name in
+# agents/*.md appears in each hook's set (forward — a missing name would let the
+# gate mis-classify a real feeder subagent as an outside actor), AND that every
+# name in each hook's set has a matching agents/*.md file (reverse — a name with
+# no matching agent is dead weight left behind by a deletion/rename, e.g. a
+# deleted agent never trimmed from the allowlist). Neither direction is
+# exempted: a missing name and an orphaned name both fail CI. The comment-vs-
+# runtime check, separately, IS strict set equality, because a disagreement
+# there is exactly the false-PASS this guard exists to catch. All parsing is
+# stdlib `re` only — NO shell/pwsh execution.
 
 FEEDER_AGENT_SET_RE = re.compile(r"^#\s*FEEDER_OWN_AGENTS:\s*(.+?)\s*$", re.MULTILINE)
 
@@ -308,6 +311,10 @@ hook_scripts = {
     "sh": REPO_ROOT / "hooks" / "no-source-edit.sh",
     "ps1": REPO_ROOT / "hooks" / "no-source-edit.ps1",
 }
+# Set form of agent_names for O(1) `in` checks in the reverse-coverage loops
+# below (agent_names itself stays a list — order doesn't matter for membership,
+# but no need to change its existing type/uses elsewhere in this script).
+agent_names_set = set(agent_names)
 for _label, hook_path in hook_scripts.items():
     checked += 1
     comment_set = parse_hook_agent_set(hook_path)
@@ -336,6 +343,23 @@ for _label, hook_path in hook_scripts.items():
                            f"'{agent_name}' (declared in agents/*.md) — the "
                            f"actor-gate drift-guard comment has drifted from the "
                            f"real agent set; add it to keep the safety gate correct")
+    # Reverse coverage: every name the hook actually carries must map to a real
+    # agents/*.md file. This is the NEW direction — an orphaned name (e.g. a
+    # deleted agent left behind in the hook's allowlist) is dead weight that
+    # silently masks drift forever without this check. No escape hatch: any
+    # orphaned name fails CI, full stop.
+    for name in runtime_set:
+        if name not in agent_names_set:
+            err(hook_path, f"runtime FEEDER_OWN_AGENTS set contains '{name}', "
+                           f"which has no matching agents/*.md — this is a stale "
+                           f"orphaned name (e.g. from a deleted agent); remove it "
+                           f"from the hook's allowlist")
+    for name in comment_set:
+        if name not in agent_names_set:
+            err(hook_path, f"FEEDER_OWN_AGENTS comment literal contains '{name}', "
+                           f"which has no matching agents/*.md — this is a stale "
+                           f"orphaned name (e.g. from a deleted agent); remove it "
+                           f"from the hook's comment literal")
 
 # --- 5: cross-file SKILL.md line-citation guard -----------------------------
 #


### PR DESCRIPTION
## Summary
Removes the dead `brief-coverage-verifier` name (removed in #223/v0.9.0) from both `hooks/no-source-edit.sh` and `hooks/no-source-edit.ps1`'s `FEEDER_OWN_AGENTS` allowlists, and adds a reverse coverage check to `scripts/validate-plugin-structure.py` so a stale hook-allowlist name with no matching `agents/*.md` fails CI going forward.

Closes #264