### PR TITLE
feat(roadmap-splitter): offer the anchor form in the grounding rule (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release notes for milestone-feeder. Each tagged release is also published on the
 | #346 Recognize `path (anchor)` citations as file-map seeds | #351 | The file-map's seed rule, fallback gate, and ordering rule recognize both forms, so an anchor-only candidate no longer falls through to a keyword scan |
 | #347 Add the `path (anchor)` form to issue-author's pattern-to-mirror slot and rigor gate | #352 | Both accept the anchor, held to the same grep-verified standard as `file:line`, and the gate now requires the whole reference to sit inside one code span |
 | #348 Offer the anchor form in the architect's sketch slot, dependency edges, and citation rigor gate | #353 | Seven grounding sites in `agents/architect.md` gain the form, with the rules stated once at the Rigor gate |
+| #355 Offer the anchor form in the roadmap-splitter's grounding rule | #356 | The one authoring agent the milestone had not reached; also corrects an off-by-one line pin in `docs/style-contracts.md` |
 
 ### Consumer notes (upgrading from v0.12.3)
 
@@ -33,7 +34,6 @@ Judgment-call PRs for this release: none
 
 Two follow-ups recorded during the run, neither blocking:
 
-- `agents/roadmap-splitter.md` is the one authoring agent no issue in this milestone touched. Its grounding slots still name `file:line` only, and `docs/style-contracts.md:72` still pins it with bare `` `:31` `` / `` `:46` `` line references.
 - milestone-driver's `skills/citation-format.md` does not cover the **same-file** case. A `path (anchor)` citation written into the file it points at reproduces its own anchor, so it can never resolve cleanly; and when the citing line precedes its target, the citing line becomes the resolved answer. `agents/architect.md:163` keeps bare line pins for this reason.
 
 ## v0.12.3 — consumer issue templates & prose-style reach

--- a/agents/roadmap-splitter.md
+++ b/agents/roadmap-splitter.md
@@ -98,7 +98,7 @@ assistant: "Dispatching roadmap-splitter once to turn the brief + project docs i
 
 ## Rigor gate (hard — this enforces the seniority, not the title)
 
-Every milestone boundary and every ordering decision **is grounded** — in the brief's own structure, a `.project/<doc>.md#<section>` layering/convention ref, or a sibling `file:line` read in the repo. No exceptions.
+Every milestone boundary and every ordering decision **is grounded** — in the brief's own structure, a `.project/<doc>.md#<section>` layering/convention ref, or a sibling `path (anchor)` or `file:line` read in the repo. No exceptions. Both sibling forms are defined in `milestone-driver/skills/citation-format.md`. Prefer `path (anchor)` when the region you cite will outlive the line it sits on today; it is never required, so a `file:line` ref stays a correct choice, not a legacy one.
 
 - A `position` (build-order) edge cites the **actual dependency** that forces it — the artifact, layer, or capability one milestone introduces and a later one consumes. An order you cannot ground in a real dependency is author order, not a reorder — do not assert a reorder you cannot ground.
 - A **merge** or **split** cites why: a section too trivial to be its own release (merge), or a section that is plainly several releases (split). "Feels cleaner" is not a reason.

--- a/docs/style-contracts.md
+++ b/docs/style-contracts.md
@@ -69,7 +69,7 @@ enum structure (that is [`## Communication style`](#communication-style)).
 |---|---|---|
 | `agents/issue-author.md` | The whole `ISSUE_BODY`. | The return wrapper (`STATUS` / `ISSUE_TAG` / `TITLE` / `LABELS` / `PRODUCT_GAP`). |
 | `agents/architect.md` | `sketch` (`agents/architect.md (sketch: <one or two lines)`), the `EDGES` `<reason>` slot (`agents/architect.md (<reason / the exact artifact reference>)`). | `title`, `surface`, `risk`, `layer` — one-liners and enums. |
-| `agents/roadmap-splitter.md` | `parent_title`, `parent_intro`, `rationale` (clause 4, `:31`). | `milestone`, `position` — an identifier and an integer; `brief_slice` (`:46`) — the author's own brief text, quoted or closely paraphrased. |
+| `agents/roadmap-splitter.md` | `parent_title`, `parent_intro`, `rationale` (clause 4, `agents/roadmap-splitter.md (**4. Every change recorded in the rationale.**)`). | `milestone`, `position` — an identifier and an integer; `brief_slice` (`agents/roadmap-splitter.md (brief_slice: <the portion of the brief this milestone owns)`) — the author's own brief text, quoted or closely paraphrased. |
 
 Each agent cites the definition from its own `## Prose style` section rather
 than carrying a copy of the rules.


### PR DESCRIPTION
Closes #355

## Summary

`agents/roadmap-splitter.md` was the one authoring agent v0.13.0 did not reach. Its rigor-gate grounding line (`:101`) named only a project-docs ref and a sibling `file:line`; it now names `path (anchor)` beside them, reusing the wording already shipped at `agents/architect.md:144` so the two gates read as one rule rather than two paraphrases.

`docs/style-contracts.md:72`'s two bare pins are now content-anchored.

## Decision Log

| Choice | Rationale | Citation | Rejected |
|---|---|---|---|
| Reuse `agents/architect.md:144`'s sentence near-verbatim, minus its D1/D2/D3 enumeration | This milestone's premise is one definition without drifting copies; a fresh paraphrase would be a fifth | `agents/architect.md:144`, `:29` (short-pointer shape) | New phrasing, or reproducing the full gate clause |
| `brief_slice` pin anchors `:47`, not `:46` | The row names the `brief_slice` slot, which is line 47. The bare `:46` pointed at `position: 1`, one line above, so the shipped pin was off by one | Resolver: `PRIMARY 47`, zero `MATCH` | Anchoring `position: 1`, which names a slot the row does not describe |
| No heading-precedence sentence at `:101` | The line already names `.project/<doc>.md#<section>` as its own alternative and scopes the new text to "Both sibling forms", so precedence holds structurally; adding it breaks the one-line constraint | Review confirmed | Copying architect's full clause |

## Code Review

One round, effort medium, one dedicated reviewer. **Ship. 0 Critical, 0 Important, 3 Minor, all informational.**

| Finding | Disposition |
|---|---|
| This is not a pure re-anchor: the shipped `:46` pin was an off-by-one, and the new anchor corrects a pre-existing defect | Recorded. Third live drift instance this milestone found in its own files |
| The implementer's rationale was half overstated: `'    position: 1'` **with leading whitespace** does resolve uniquely (`PRIMARY 46`, zero `MATCH`); only the bare string fans out to four hits | Accepted. The load-bearing half stands: the pin belongs on `brief_slice`, and nothing was dropped, since `position` never had a pin of its own |
| `:101` omits architect's heading-precedence sentence | Not a defect; precedence holds structurally |

Verified: `:101` one line with no D1/D2/D3 restatement; the `.project/<doc>.md#<section>` form byte-unchanged; both anchors exit 0 with a single `PRIMARY` and zero `MATCH`; row `:71` byte-identical to develop; **no bare `` `:NN` `` pins left anywhere in `docs/style-contracts.md`**; the one `milestone-driver/…` reference closes its span before the following period; line counts 130 and 75 unchanged; both gates PASS; two files; no CR, no BOM, no authored em-dash.

## Gates

- `scripts/check-vocabulary.sh` — PASS, exit 0
- `scripts/validate-plugin-structure.py` — PASS, 20 files, 0 warnings, exit 0
- No unit or E2E layer for markdown contracts; the reviewer's read is the verification pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)