### PR TITLE
chore: ignore per-developer .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ desktop.ini
 *.swp
 *~
 
+# Per-developer Claude Code settings. A project-level .claude/settings.json (shared,
+# repo-relative permissions) stays trackable; settings.local.json is per-clone and
+# routinely holds machine-absolute paths — never commit it.
+.claude/settings.local.json
+
 # Python bytecode cache from the CI gate scripts under scripts/
 __pycache__/
 *.pyc


### PR DESCRIPTION
## What

Adds `.claude/settings.local.json` to `.gitignore`.

## Why

Until now this file was ignored only via a machine-global `core.excludesFile` on one developer's box. Any other clone would have seen it as untracked and committable — and it routinely holds machine-absolute paths (usernames, version-pinned plugin cache paths).

Found while cleaning up an uncommitted `.claude/settings.json` in `milestone-designer` that had exactly that kind of path in it. The hole was suite-wide, so this is one of four companion PRs (designer / driver / feeder / suite).

## Scope

Scoped to `settings.local.json` only. A project-level `.claude/settings.json` holds shared repo-relative permissions and stays trackable — verified with `git check-ignore` that this rule does not catch it.
