### PR TITLE
feat(architect): add clause 10 and an INVARIANTS return entry (#374)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues — each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly — the driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: |
-  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief plus your project's standing docs and repo into a candidate issue set, a dependency graph, and a Wave order - before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the breakdown, but never writes code and opens no issues/milestones/PRs, returning a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS / SCOPE_SPANS_MULTIPLE_MILESTONES block the plan skill consumes. It never invents PRODUCT scope - a decision with no conventional default is surfaced in PRODUCT_GAPS, never guessed to make an issue buildable.
+  Dispatched by milestone-feeder's /milestone-feeder:plan skill ONCE per run to turn a brief plus your project's standing docs and repo into a candidate issue set, a dependency graph, and a Wave order - before any GitHub write. Read-only; reads the brief, the standing docs, and the repo to ground the breakdown, but never writes code and opens no issues/milestones/PRs, returning a structured CANDIDATES / EDGES / WAVES / PRODUCT_GAPS / SCOPE_SPANS_MULTIPLE_MILESTONES / INVARIANTS block the plan skill consumes. It never invents PRODUCT scope - a decision with no conventional default is surfaced in PRODUCT_GAPS, never guessed to make an issue buildable.
 model: opus
 color: blue
 ---
@@ -60,6 +60,16 @@ Apply the reference's three triggers: the **new-entity baseline cluster** (list 
 - A layer you cannot ground in a stated layering convention is not assigned: the candidate carries no `layer` field, and ordering falls back to clause 3's concrete-artifact edges only.
 - A project whose standing docs state no layering convention gets no `layer` field, no layer edge, and the dependency-only Wave order it produces today, unchanged.
 
+**10. Cross-candidate invariants: resolve once, then transcribe.** A directive that must hold across two or more candidates (a page size, a sort order, a date format, an ID or naming rule) is resolved ONCE here, during breakdown, and returned in `INVARIANTS` rather than left for each candidate to re-derive independently.
+
+- Record each one as an `INVARIANTS` entry carrying `key` (a short stable name), `value` (the directive VERBATIM, literal values intact), `citation` (the project-docs ref, the recorded brief line, or a sibling `path (anchor)` or `file:line`, per the Rigor gate), and `applies_to` (the two or more candidate tags it binds).
+- Transcribe `value`, never paraphrase it: a directive naming a literal keeps that literal.
+- `applies_to` draws its tags from `CANDIDATES` as returned, the full set: never from the reduced set the downstream Step 3.5 pre-park and Step 5 drop pass leave.
+- A directive binding exactly one candidate is never emitted here: it stays that candidate's own design, grounded in its sketch under clause 2.
+- Emitting an invariant does not remove it from the candidates it binds: every tag in `applies_to` still records the directive in its own sketch under clause 2, and the `INVARIANTS` entry pins the one resolution they share.
+- A directive you cannot ground in the recorded brief line, the project docs, or an established repo convention is not an invariant: it is a clause 2 call, resolved or parked to `PRODUCT_GAPS`, never asserted here as a cross-candidate rule.
+- A breakdown in which no directive binds two or more candidates returns the literal `none`, and the downstream issue-authors receive exactly what they receive today, unchanged.
+
 ## Structured return block
 
 Return **only** this block. No prose before or after it, no issues opened, no recommendations:
@@ -111,6 +121,12 @@ SCOPE_SPANS_MULTIPLE_MILESTONES:
                             #   when raised, names two or more milestones forming a
                             #   strict partition of `CANDIDATES` - every tag in
                             #   `CANDIDATES` assigned to exactly one milestone
+INVARIANTS:
+  - key: <short stable name, e.g. table-pagination>
+    value: <the directive VERBATIM, literal values intact>
+    citation: <the project-docs ref / path (anchor) / file:line / recorded brief line it came from>
+    applies_to: [#A, #B, #C]   # the candidate tags it binds; two or more
+  - …                       # "none" when no directive binds two or more candidates
 ```
 
 `disposition` and `layer` compose: a candidate may carry either, both, or neither, and each is independently additive to downstream consumers.
@@ -144,6 +160,7 @@ assistant: "Dispatching architect once to turn the brief + project docs + repo i
 - A design call you cannot ground in your project docs or an established repo convention, with no conventional default, is a `PRODUCT_GAP`: never invented, never silently resolved to a plausible-sounding guess.
 - Every dependency edge cites the actual artifact reference (the type, screen, or contract one candidate introduces and another consumes) at `path (anchor)` or `file:line`, or by the recorded brief/project-docs line. An edge you cannot ground is not emitted.
 - Every layer assignment and layer edge (clause 9) cites the project's stated architecture (`.project/<doc>#<section>`, or a sibling `path (anchor)` or `file:line`). A layer you cannot ground in a stated layering convention is not assigned: the candidate carries no `layer` field, and the breakdown falls back to concrete-artifact edges only.
+- Every `INVARIANTS` entry (clause 10) cites its grounding (a project-docs ref, the recorded brief line, or a sibling `path (anchor)` or `file:line`). A directive you cannot ground in one of those is not an invariant: it falls back to a clause 2 call on each candidate it would have bound, resolved or parked to `PRODUCT_GAPS`.
 - A candidate is in exactly one of three dispositions: grounded in the brief or project docs; a grounded conventional surface proposed for review, labeled `implied` (clause 8); or a parked product gap. A surface with no conventional default parks to `PRODUCT_GAPS` rather than proceeding as an implied guess.
 - "Looks reasonable / probably / should be fine" are contract violations. Ground the call in the project docs or convention, or park it to `PRODUCT_GAPS`.
 
@@ -158,7 +175,7 @@ assistant: "Dispatching architect once to turn the brief + project docs + repo i
 
 The GitHub prose contract is defined once at `agents/issue-author.md` `## Prose style`, indexed at `docs/style-contracts.md#github-prose-style`.
 
-It binds exactly two of your slots: the `sketch` field and the `<reason>` clause inside each `EDGES` entry, both defined in the return block above and both riding downstream into text authored for GitHub (`skills/plan/SKILL.md (Brief each with)` hands the sketch to the issue-author). It does not bind `title`, `surface`, `risk`, or `layer`: those are one-liners and enums carrying no prose. Where a sketch carries the literal `implied — review / trim / augment` directive of clause 8, that directive stays byte-identical.
+It binds exactly two of your slots: the `sketch` field and the `<reason>` clause inside each `EDGES` entry, both defined in the return block above and both riding downstream into text authored for GitHub (`skills/plan/SKILL.md (Brief each with)` hands the sketch to the issue-author). It does not bind `title`, `surface`, `risk`, `layer`, or `value`: `title`, `surface`, `risk`, and `layer` are one-liners and enums carrying no prose, and `value` is a clause 10 directive transcribed from its source, whose wording is that source's and not yours, so it stays byte-identical and no cut pass rewrites it. Where a sketch carries the literal `implied — review / trim / augment` directive of clause 8, that directive stays byte-identical.
 
 Your return's structure stays governed by `## Communication style` below: which block you emit, the `CANDIDATES` / `EDGES` / `WAVES` / `PRODUCT_GAPS` shape, the `#A` / `#B` tag convention, and the enum values.
 


### PR DESCRIPTION
Closes #374.

`agents/architect.md` gains clause 10 and an `INVARIANTS` entry in its `## Structured return block`, so a directive binding two or more candidates is resolved once by the architect, which runs with whole-brief visibility, and transcribed rather than re-derived independently by each issue-author.

## Decision Log

- Clause 10 placed after clause 9 and before `## Structured return block`, following clause 9's exposition shape. Rationale: the recorded design fixes that position; clause 9 is the sibling with the same lead-directive-then-bullets form. Citation: `agents/architect.md (**9. Architectural layer: assign, then order by the layer dependency.**)`. Rejected: a prose-only clause with no explicit fallback bullet.
- `INVARIANTS:` appended as the last key in the fenced block, not inserted mid-block. Rationale: tail placement leaves every existing key's order byte-stable, mirroring how `SCOPE_SPANS_MULTIPLE_MILESTONES` was itself appended. Citation: commit `e5bda51`. Rejected: inserting beside `CANDIDATES` on semantic affinity, which reorders keys downstream consumers enumerate positionally.
- Emitting an invariant does NOT remove it from the bound candidates' sketches. Rationale: threading `INVARIANTS` downstream is #388, so today the `sketch` is the only channel reaching the issue-author; without this clause the change would delete every cross-candidate directive from every downstream issue instead of pinning it. Citation: `skills/plan/SKILL.md (Brief each with)`, which enumerates the Step-4 brief and carries no `INVARIANTS`. Rejected: leaving retention implicit until #388.
- The recorded brief line is a valid grounding source for an invariant. Rationale: a brief-stated cross-candidate directive is the most decided input in a run, and the brief is already first-class grounding elsewhere in this file. Citation: `agents/architect.md (## Rigor gate)` and its `brief_ref` field in `PRODUCT_GAPS`. Rejected: project-docs and repo convention only, which routes the commonest case back to per-candidate re-derivation.
- `applies_to` draws from `CANDIDATES` as returned, the full set. Rationale: the architect returns before Step 3.5's pre-park and Step 5's drop pass run, so the full set is the only set it can name. Citation: `agents/architect.md (The split is a strict partition of `CANDIDATES`)`. Rejected: the surviving set, which the architect cannot know.
- `## Prose style` gains a `value` carve-out. Rationale: the contract's own cut rules would rewrite a transcribed literal; the sibling agent already carves out its equivalent field for the same reason. Citation: `agents/roadmap-splitter.md (## Prose style)`. Rejected: a separate paragraph, which would leave the existing "does not bind" list reading complete while stale.
- Frontmatter `description` enumeration extended to include `INVARIANTS`. Rationale: repo precedent updates that enumeration in the same commit that adds a return-block key. Citation: commit `e5bda51`. Rejected: leaving a stale self-description in an accuracy milestone.
- No one-time discovery notice. Rationale: no new config key and no user-facing surface, so clause 10's own contract text carries the obligation. Citation: `.project/design-philosophy.md#One-way doors`. Rejected: a notice, which that doc reserves for user-facing or config changes.

## Code Review

- /code-review run: yes, two cycles
- Cycle 1 findings: 2 Critical, 2 Important, 5 Minor at high effort
  - Clause 10 did not state whether an invariant also stays in each bound candidate's `sketch`, and every surrounding signal read as removal. Since #388 has not landed, that would have DELETED cross-candidate directives from downstream issues rather than pinning them. Evidence: `skills/plan/SKILL.md (Brief each with)` carries no `INVARIANTS` on `develop`, verified `git grep -n INVARIANTS develop` returns zero hits repo-wide. → re-dispatched and resolved
  - Bullet 4's grounding set omitted the brief, excluding brief-stated directives by rule. Evidence: `agents/architect.md (## Rigor gate)` already grounds by the recorded brief line. → re-dispatched and resolved
  - `## Rigor gate` had no clause-10 entry while clause 9 has one. Evidence: `agents/architect.md (Every layer assignment and layer edge (clause 9) cites)`. → re-dispatched and resolved
  - `## Prose style` was not extended for the new `value` slot. Evidence: `agents/roadmap-splitter.md (## Prose style)`. → re-dispatched and resolved
  - Five minors: `.project` versus project-docs wording, three phrasings of one threshold, sentinel comment alignment, open `applies_to` scope, two justification sentences clause 9 does not carry. → all re-dispatched and resolved
- Cycle 2: 0 Critical, 0 Important, 3 Minor at high effort. Verdict: merge.
  - `applies_to`'s inline comment sits 3 columns off the block's convention → accepted (the field content is 28 chars, so the convention's column is not achievable)
  - `skills/plan/SKILL.md` still enumerates the 5-block schema → routed to #388
  - Sketch budget pressure when several invariants bind one candidate → no action; #388 relieves it
- The riskiest fix rewrote a single physical line containing the canonical contract string `implied — review / trim / augment`. Verified byte-identical against `develop` by hexdump; U+2014 count unchanged at 3, all three that string. `scripts/check-contract-strings.sh` passes both its drift and presence checks.
- No park-triggering findings.
- A coherence pass ran before review and found two stale schema enumerations, both routed to #388 and #390 rather than fixed here.
- Version bump: sets `.claude-plugin/plugin.json` to the milestone target `0.14.0`, idempotent with every other PR in v0.14.0.

## Note on the issue body

The issue's Design block recorded the `INVARIANTS` fence comments verbatim as `2 or more` and `more than one candidate`. Review unified the threshold wording to `two or more` throughout, matching this file's existing house usage, so the issue body is stale on those two comment strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
