### PR TITLE
docs(readme): the suite carries five plugins, not four (#323)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly — the driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ milestone-feeder is a Claude Code plugin. You hand it a brief — a file, a few 
 
 **Before you install, add `superpowers` first.** milestone-feeder needs the `superpowers` plugin to plan — it is a required prerequisite you now install yourself (it is no longer pulled in automatically). Add the `claude-plugins-official` marketplace and install `superpowers` from it, then install milestone-feeder from one of the marketplaces below, then restart Claude Code so the plugin's hook loads. Skip `superpowers` and the planning commands won't work.
 
-**Recommended — the milestone-suite marketplace.** One marketplace carries all four milestone plugins (`milestone-bootstrapper`, `milestone-feeder`, `milestone-driver`, `milestone-coherence-reviewer`), so you add it once and install whichever you want:
+**Recommended — the milestone-suite marketplace.** One marketplace carries all five milestone plugins (`milestone-bootstrapper`, `milestone-designer`, `milestone-feeder`, `milestone-driver`, `milestone-coherence-reviewer`), so you add it once and install whichever you want:
 
 ```
 /plugin marketplace add kenmulford/milestone-suite


### PR DESCRIPTION
Closes #323.

`README.md:11` advertised the milestone-suite marketplace as carrying **"all four"** milestone plugins and listed four. `milestone-designer` shipped as the pre-plan design phase ([milestone-suite#55](https://github.com/kenmulford/milestone-suite/pull/55), merged to `develop`), making both the count and the roster stale.

This updates the count to **"all five"** and inserts `milestone-designer` into the list in pipeline order (bootstrapper → designer → feeder → driver → coherence-reviewer).

```diff
-**Recommended — the milestone-suite marketplace.** One marketplace carries all four milestone plugins (`milestone-bootstrapper`, `milestone-feeder`, `milestone-driver`, `milestone-coherence-reviewer`), so you add it once and install whichever you want:
+**Recommended — the milestone-suite marketplace.** One marketplace carries all five milestone plugins (`milestone-bootstrapper`, `milestone-designer`, `milestone-feeder`, `milestone-driver`, `milestone-coherence-reviewer`), so you add it once and install whichever you want:
```

Plus the milestone version bump to `0.12.3`. Diff is 2 files / 2 insertions / 2 deletions.

## Scope held

Per the issue's recorded non-goals:

- The install command block below line 11 installs only `milestone-feeder` as a **representative example** and is deliberately unchanged.
- Mentioning the designer→feeder spec handoff in the feeder's prose or mermaid diagram is an explicitly **separate, optional** enhancement — not done here.
- `CHANGELOG.md:480` ("all three milestone plugins") is a dated historical entry (#77); CHANGELOG is append-only history and stays as written.

## Decision Log

| Decision | Rationale | Alternative rejected |
|---|---|---|
| Edited via a substring anchored on the plugin list, not the whole line | The line carries an em dash (U+2014) and backtick code spans; matching the shortest unique span minimizes whitespace/encoding mismatch risk while still being unique in the file | Rewriting the whole line via a full-file write — would risk disturbing the other 156 lines and the file's encoding |
| Inserted `milestone-designer` in **second** position | The issue specifies pipeline order and the pre-existing list was already in pipeline order, so second position is the only placement preserving the line's existing convention | Appending to the end of the list — would break the established ordering |
| Left the install command block (lines 13–16) unchanged | Recorded non-goal: it installs only `milestone-feeder` as a representative example and is correct as written | Expanding it to install all five plugins — explicit scope violation |
| Left `CHANGELOG.md:480` unchanged | Dated historical entry describing a past release state; append-only history | Retroactively editing history to say "five" — would falsify the record |
| Did **not** touch `README.md:7` prose or `.project/environment.md:30` sibling-plugin lists | Neither states a *count* nor claims to be the suite roster; both fall inside the recorded non-goal deferring designer→feeder handoff prose to a separate enhancement | Broadening scope to mention the handoff — explicitly deferred by the issue |
| Proceeded past the local commit gate after the version bump | The only change since `/code-review` was the single `plugin.json` version string — a config edit outside `sourceGlobs`. solve-issue documents this exact carve-out: a version bump needs no `/code-review` re-run and no test re-run. Recorded as a judgment call rather than stranding an autonomous run | Re-running a full `/code-review` for a one-character version delta — no new information, pure cost |

## Verification

No test layer in this repo (`unitTestCmd` absent from the profile), so verification is direct inspection:

| Check | Result |
|---|---|
| Resulting line byte-exact to the issue's required text | ✅ exact match; em dash preserved as U+2014; 10 backticks balanced across 5 code spans |
| Diff confined to the intended files/lines | ✅ `README.md` one line + `plugin.json` version only |
| Count matches entries listed | ✅ "five" = 5 backticked entries |
| No other current-state roster/count contradicted | ✅ repo-wide sweep found none |
| Encoding / line endings / trailing whitespace | ✅ `git diff --check` clean; README length unchanged at 157 lines |

Gates: unit, E2E, and preflight all **skip cleanly** — `unitTestCmd`, `e2eTestCmd`, and `preflightCmd` are all absent from `.milestone-config/driver.json`. Non-UI issue (`uiSurfaceGlobs` absent), so no visual-review gate applies.

**Coherence review:** `FINDINGS: none` — clean fit. It independently confirmed no `sourceGlobs` file references the plugin roster or count.

## Code Review

- /code-review run: yes (omission is a park trigger — a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope finding(s) at medium effort
  - none
- No park-triggering findings.

Reviewer verdict: **Ready to merge: Yes** — "the resulting line is a byte-exact match to the specified target text with correct pipeline ordering, balanced markdown, and intact UTF-8 em dash; the diff is confined to exactly the one file and one line, with no encoding or line-ending collateral."

Version bump annotation: **version-bump only — no logic change** (`0.12.2` → `0.12.3`, the milestone target).
