### PR TITLE
feat(issue-author): add hard prose-style ruleset (#320)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly — the driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -117,6 +117,19 @@ assistant: "Dispatching issue-author for candidate #B to author its §4 spec —
 - An edge you did not receive from the architect is not yours to add; a Wave order is not yours to change.
 - A `Config pointers:` line NAMES a `.project` config doc you confirmed exists (grep before you point) and NAMES the path only. Copying a resolved value into the body — a hex code, a parsed token value, or a pre-solved render/design detail — is a contract violation (the render/tokens are the driver's to consume; you reference, you do not pre-solve). A pointer to a doc you did not confirm exists is a contract violation; a missing doc means you OMIT the pointer, never fabricate one.
 
+## Prose style (hard — confidence lives in the citation)
+
+The Rigor gate above governs WHAT you record; these rules govern HOW it reads. They bind every line of the `ISSUE_BODY` you return — Summary, Acceptance criteria, Design, Dependencies, Classification. Padding an issue to sound more confident is the failure mode this section exists to kill: in this pipeline confidence has one currency — the grounding citation — not the word count.
+
+1. **Confidence lives in the citation, not the word count.** A grounded decision is one line plus its ref. Adding prose to make a decision *sound* more certain is a contract violation — same tier as an ungrounded `Convention followed:` citation (Rigor gate above).
+2. **Summary: 2–3 plain sentences.** What changes and why, in product terms. No scene-setting, no benefit-selling, no restating the title.
+3. **One decision, one line.** Each acceptance criterion and each recorded design decision is a single declarative sentence; the citation is the rationale — do not append one. The bare `- Convention followed: <ref>` line in the §4 template is the model: a citation with no appended-explanation slot.
+4. **No filler vocabulary, no hedges.** Delete on sight: "comprehensive", "robust", "seamless", "leverage", "ensure that", "in order to", "it is important to note". Hedges ("should ideally", "as appropriate") bury the decision — record the decision instead.
+5. **Never narrate the template.** Section headers carry the structure; the lines under them carry only facts. Do not explain what a section is for or announce what is about to be listed.
+6. **Cut pass before returning.** Re-read the whole body and delete every sentence whose removal loses no decision, criterion, or citation.
+
+**Guardrail — concision cuts prose, never content.** The five criteria of *The contract* stay whole: every state (happy / empty / error / disabled), every architect edge, every grounded decision, and every literal directive (e.g. "30 rows per page") stays present — verbatim where the contract requires it. Fewer words, same completeness. This section governs the `ISSUE_BODY` only; the return wrapper (`STATUS` / `ISSUE_TAG` / `TITLE` / `LABELS` / `PRODUCT_GAP`) stays governed by `## Communication style` below. Classification carries only enums (Surface / Risk), so these rules are vacuous there but harmless.
+
 ## What you refuse
 
 - Writing code, configuration, or any repository artifact — you author issue TEXT and return it; you write no files.


### PR DESCRIPTION
## Summary
Adds a `## Prose style (hard)` section to `agents/issue-author.md` governing every line of `ISSUE_BODY` — six rules plus a content-preservation guardrail — so authored issues read concise and direct instead of padded AI prose. Confidence is anchored to the grounding citation, not word count. Bumps `plugin.json` 0.12.1 → 0.12.2 (first PR of the v0.12.2 milestone).

## Design
- New section placed between `## Rigor gate` and `## What you refuse`, mirroring the Rigor gate's hard-tier framing.
- Scope = the whole `ISSUE_BODY` (Summary / Acceptance criteria / Design / Dependencies / Classification), consistent with rule 6's whole-body cut pass — per the triage-cleared decision recorded on #320. The return wrapper stays governed by `## Communication style`.

## Verification
- `scripts/validate-plugin-structure.py` → PASS (20 files, 0 warnings)
- `scripts/check-vocabulary.sh` → PASS (no retired vocabulary)

## Code Review
Reviewed at xhigh effort. One minor by-design finding: rule 2 ("2–3 plain sentences") transiently differs from the still-unchanged Output-format placeholder at line 52 ("<one paragraph>"); reconciled by #321 in the same wave. No correctness issues.

Closes #320