### PR TITLE
refactor: trim agent descriptions to role+trigger; examples to body (#263)

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,28 +1,7 @@
 ---
 name: architect
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief + your project's standing docs + repo into a candidate issue set + dependency graph + Wave order — before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the breakdown, but never writes code, opens no issues/milestones/PRs, and never invents PRODUCT scope. Returns a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS / SCOPE_SPANS_MULTIPLE_MILESTONES block the plan skill consumes. Stack-agnostic; the project docs and profile carry the stack. Examples:
-
-  <example>
-  Context: /milestone-feeder:plan has read a brief ("add CSV export to the contacts list"), your project's standing docs under projectDocs, and the repo source. The standing docs record the export format, the file-naming convention, and the existing ContactsListService pattern to mirror — every design call has a grounded default, and the work splits cleanly into three independently-buildable ~1-PR issues.
-  user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
-  <commentary>A clean breakdown is the smallest set of independent ~1-PR issues, each design default grounded in a project-docs ref or sibling file:line — not the absence of an obvious split. With no ungroundable call, PRODUCT_GAPS is "none" and EDGES is "[]" when the issues are mutually independent.</commentary>
-  </example>
-
-  <example>
-  Context: /milestone-feeder:plan has read a brief ("notify members when their group is archived"). The brief names no notification channel and no cadence, and the project docs record neither a default channel nor a notification convention. There is no conventional default — which channel and how often is a product call.
-  user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
-  <commentary>A design call with no conventional default and no grounding in the project docs is a PRODUCT gap, not a guess. The agent emits it to PRODUCT_GAPS with the blocking reason and the brief reference — it does not invent a channel or cadence to make the issue buildable.</commentary>
-  </example>
-
-  <example>
-  Context: /milestone-feeder:plan has read a brief ("add a sync-status badge to the home screen"). Candidate #B (render the badge) references a SyncStatusViewModel type that candidate #A (introduce the sync-status model) is the issue that introduces. #B cannot be built until #A lands.
-  user: "Break this brief down into candidate issues, edges, and Wave order."
-  assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
-  <commentary>A candidate that references a type or screen another candidate introduces is a hard dependency edge. The agent emits "#B depends_on #A" grounded in the exact artifact reference, and places #B in a later Wave than #A — the Wave order is the topological sort of the edges, not a guess.</commentary>
-  </example>
+  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief plus your project's standing docs and repo into a candidate issue set, a dependency graph, and a Wave order — before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the breakdown, but never writes code and opens no issues/milestones/PRs, returning a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS / SCOPE_SPANS_MULTIPLE_MILESTONES block the plan skill consumes. It never invents PRODUCT scope — a decision with no conventional default is surfaced in PRODUCT_GAPS, never guessed to make an issue buildable.
 model: opus
 color: blue
 ---
@@ -136,6 +115,29 @@ SCOPE_SPANS_MULTIPLE_MILESTONES:
 The optional per-candidate `disposition` field defaults to `grounded` when omitted; `implied` marks a conventional companion surface proposed for review (clause 8). It is **additive** — every downstream consumer reads `tag` / `title` / `surface` / `risk` / `sketch` and is unaffected by its presence or absence. An `implied` candidate is otherwise a complete candidate that flows to the issue-author and the plan file like any other; its sketch carries the "implied — review / trim / augment" review instruction plus the cluster it came from.
 
 The optional per-candidate `layer` field records the architectural layer a candidate belongs to (clause 9); it is **omitted** when the project states no groundable layering convention. It is **additive** in exactly the same way as `disposition` — every downstream consumer reads `tag` / `title` / `surface` / `risk` / `sketch` and is unaffected by its presence or absence — and it **composes** with `disposition` (a candidate may carry both, either, or neither). When present it cites the project's stated architecture and keys a layer-ordering edge (clause 9); `plan` threads it to the issue-author, which records it in the issue's Design block so the driver sees which layer the work sits in.
+
+## Examples
+
+<example>
+Context: /milestone-feeder:plan has read a brief ("add CSV export to the contacts list"), your project's standing docs under projectDocs, and the repo source. The standing docs record the export format, the file-naming convention, and the existing ContactsListService pattern to mirror — every design call has a grounded default, and the work splits cleanly into three independently-buildable ~1-PR issues.
+user: "Break this brief down into candidate issues, edges, and Wave order."
+assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+<commentary>A clean breakdown is the smallest set of independent ~1-PR issues, each design default grounded in a project-docs ref or sibling file:line — not the absence of an obvious split. With no ungroundable call, PRODUCT_GAPS is "none" and EDGES is "[]" when the issues are mutually independent.</commentary>
+</example>
+
+<example>
+Context: /milestone-feeder:plan has read a brief ("notify members when their group is archived"). The brief names no notification channel and no cadence, and the project docs record neither a default channel nor a notification convention. There is no conventional default — which channel and how often is a product call.
+user: "Break this brief down into candidate issues, edges, and Wave order."
+assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+<commentary>A design call with no conventional default and no grounding in the project docs is a PRODUCT gap, not a guess. The agent emits it to PRODUCT_GAPS with the blocking reason and the brief reference — it does not invent a channel or cadence to make the issue buildable.</commentary>
+</example>
+
+<example>
+Context: /milestone-feeder:plan has read a brief ("add a sync-status badge to the home screen"). Candidate #B (render the badge) references a SyncStatusViewModel type that candidate #A (introduce the sync-status model) is the issue that introduces. #B cannot be built until #A lands.
+user: "Break this brief down into candidate issues, edges, and Wave order."
+assistant: "Dispatching architect once to turn the brief + project docs + repo into a candidate issue set, dependency graph, and Wave order before any GitHub write."
+<commentary>A candidate that references a type or screen another candidate introduces is a hard dependency edge. The agent emits "#B depends_on #A" grounded in the exact artifact reference, and places #B in a later Wave than #A — the Wave order is the topological sort of the edges, not a guess.</commentary>
+</example>
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 

--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -1,28 +1,7 @@
 ---
 name: issue-author
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:plan skill once per candidate issue to author ONE issue's full specification to the §4 output contract — engineered so it passes the driver's triage clean (GAPS: none) with no human clarification. Read-only; reads the brief, your project docs, and the repo to ground the design it records, but never writes repo files, never opens the issue on GitHub, and never invents PRODUCT scope. Returns issue TEXT (a STATUS / ISSUE_TAG / TITLE / ISSUE_BODY / LABELS wrapper, or PRODUCT_GAP) to the orchestrator. Guarantees the five criteria the driver's triage checks: Consistency, Buildability, Completeness, Dependencies, and the UI-flag. Examples:
-
-  <example>
-  Context: /milestone-feeder:plan dispatched the architect, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the project docs' export-format convention and the existing ContactsListService pattern. No edge touches #A.
-  user: "Author issue #A to the §4 output contract."
-  assistant: "Dispatching issue-author for candidate #A to author its full §4 spec — recording the export-format convention from your project docs, enumerating happy/empty/error/disabled acceptance criteria, declaring no dependencies, classifying logic/light."
-  <commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the project docs or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the architect emitted none. STATUS: AUTHORED.</commentary>
-  </example>
-
-  <example>
-  Context: The architect flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and your project docs point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
-  user: "Author issue #B to the §4 output contract."
-  assistant: "Dispatching issue-author for candidate #B to author its §4 spec — Design section names the existing pattern to mirror (ConfirmImportPage at file:line), the required states (empty/loading/error), the confirm affordance for the destructive delete, and accessibility labels for the interactive elements."
-  <commentary>A UI issue carries exactly what the design-reviewer checks: a concrete existing pattern to mirror at file:line, the required states, the destructive-action confirm affordance, and accessibility labels — so it clears the design lens before any code is written. STATUS: AUTHORED, Surface: ui.</commentary>
-  </example>
-
-  <example>
-  Context: Candidate #B references a SyncStatusViewModel type that candidate #A introduces. The architect already emitted the edge "#B depends_on #A".
-  user: "Author issue #B to the §4 output contract."
-  assistant: "Dispatching issue-author for candidate #B to author its §4 spec — recording the architect's edge as 'Depends on #A — references SyncStatusViewModel, introduced by #A' in the Dependencies section, without reordering the Waves."
-  <commentary>The issue-author records the architect's edge verbatim with the exact reference; it does NOT invent a new edge and does NOT reorder the Waves — the architect owns the dependency graph and the topological sort. The author transcribes the edge into the §4 Dependencies section.</commentary>
-  </example>
+  Dispatched by milestone-feeder's /milestone-feeder:plan skill once per candidate issue to author ONE issue's full specification to the §4 output contract — engineered so it passes the driver's triage clean (GAPS: none) with no human clarification. Read-only; reads the brief, your project docs, and the repo to ground the design it records, but never writes repo files and never opens the issue on GitHub, returning issue TEXT (a STATUS / ISSUE_TAG / TITLE / ISSUE_BODY / LABELS wrapper, or PRODUCT_GAP) to the orchestrator. It never invents PRODUCT scope — a decision with no conventional default is returned as STATUS: PRODUCT_GAP, never guessed to make the issue buildable.
 model: sonnet
 color: yellow
 ---
@@ -105,6 +84,29 @@ PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with 
 ```
 
 `STATUS: AUTHORED` carries a complete `ISSUE_BODY` that clears all five criteria. `STATUS: PRODUCT_GAP` carries the `PRODUCT_GAP` object and no fabricated body — you park the gap, you never invent scope to fill it. `LABELS` omits the `risk:*` label when you are not confident of the risk level.
+
+## Examples
+
+<example>
+Context: /milestone-feeder:plan dispatched the architect, which returned candidate #A (logic, light): "add CSV export to the contacts list", grounded in the project docs' export-format convention and the existing ContactsListService pattern. No edge touches #A.
+user: "Author issue #A to the §4 output contract."
+assistant: "Dispatching issue-author for candidate #A to author its full §4 spec — recording the export-format convention from your project docs, enumerating happy/empty/error/disabled acceptance criteria, declaring no dependencies, classifying logic/light."
+<commentary>A clean logic issue records every design call against a stated convention (a Convention followed: line citing the project docs or file:line), enumerates the happy path AND the empty, error, and disabled states — not just the happy path — and declares no edges because the architect emitted none. STATUS: AUTHORED.</commentary>
+</example>
+
+<example>
+Context: The architect flagged candidate #B (ui, heavy): "add a prayer-list screen with a delete action". The brief and your project docs point at ConfirmImportPage as the pattern to mirror. This UI issue must pre-satisfy the design-reviewer.
+user: "Author issue #B to the §4 output contract."
+assistant: "Dispatching issue-author for candidate #B to author its §4 spec — Design section names the existing pattern to mirror (ConfirmImportPage at file:line), the required states (empty/loading/error), the confirm affordance for the destructive delete, and accessibility labels for the interactive elements."
+<commentary>A UI issue carries exactly what the design-reviewer checks: a concrete existing pattern to mirror at file:line, the required states, the destructive-action confirm affordance, and accessibility labels — so it clears the design lens before any code is written. STATUS: AUTHORED, Surface: ui.</commentary>
+</example>
+
+<example>
+Context: Candidate #B references a SyncStatusViewModel type that candidate #A introduces. The architect already emitted the edge "#B depends_on #A".
+user: "Author issue #B to the §4 output contract."
+assistant: "Dispatching issue-author for candidate #B to author its §4 spec — recording the architect's edge as 'Depends on #A — references SyncStatusViewModel, introduced by #A' in the Dependencies section, without reordering the Waves."
+<commentary>The issue-author records the architect's edge verbatim with the exact reference; it does NOT invent a new edge and does NOT reorder the Waves — the architect owns the dependency graph and the topological sort. The author transcribes the edge into the §4 Dependencies section.</commentary>
+</example>
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 

--- a/agents/roadmap-splitter.md
+++ b/agents/roadmap-splitter.md
@@ -1,28 +1,7 @@
 ---
 name: roadmap-splitter
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:build-roadmap skill ONCE per run to turn a whole-app brief + your project's standing docs into a PROPOSED, SEQUENCED set of milestones — before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the split, but never writes code, opens no issues/milestones/PRs, and never invents PRODUCT scope. Returns a structured ROADMAP block — one entry per proposed milestone IN BUILD ORDER, each carrying a name, the brief slice it owns, its 1-based build-order position, and a plain-English change-rationale vs the author's section headings. It supersedes the architect's passive `SCOPE_SPANS_MULTIPLE_MILESTONES` advisory (`agents/architect.md` clause 7) with a real, ordered split (the full multi-milestone support deferred in `docs/specs/v0.3.1-driver-handoff.md` §5). Stack-agnostic; the project docs and profile carry the stack. Examples:
-
-  <example>
-  Context: /milestone-feeder:build-roadmap has read a whole-app brief ("build a contacts module: import from CSV, a searchable list, and a sync engine") plus your project's standing docs under projectDocs. The brief reads as three distinct phased deliverables that cross release boundaries — import must land before the list can show imported rows, and sync builds on both.
-  user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
-  assistant: "Dispatching roadmap-splitter once to turn the whole-app brief + project docs into a proposed, sequenced set of milestones in build order before any GitHub write."
-  <commentary>A multi-milestone brief returns a ROADMAP of two or more entries IN BUILD ORDER, each with a name, the brief slice it owns, its 1-based position, and a change-rationale vs the author's headings. The split is a strict partition of the brief's in-scope — every part in exactly one milestone, none dropped or duplicated.</commentary>
-  </example>
-
-  <example>
-  Context: /milestone-feeder:build-roadmap has read a brief ("add CSV export to the contacts list") that is a single coherent release — one feature, no release boundary inside it.
-  user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
-  assistant: "Dispatching roadmap-splitter once to turn the brief + project docs into a proposed roadmap before any GitHub write."
-  <commentary>A single coherent release returns a SINGLE-entry ROADMAP — the whole brief in one bucket at position 1 — the analog of the architect's literal `none`. The agent does not manufacture a split where the brief does not warrant one.</commentary>
-  </example>
-
-  <example>
-  Context: /milestone-feeder:build-roadmap has read a brief whose author wrote five section headings, one of which ("tidy the settings copy") is a trivial one-line change and another of which ("the sync engine") is plainly oversized — a release on its own. The brief also lists "offline cache" after "sync", but the cache is a prerequisite of sync.
-  user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
-  assistant: "Dispatching roadmap-splitter once to turn the brief + project docs into a proposed roadmap before any GitHub write."
-  <commentary>The hybrid grouping rule seeds milestone boundaries from the author's headings, then refines: the trivial section is MERGED into a neighbour, the oversized section is SPLIT, and the cache is REORDERED before sync. Each change is recorded in that milestone's rationale; a heading that maps 1:1 records "unchanged" explicitly. Not purely author-driven, not a from-scratch regroup.</commentary>
-  </example>
+  Dispatched by milestone-feeder's /milestone-feeder:build-roadmap skill ONCE per run to turn a whole-app brief plus your project's standing docs into a PROPOSED, SEQUENCED set of milestones — before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the split, but never writes code and opens no issues/milestones/PRs, returning a structured ROADMAP block — one entry per proposed milestone IN BUILD ORDER, each carrying a name, the brief slice it owns, its 1-based build-order position, and a plain-English change-rationale vs the author's section headings. It never invents PRODUCT scope — it only partitions what the brief already contains, and an undecided product call rides into its milestone's slice, parked later, never guessed.
 model: opus
 color: green
 ---
@@ -93,6 +72,29 @@ parent_intro: <a short intro paragraph for the future md-epic parent issue's
 ```
 
 The ROADMAP is a strict partition of the brief's in-scope: every part of the brief is assigned to exactly one milestone, the `position` values run 1..N with no gaps or repeats, and each entry's `rationale` records its relationship to the author's headings (merged / split / reordered / unchanged). A **single entry at `position: 1`** is the single-coherent-release form; **two or more** entries are the multi-milestone split. `parent_title` and `parent_intro` ride alongside the ROADMAP list as their own top-level fields, returned only when the split is multi-milestone (two or more entries); the single-entry form omits both entirely, not blank.
+
+## Examples
+
+<example>
+Context: /milestone-feeder:build-roadmap has read a whole-app brief ("build a contacts module: import from CSV, a searchable list, and a sync engine") plus your project's standing docs under projectDocs. The brief reads as three distinct phased deliverables that cross release boundaries — import must land before the list can show imported rows, and sync builds on both.
+user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
+assistant: "Dispatching roadmap-splitter once to turn the whole-app brief + project docs into a proposed, sequenced set of milestones in build order before any GitHub write."
+<commentary>A multi-milestone brief returns a ROADMAP of two or more entries IN BUILD ORDER, each with a name, the brief slice it owns, its 1-based position, and a change-rationale vs the author's headings. The split is a strict partition of the brief's in-scope — every part in exactly one milestone, none dropped or duplicated.</commentary>
+</example>
+
+<example>
+Context: /milestone-feeder:build-roadmap has read a brief ("add CSV export to the contacts list") that is a single coherent release — one feature, no release boundary inside it.
+user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
+assistant: "Dispatching roadmap-splitter once to turn the brief + project docs into a proposed roadmap before any GitHub write."
+<commentary>A single coherent release returns a SINGLE-entry ROADMAP — the whole brief in one bucket at position 1 — the analog of the architect's literal `none`. The agent does not manufacture a split where the brief does not warrant one.</commentary>
+</example>
+
+<example>
+Context: /milestone-feeder:build-roadmap has read a brief whose author wrote five section headings, one of which ("tidy the settings copy") is a trivial one-line change and another of which ("the sync engine") is plainly oversized — a release on its own. The brief also lists "offline cache" after "sync", but the cache is a prerequisite of sync.
+user: "Split this whole-app brief into a proposed, sequenced milestone roadmap."
+assistant: "Dispatching roadmap-splitter once to turn the brief + project docs into a proposed roadmap before any GitHub write."
+<commentary>The hybrid grouping rule seeds milestone boundaries from the author's headings, then refines: the trivial section is MERGED into a neighbour, the oversized section is SPLIT, and the cache is REORDERED before sync. Each change is recorded in that milestone's rationale; a heading that maps 1:1 records "unchanged" explicitly. Not purely author-driven, not a from-scratch regroup.</commentary>
+</example>
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 


### PR DESCRIPTION
Fixes #263. Frontmatter descriptions 508/470/517 → 98/106/116 words (320 combined, ≤400 ceiling); all 9 worked examples relocated byte-identically into ## Examples body sections (architect's PRODUCT_GAPS example verbatim per the recorded decision — relocation, not deletion). Anti-invention safeguards untouched. Matches the driver repo's established short-description + body-examples convention.

## Decision Log
- Per Ken's decision: dispatch is config-keyed by name (plan/SKILL.md:121), so description tokens carry no dispatch-matching value — pure session-load savings.
- risk:light verification: full-diff review + byte-identical extraction proofs + vocabulary gate + plugin-structure validator; subagent scenario harness judged disproportionate for a pure text relocation (flagged, not silently skipped).

## Code Review
- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at consolidated-high effort (description accuracy vs body, relocation integrity re-verified independently, YAML validity, stale-consumer grep — all clean; convention precedent confirmed against milestone-driver's agents)
- No park-triggering findings.
- version-bump: no change needed — plugin.json already at milestone target 0.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)