### PR TITLE
feat(ci): add contract-strings gate to catch em-dash drift (#369)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
-# Two pull-request gates for the milestone-feeder plugin. Both must pass before
-# a PR into main or develop can merge. Neither builds anything — this repo is a
-# Claude Code plugin (markdown skills/agents + JSON manifests), so the gates only
-# verify the surface stays clean and loadable.
+# Three pull-request gates for the milestone-feeder plugin. All must pass
+# before a PR into main or develop can merge. Neither builds anything — this
+# repo is a Claude Code plugin (markdown skills/agents + JSON manifests), so
+# the gates only verify the surface stays clean and loadable.
 #
 #   1. vocabulary-purge gate   — fails if the retired v0.3.0 words reappear on
 #                                the live plugin surface (spec §11).
@@ -11,9 +11,13 @@ name: CI
 #                                frontmatter block is malformed, or a governed
 #                                skills/**/SKILL.md or agents/**/*.md exceeds
 #                                its size-budget ceiling (issue #270).
+#   3. contract-strings gate   — fails if the implied-surfaces marker or the
+#                                anti-fixation prompt drifts from its
+#                                canonical em-dash form (issue #369).
 #
-# The two job names below ("vocabulary-purge gate" and "plugin-structure check")
-# are the required-status-check contexts to wire in branch protection.
+# The three job names below ("vocabulary-purge gate", "plugin-structure check",
+# "contract-strings gate") are the required-status-check contexts to wire in
+# branch protection.
 #
 # Runs on pull_request only: required status checks are evaluated on PRs, so a
 # push-triggered run would gate nothing and only add noise on the protected
@@ -52,3 +56,12 @@ jobs:
           python-version: "3.x"
       - name: Validate manifests and skill/agent/command frontmatter
         run: python3 scripts/validate-plugin-structure.py
+
+  contract-strings-gate:
+    name: contract-strings gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code under review
+        uses: actions/checkout@v7
+      - name: Scan the live surface for drifted contract strings
+        run: ./scripts/check-contract-strings.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Release notes for milestone-feeder. Each tagged release is also published on the
 ### 🔧 Fixes
 
 - The em-dash sweep also swept two strings other files require byte-exact: `implied — review / trim / augment` (`agents/architect.md` clause 8's implied-surfaces marker, 3 sites) and `this is a starting set for YOUR app — what's missing?` (`SPEC.md` `### Implied companion surfaces: capability-aware completeness`, the anti-fixation prompt). Both are declared verbatim at `skills/plan/SKILL.md`, specified at `docs/plan-file-contract.md`, and asserted byte-exact by `tests/scenarios/12-implied-surfaces` and `tests/scenarios/12b-implied-surfaces-control`. Both are restored to the em dash. The `Depends on #<n> - <reason>` separator stays a hyphen: no grader asserts it.
+- New `contract-strings gate` CI job (`scripts/check-contract-strings.sh`) fails a pull request when either contract string drifts from its canonical em-dash form, scanning the tracked surface except `CHANGELOG.md` and the `tests/**/*observed-*.md` run records. Closes #369.
 
 ### Consumer notes (upgrading from v0.13.1)
 

--- a/scripts/check-contract-strings.sh
+++ b/scripts/check-contract-strings.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# check-contract-strings.sh — the contract-strings gate.
+#
+# What this checks, in plain terms:
+#   Two prompt strings are contract-declared byte-exact, em dash and all.
+#   A prose pass can quietly swap that em dash for a hyphen, en dash, colon,
+#   comma, or drop the separator entirely — the words survive, only the
+#   canonical punctuation drifts, and nothing else notices (issue #369: a
+#   prose sweep did exactly this and both existing CI gates stayed green).
+#   This script does NOT assert the strings are present anywhere — most files
+#   never mention them, and a presence-anywhere scan can't fail closed with a
+#   real file:line either way. Instead it scans the live, committed surface
+#   for DRIFTED VARIANTS of the two strings and fails the moment one turns
+#   up. A variant hit is, by construction, a real occurrence of the phrase
+#   with corrupted punctuation, so it inherently names its own file and line
+#   — no separate canonical-location table to keep in sync.
+#
+# The two contract strings (canonical form, em dash U+2014):
+#   implied — review / trim / augment
+#   this is a starting set for YOUR app — what's missing?
+#
+# Authoritative definition (do not widen without updating these anchors):
+#   Both strings are declared verbatim at skills/plan/SKILL.md ("Surface the
+#   implied-surfaces review prompt"), specified at docs/plan-file-contract.md
+#   ("Plan-file output template"), and asserted byte-exact by
+#   tests/scenarios/12-implied-surfaces/expected.grader.md and
+#   tests/scenarios/12b-implied-surfaces-control/expected.grader.md.
+#   Excluded: CHANGELOG.md (historical entries legitimately quote older
+#   forms, and the v0.13.2 entry discusses this exact drift) and the
+#   tests/**/*observed-*.md scenario run records (historical, same reason —
+#   the pathspec's leading `*` covers both the `observed-*.md` files and the
+#   `needs-product-input-observed-*.md` sibling that a plain `observed-*.md`
+#   glob would miss). Not excluded: scripts/ and .github/. Unlike
+#   scripts/check-vocabulary.sh, whose pattern is a bare literal alternation
+#   that self-matches its own source, this gate's pattern is built by
+#   shell-variable interpolation (see SEP below), so the drifted-variant
+#   regex never appears literally anywhere in this file, including this
+#   header's own canonical em-dash quotes — verified by scanning this file
+#   with no scripts/ or .github/ exclusion: zero hits.
+#
+# Why `git grep`:
+#   Same reasoning as scripts/check-vocabulary.sh: the "live surface" is
+#   exactly what is committed, `git grep` enumerates tracked files itself (no
+#   ARG_MAX ceiling, no bash `mapfile`), behaves identically on macOS and
+#   Linux, honours pathspec excludes by path reliably, and returns clean
+#   three-state exit codes (0 match / 1 no-match / >1 error) so the gate can
+#   FAIL CLOSED on a scan error instead of silently passing.
+#
+# Run it locally from the repo root:  ./scripts/check-contract-strings.sh
+# Exit 0 = clean. Exit 1 = a drifted variant found (file:line:match printed).
+# Exit 2 = the scan itself failed (treated as a failure, never as "clean").
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Match the two contract strings with anything OTHER than the canonical em
+# dash (U+2014) in the separator position: an ASCII hyphen, an en dash
+# (U+2013), a colon, a comma, or nothing at all (just whitespace). Case-
+# insensitive via -i below, same as check-vocabulary.sh.
+#
+# [[:space:]]* on both sides of an optional single-character separator group
+# means: if the separator is the em dash, the group can't consume it (it's
+# not one of the four alternatives) and the following [[:space:]]* can't
+# consume it either (it isn't whitespace) — so the canonical form can never
+# match. Any of the four drifted punctuation marks, or no punctuation mark
+# at all, matches cleanly.
+SEP='[[:space:]]*(-|–|:|,)?[[:space:]]*'
+PATTERN="implied${SEP}review / trim / augment|this is a starting set for YOUR app${SEP}what's missing\\?"
+
+# Scan tracked files minus the historical records (this gate's own machinery
+# does not need excluding — see above). Capture the exit status explicitly
+# so a grep *error* can't masquerade as a clean tree. Do not discard
+# stderr — a real failure should be visible.
+set +e
+MATCHES="$(git grep -EIinH "${PATTERN}" -- \
+  ':!:CHANGELOG.md' ':!:tests/**/*observed-*.md')"
+status=$?
+set -e
+
+case "${status}" in
+  0)
+    echo "FAIL: a contract string drifted from its canonical em-dash form." >&2
+    echo "      Canonical (em dash U+2014):" >&2
+    echo "        implied — review / trim / augment" >&2
+    echo "        this is a starting set for YOUR app — what's missing?" >&2
+    echo >&2
+    echo "${MATCHES}" >&2
+    exit 1
+    ;;
+  1)
+    echo "PASS: both contract strings are intact wherever they appear."
+    echo "      (checked: the implied-surfaces marker and anti-fixation prompt)"
+    exit 0
+    ;;
+  *)
+    echo "ERROR: 'git grep' failed (exit ${status}) — scan unreliable; failing closed." >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a third CI job, `contract-strings gate`, that fails a pull request when either of the two contract-declared strings (the implied-surfaces marker and the anti-fixation prompt) drifts from its canonical em-dash form. Neither existing gate (`vocabulary-purge gate`, `plugin-structure check`) inspects these strings, so the v0.13.2 regression where a prose sweep mutated both would have merged green without this.

