### PR TITLE
docs: v0.11.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.11.2 — implied-surfaces and scenario-harness fixes
+
+**Theme:** Gaps surfaced by the first real installed-plugin run of the scenario harness (item 4a, 2026-07-06): one implied-surfaces design call plus two test-harness fixes.
+
+### ✨ Scenario-harness hardening
+
+| Issue | PR | What |
+|---|---|---|
+| #285 scenario 12: the implied-surfaces control assertion (no-capability slice) is never exercised | #289 | Creates `tests/scenarios/12b-implied-surfaces-control/` — a capability-free control sibling to scenario 12; its grader-only expectations assert zero `implied`-disposition candidates, no `[implied …]` marker, and no anti-fixation prompt string. |
+| #286 scenario harness: enforce blind-runner isolation (expected.md is readable from the runner path) | #290 | Renames the grader answer key `expected.md` → `expected.grader.md` in all 11 scenario dirs, defines the runner input set explicitly as {`brief.md`, `project/`, `feeder-env.md`}, and records a neutral runner-brief template — a blind runner can no longer ground on the answer key by accident (the recorded Option C decision). |
+
+### 🔧 Fixes
+
+| Issue | PR | What |
+|---|---|---|
+| #284 implied-surfaces: mark [implied] or absorb companions that already exist as app-wide infra? (DECISION) | #288 | Records the human decision in architect clause 8: the architect marks EVERY conventional companion surface `disposition: implied` — net-new and reused-existing-infra alike. The first scenario-12 run graded PARTIAL because reused-infra companions were absorbed as grounded rather than marked. |
+
+### Consumer notes (upgrading from v0.11.1)
+
+- **Architect behavior change:** companion surfaces that reuse existing app-wide infra are now marked `[implied]` in candidate issues instead of being silently absorbed as grounded — you'll see the marker on more candidates when planning briefs that touch conventional companions (logs, retries, audit trails).
+- **Test-harness only:** the `expected.md` → `expected.grader.md` rename and the 12b control fixture affect only the in-repo scenario harness; nothing changes for consumers who don't run it.
+- **No schema changes** to `.milestone-config/feeder.json`.
+
+### ⚖️ Post-run audit trail
+
+Judgment-call PRs for this release: none
+
 ## v0.11.1: audit remediation — re-trims, honest harness, size budgets
 
 Patch release — the audit-remediation milestone (10 issues, all merged CI-green).


### PR DESCRIPTION
## CHANGELOG preview

Adds the `## v0.11.2 — implied-surfaces and scenario-harness fixes` entry: theme line, ✨ Scenario-harness hardening (#285/PR #289, #286/PR #290), 🔧 Fixes (#284/PR #288), consumer notes (architect clause-8 behavior change; test-harness-only rename; no feeder.json schema changes), and an empty judgment-call audit trail.

---

_This entry doubles as the GitHub-release body for the human release step._

## Code Review

Doc-only CHANGELOG entry authored by the solve-milestone run's step 6 (clean-completion path). No code changed; content is grounded in the merged PRs #288/#289/#290 and the milestone description. No findings.