### PR TITLE
docs: v0.13.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.13.0 — citation anchors
+
+**Theme:** Every citation the feeder authors was pinned to a line number, so any edit above the cited line silently invalidated it. The feeder now offers the content-anchored `path (anchor)` form at every grounding slot it writes, adopting the definition milestone-driver shipped rather than re-deriving it.
+
+### ✨ Citation anchors
+
+| Issue | PR | What |
+|---|---|---|
+| #344 Add the `path (anchor)` citation form to the §4 Design-block grounding slots | #350 | The `Convention followed:` and `Layer:` slots in `SPEC.md` and `agents/issue-author.md` gain the anchor form, as one shared clause byte-identical at all four sites |
+| #345 Offer the anchor form in the plan file's design-call grounding line | #349 | The Plan-file output template's grounding bullet gains `sibling path (anchor)`, with the preference stated in the field table above the fence so it cannot render into a generated plan file |
+| #346 Recognize `path (anchor)` citations as file-map seeds | #351 | The file-map's seed rule, fallback gate, and ordering rule recognize both forms, so an anchor-only candidate no longer falls through to a keyword scan |
+| #347 Add the `path (anchor)` form to issue-author's pattern-to-mirror slot and rigor gate | #352 | Both accept the anchor, held to the same grep-verified standard as `file:line`, and the gate now requires the whole reference to sit inside one code span |
+| #348 Offer the anchor form in the architect's sketch slot, dependency edges, and citation rigor gate | #353 | Seven grounding sites in `agents/architect.md` gain the form, with the rules stated once at the Rigor gate |
+
+### Consumer notes (upgrading from v0.12.3)
+
+- **No schema changes** to `.milestone-config/feeder.json` or `.milestone-config/driver.json`. No new config key, no changed default, and no consumer action required.
+- **Nothing already written migrates.** `path:line` and `path:start-end` remain fully valid, not a legacy tolerance, and no slot requires an anchor. A newly written line citation is correct, not a lapse.
+- Where a heading exists, a heading form (`path#Heading`, `path § Heading`) remains the form to write. The anchor form is preferred only where the cited region will outlive the line number it sits on today.
+- A citation never combines an anchor with a line number in one reference.
+- **A citation only counts inside a code span.** The span opens before the path and closes after the final `)`, and the reference must also stand in a citation position. The same words written bare read as a file name plus a parenthetical aside, resolve to nothing, and warn no one.
+- The forms are defined once, in milestone-driver's `skills/citation-format.md` (shipped v1.19.0). This repo cites that file and restates none of it.
+- The discovery path is the updated templates and agent contracts themselves: the next `plan` run surfaces the new form in the artifact you already review.
+
+### ⚖️ Post-run audit trail
+
+Judgment-call PRs for this release: none
+
+Two follow-ups recorded during the run, neither blocking:
+
+- `agents/roadmap-splitter.md` is the one authoring agent no issue in this milestone touched. Its grounding slots still name `file:line` only, and `docs/style-contracts.md:72` still pins it with bare `` `:31` `` / `` `:46` `` line references.
+- milestone-driver's `skills/citation-format.md` does not cover the **same-file** case. A `path (anchor)` citation written into the file it points at reproduces its own anchor, so it can never resolve cleanly; and when the citing line precedes its target, the citing line becomes the resolved answer. `agents/architect.md:163` keeps bare line pins for this reason.
+
 ## v0.12.3 — consumer issue templates & prose-style reach
 
 **Theme:** The feeder writes issues into other people's repos, so it now authors to *their* `.github/ISSUE_TEMPLATE/` convention instead of imposing its own structure. Alongside it, v0.12.2's prose ruleset grows past the one agent and one field it originally bound.


### PR DESCRIPTION
## CHANGELOG preview

## v0.13.0 — citation anchors

**Theme:** Every citation the feeder authors was pinned to a line number, so any edit above the cited line silently invalidated it. The feeder now offers the content-anchored `path (anchor)` form at every grounding slot it writes, adopting the definition milestone-driver shipped rather than re-deriving it.

### ✨ Citation anchors

| Issue | PR | What |
|---|---|---|
| #344 §4 Design-block grounding slots | #350 | `Convention followed:` and `Layer:` in `SPEC.md` and `agents/issue-author.md`, as one shared clause byte-identical at all four sites |
| #345 Plan file's design-call grounding line | #349 | The grounding bullet gains `sibling path (anchor)`, preference stated in the field table above the fence so it cannot render into a plan file |
| #346 File-map seeds | #351 | Seed rule, fallback gate, and ordering recognize both forms, so an anchor-only candidate no longer falls through to a keyword scan |
| #347 Issue-author pattern-to-mirror slot and rigor gate | #352 | Both accept the anchor at the same grep-verified standard as `file:line`; the gate now requires the reference to sit inside one code span |
| #348 Architect sketch slot, dependency edges, rigor gate | #353 | Seven grounding sites in `agents/architect.md`, rules stated once at the Rigor gate |

### Consumer notes (upgrading from v0.12.3)

- **No schema changes.** No new config key, no changed default, no consumer action required.
- **Nothing already written migrates.** `path:line` and `path:start-end` stay fully valid, not a legacy tolerance; no slot requires an anchor.
- Heading forms remain the form to write where a heading exists. The anchor is preferred only where the cited region will outlive its current line.
- A citation never mixes an anchor with a line number, and **only counts inside a code span** that also stands in a citation position.
- The forms are defined once, in milestone-driver's `skills/citation-format.md` (v1.19.0); this repo cites it and restates none of it.

### ⚖️ Post-run audit trail

Judgment-call PRs for this release: none

Two follow-ups recorded, neither blocking: `agents/roadmap-splitter.md` was touched by no issue in this milestone and still names `file:line` only; and the driver's citation format does not cover the same-file case, where a citation reproduces its own anchor and can never resolve cleanly.

## Code Review

Doc-only release notes, authored by the orchestrator at the end of the run. **No reviewer was dispatched for this PR**, and no finding count is claimed.

Evidence: the entry is assembled from the five merged PRs' own reviewed content, and every claim in it traces to a verification already run and recorded in #349, #350, #351, #352, or #353. Both required CI gates run on this PR as its check.

| Item | Evidence |
|---|---|
| Issue-to-PR mapping | #344→#350, #345→#349, #346→#351, #347→#352, #348→#353, each squash-merged to `develop` and its issue explicitly closed |
| "No schema changes" | No issue in the milestone touched `.milestone-config/`; verified across all five merged diffs |
| "Judgment-call PRs: none" | No PR in this run's set carries the `judgment call` label |
| Both follow-ups | Recorded from review findings in #351 and #353 |

Park triggers: none. Nothing in this PR is code.

---

_This entry doubles as the GitHub-release body for the human release step._

🤖 Generated with [Claude Code](https://claude.com/claude-code)