### PR TITLE
chore: opt in to parallel builds with 8-worker cap in driver profile

### DIFF
--- a/.milestone-config/driver.json
+++ b/.milestone-config/driver.json
@@ -7,5 +7,7 @@
   "nonNegotiables": [
     "Claude Code plugin: markdown skills + bash-first/pwsh-fallback hooks",
     "Cross-platform: bash (jq) and PowerShell 7+"
-  ]
+  ],
+  "parallel": true,
+  "maxParallelWorkers": 8
 }


### PR DESCRIPTION
Adds the operator's parallel-execution preferences to the driver profile: `parallel: true` (explicit opt-in — skips the run-start DB-hazard interview in any future config where `unitTestCmd` is set) and `maxParallelWorkers: 8` (raises the per-Wave concurrent-worker cap from the default 4).

Config-only change to `.milestone-config/driver.json`; no source, no skills, no hooks.

## Code Review

Config-only 2-line JSON edit; /code-review waived by the operator for this change ("no code-review needed"). Values validated against docs/profile-schema.md: `parallel` boolean, `maxParallelWorkers` integer ≥ 1.