### PR TITLE
Set UTF-8 console encoding in the PowerShell notice emitter twins (#337)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues: each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly. The driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/docs/one-time-notices.md
+++ b/docs/one-time-notices.md
@@ -174,6 +174,8 @@ fi
 ```powershell
 # PowerShell 7+: same read-only detect + one-time notice; NEVER writes the root .gitignore; never aborts plan.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'legacy-blanket-notice')
   if ((-not (Test-Path $marker)) -and (Test-Path '.gitignore')) {
     $lines = Get-Content -LiteralPath '.gitignore'
@@ -264,6 +266,8 @@ fi
 ```powershell
 # PowerShell 7+: same read-only detect + one-time notice; NEVER writes projectDocs/.project/ or driver.json, NEVER runs the bootstrapper; never aborts plan.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   # Resolve projectDocs in-block (the key-extraction table below has not run yet) with the SAME default the table uses,
   # so the two reads can't diverge; a non-string projectDocs (number/array), missing file / malformed JSON all fall
   # back to .project/. Strip ALL trailing slashes for the detect operand; an empty result (e.g. "/") falls back to
@@ -347,6 +351,8 @@ fi
 ```powershell
 # PowerShell 7+: same one-time roadmap-routing discovery notice; read-only; marker-gated; never aborts plan.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'roadmap-routing-notice')
   if (-not (Test-Path $marker)) {
     # Indent-safe array-join (the #120/#121 self-heal construct), NOT a here-string; byte-identical
@@ -430,6 +436,8 @@ fi
 ```powershell
 # PowerShell 7+: same read-only detect + one-time notice; NEVER writes the overlay; never aborts plan.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'implied-surfaces-notice')
   $overlay = Join-Path '.milestone-config' 'implied-surfaces.md'
   if ((-not (Test-Path $marker)) -and (-not (Test-Path $overlay))) {
@@ -504,6 +512,8 @@ fi
 ```powershell
 # PowerShell 7+: same one-time md-epic-parent discovery notice; read-only; marker-gated; never aborts create/update.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'md-epic-parent-notice')
   if (-not (Test-Path $marker)) {
     # Indent-safe array-join (the #120/#121 self-heal construct), NOT a here-string: an
@@ -580,6 +590,8 @@ fi
 ```powershell
 # PowerShell 7+: same one-time consumer-issue-template discovery notice; read-only; marker-gated; never aborts plan.
 try {
+  # UTF-8 console output so the emoji survives a default Windows codepage; own catch so a throwing setter never skips the notice.
+  try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
   $marker = Join-Path '.milestone-config' (Join-Path '.runtime' 'issue-template-notice-v2')
   if (-not (Test-Path $marker)) {
     # Indent-safe array-join (the #120/#121 self-heal construct), NOT a here-string; byte-identical


### PR DESCRIPTION
Adds a best-effort UTF-8 console-encoding assignment to each of the six `Write-Host` PowerShell emitter fences in `docs/one-time-notices.md`, per #337. Each fence gains one comment plus `try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}` as the first statement inside its existing outer try, before its first `Write-Host`. All six twins now emit bytes identical to their bash twins under a simulated default Windows codepage (each was 2 bytes short before: the emoji best-fit-fell-back to `??`). The Self-heal fence has no `Write-Host` and is untouched. Applies the idempotent milestone version bump (plugin.json to 0.14.1).

milestone-driver carries no mirror of these twins (verified by grep: no one-time-notices doc, no notice markers, no `Write-Host (@(` emitters); AC7 is vacuously satisfied on the local checkout.

🔴 AC2 residual for maintainer sign-off: CI is ubuntu-only and the probe simulated codepage 437 on macOS; one-time manual confirmation on a real default-encoding Windows console remains outstanding. Nothing in the change depends on it.

## Decision Log

- Wrapped the encoding assignment in its own inner `try { } catch {}` rather than the plan's bare-statement literal · a throwing setter as a bare first statement routes to the outer catch and suppresses the notice entirely, violating AC4; verified by execution in both directions (bare literal + throw = 0 bytes emitted; shipped form + throw = notice intact) · https://learn.microsoft.com/dotnet/api/system.console.outputencoding (setter throws IOException/SecurityException) · rejected: the bare form (fails AC4); placing the assignment outside the try (aborts the run on a restricted host).
- Used `[System.Text.UTF8Encoding]::new()` per the issue's Proposed-solution literal · parameterless UTF8Encoding is documented no-preamble, behaviorally identical to the sibling's explicit `$false` · https://learn.microsoft.com/dotnet/api/system.text.utf8encoding · rejected: the driver's `New-Object` form (more verbose, contradicts the issue literal). Coherence noted the in-file self-heal sibling uses `::new($false)`; the `$false` there suppresses a file-write BOM, which does not apply to a console-encoding assignment (probe confirmed no BOM in console output).
- One comment line per fence, not two · keeps 109 words of headroom under the 5350 ceiling while recording why the inner catch exists · `scripts/validate-plugin-structure.py (FILE_WORD_CEILINGS)` · rejected: no comment (invites a cleanup pass to reintroduce the AC4 regression); two lines (headroom too thin at 61 words).

## Code Review

- /code-review run: yes (omission is a park trigger; a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 1 in-scope finding at medium effort
  - Minor: AC7's vacuous-satisfaction determination was unrecorded (`docs/one-time-notices.md` vs the driver repo) → resolved by recording it in this PR body (second paragraph above)
- No park-triggering findings.
- Version bump: idempotent same-line bump to 0.14.1 (milestone target; reconciled by the merge tail)

Gates: check-vocabulary exit 0 · validate-plugin-structure exit 0 (36 files) · check-contract-strings exit 0. Word count 5241/5350, ceiling untouched. Coherence pass: one drift-trivial note (parameterless `::new()` vs the in-file `::new($false)` idiom), accepted per the issue's own literal; its codify-the-idiom proposal is recorded in the run summary for a human call. Reviewer reproduced the AC4 throwing-setter behavior, twin byte-identity (858 bytes, no BOM), idempotence, and marker gating by execution.

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
