### PR TITLE
chore: sync .milestone-config/.gitignore with the current driver scratch set

### DIFF
--- a/.milestone-config/.gitignore
+++ b/.milestone-config/.gitignore
@@ -7,6 +7,8 @@ trello-notice
 visualcapture-notice
 parallel-default-notice
 code-review-gate-notice
+aiprefilter-notice
+cost-record-notice
 triage-cache.json
 tests-stamp
 .runtime/


### PR DESCRIPTION
## Summary

The committed `.milestone-config/.gitignore` block had drifted behind the milestone-driver plugin's KEEP-IN-SYNC source. Two newer per-clone scratch markers were missing, so `cost-record-notice` showed as untracked in `git status` on every driver run.

Adds the two missing entries:

- `aiprefilter-notice`
- `cost-record-notice`

Tracked config (`driver.json`, `feeder.json`) stays unlisted and therefore tracked — no blanket rule added.

## Provenance

Surfaced during a `/milestone-driver:solve-milestone 25` preflight, where the untracked marker would otherwise have failed the clean-tree check.