### PR TITLE
docs(issue-author): tighten §4 Summary placeholder to '2-3 plain sentences' (#321)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -175,7 +175,7 @@ Maps 1:1 to the five criteria the driver's triage checks. The issue-author guara
 
 ```markdown
 ## Summary
-<one paragraph: what changes and why, in product terms>
+<2-3 plain sentences: what changes and why, in product terms>
 
 ## Acceptance criteria
 - [ ] <happy path, observable>

--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -49,7 +49,7 @@ The `ISSUE_BODY` you author reproduces the §4 issue-body template verbatim:
 
 ```markdown
 ## Summary
-<one paragraph: what changes and why, in product terms>
+<2-3 plain sentences: what changes and why, in product terms>
 
 ## Acceptance criteria
 - [ ] <happy path, observable>


### PR DESCRIPTION
## Summary
Tightens the §4 issue-body Summary placeholder from `<one paragraph: ...>` to `<2-3 plain sentences: ...>` in both must-not-drift copies — `agents/issue-author.md:52` and `SPEC.md:178` — in one commit, so they stay in sync. Reconciles the placeholder with the prose-style rule 2 introduced by #320.

## Acceptance criteria — verified
- Both copies read the new wording; trailing "what changes and why, in product terms" preserved.
- Both edits in one PR (no drift).
- Repo-wide search for the old wording → 0 matches.
- `skills/plan/SKILL.md:90` (plan-file `goal` placeholder, "what to build") left byte-for-byte unchanged — different field, out of scope.

## Verification
- `scripts/validate-plugin-structure.py` → PASS
- `scripts/check-vocabulary.sh` → PASS

## Code Review
Reviewed at xhigh effort. No correctness issues; one cosmetic dash-style nit (placeholder "2-3" hyphen vs rule 2 "2–3" en-dash) matching the issue's literal AC.

Closes #321