Closes #369.

## What changed

- `scripts/check-contract-strings.sh` (new): scans the tracked surface with `git grep` for drifted variants (hyphen, en dash, colon, comma, or missing separator in the canonical em-dash position), excluding `CHANGELOG.md` and `tests/**/*observed-*.md`. Fails closed on a scan error.
- `.github/workflows/ci.yml`: adds `contract-strings-gate` as a third job, updates the header comment from "Two gates" to "Three gates" and lists the new required-status-check context.
- `CHANGELOG.md`: one bullet appended to the existing `## v0.13.2` entry's `### 🔧 Fixes` section.

## Decision Log

- **Variant-scan design over presence-assertion.** Most files never mention either string, so a presence-anywhere scan can't fail closed with a real `file:line` either way. Scanning for drifted variants instead means a hit is by construction a real occurrence of the phrase with corrupted punctuation, so the match inherently names its own file and line. No separate canonical-location table to keep in sync.
- **Single `tests/**/*observed-*.md` pathspec.** The leading `*` in `*observed-*.md` covers both the `observed-*.md` run records and the `needs-product-input-observed-*.md` sibling; a plain `observed-*.md` glob would miss the latter.

## Code Review

`/code-review` at medium effort ran twice. The first run targeted `git diff main...HEAD` and therefore reviewed only already-merged commits, missing this change entirely because it was uncommitted at the time; that run is not a valid review of this diff. The second run, scoped to the two files, ran the script, injected drifted variants including a lowercase-`YOUR` case, verified all excludes, and cross-checked the CI job against the two existing jobs. Findings: none.

A coherence review found one drift-small issue: the script excluded `scripts/**` and `.github/**` citing `check-vocabulary.sh`'s precedent, but that reason is false here because this script builds its pattern by shell-variable interpolation, so it never self-matches. Both excludes were removed and the header corrected; the widened scan was reverified to still pass and still catch deliberate drift.

## Test plan

- [x] `./scripts/check-contract-strings.sh` passes on a clean tree.
- [x] `./scripts/check-vocabulary.sh` passes.
- [x] `python scripts/validate-plugin-structure.py` passes.
- [ ] CI green on all three jobs (`vocabulary-purge gate`, `plugin-structure check`, `contract-strings gate`).
