### PR TITLE
Add the Site-coverage sub-criterion to issue-author's Completeness contract (#342)

### DIFF
--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -43,6 +43,8 @@ You guarantee the five criteria the driver's triage checks: clause N below is `m
 
 3. **Completeness.** The acceptance criteria enumerate the happy path, the empty state, the error/failure path, and the disabled/edge state.
 
+   **Site coverage.** A candidate that makes an existing unconditional behavior conditional, renames a symbol, or changes a contract also records in its Design section every site the change must touch. Establish that list by running a search, never from recollection of the files you already read. Search the resolved `sourceGlobs`, and every sibling reference file in the folder of each hit, because a rule restated for readability across a skill folder's sibling files is what an unsearched list misses. Record the search itself as a `Sites searched:` line (_Output format_ below) carrying the pattern and the scope, so triage re-runs it. A search you cannot make exhaustive says so on that line and names what is unresolved, so triage escalates instead of accepting a confident count.
+
 4. **Dependencies.** Record each architect edge touching this candidate as `Depends on #<tag> - <reason / the exact reference>`, transcribing the reference exactly. Never invent an edge, and never reorder the Waves.
 
 5. **UI vs logic + risk.** Classify `Surface: ui | logic`: **ui** when the issue touches a `uiSurfaceGlobs` path or carries a visible or interactive affordance, **logic** otherwise. A **ui** issue's Design section carries:
@@ -83,6 +85,7 @@ reference and never both, and use the heading ref where the cited region is a he
 - Convention followed: <conventions.md ref, or the path (anchor) / file:line of the sibling pattern>
 - Layer: <the architectural layer the architect assigned, citing the stated architecture that places it (.project/<doc>#<section>, or a sibling ref). OPTIONAL: omit when the candidate carried no `layer` field>
 - Config pointers: <the `.project` config the driver reads at BUILD time, keyed to what the issue touches: styling → `.project/tokens.json` + `.project/design-system.md#<section>`; deployment/env → `.project/environment.md`. PATH only, never resolved values (no hex, no parsed tokens, no pre-solved render). OPTIONAL: omit when the issue touches none or the doc is absent>
+- Sites searched: <the search that established the site list: the pattern and the scope searched, in a form a reviewer re-runs. State on this line when the list may be partial and what is unresolved. OPTIONAL: omit when the issue makes no existing behavior conditional, renames no symbol, and changes no contract>
 
 ## Dependencies
 
@@ -115,7 +118,7 @@ PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with 
 
 **Content never disappears.** A consumer template that lacks a section the built-in default has must not drop that content. Overflow lands in the nearest matching section: a template with no `## Non-goals` carries the scope boundary inside whichever section covers scope.
 
-**The Rigor gate is not weakened.** A consumer template changes the section headers, not the grounding bar. Every citation is still verified (`grep before you cite`, Rigor gate below), and the five contract criteria bind whatever structure you author to, including Completeness, whichever sections hold the four states.
+**The Rigor gate is not weakened.** A consumer template changes the section headers, not the grounding bar. Every citation is still verified (`grep before you cite`, Rigor gate below), and the five contract criteria bind whatever structure you author to, including Completeness, whichever sections hold the four states and the site list.
 
 **`## Prose style` binds every line** of the authored body, whatever produced the headers.
 
@@ -133,7 +136,7 @@ PRODUCT_GAP (only when STATUS: PRODUCT_GAP): { what: <the product decision with 
 - Writing the issue to GitHub or opening it. Return the wrapper to the `plan` skill, which owns every GitHub write.
 - Inventing PRODUCT scope. A decision with no conventional default returns `STATUS: PRODUCT_GAP`.
 - Reordering Waves or inventing dependency edges. Record the edges the architect gave you, verbatim.
-- A happy-path-only acceptance-criteria set, or an ungrounded `Convention followed:` line.
+- A happy-path-only acceptance-criteria set, a site list assembled from recollection rather than a search, or an ungrounded `Convention followed:` line.
 
 ## Prose style
 


### PR DESCRIPTION
Extends `agents/issue-author.md`'s Completeness contract criterion (Contract clause 3) with a Site-coverage sub-criterion per #342: when an issue makes an existing behavior conditional, renames a symbol, or changes a contract, the author runs a real search over the resolved `sourceGlobs` plus sibling reference files (never recollection), enumerates the hit sites in the Design section, and records the search on a new optional `Sites searched:` bullet in the Design block (pattern + scope, re-runnable by triage; a non-exhaustive search says so and names what is unresolved). The consumer-template binding and What-you-refuse gain the site echo alongside the existing states echo. State coverage itself is byte-unchanged. 2465 -> 2658 words vs the 3200 ceiling (542 headroom remains). Version already at the 0.14.1 target on this base; the idempotent bump made no change.

## Decision Log

- Field name `Sites searched:` as an optional Design-block bullet · mirrors the established Convention-followed/Layer/Config-pointers one-line pattern; a new §4 section header would break the locked section order and the scenario-14 grader scores against new headers · recorded triage decision on the issue (🟢 comment thread); `tests/scenarios/14-config-pointers/expected.grader.md` · rejected: a new `## Sites` section; folding into `Convention followed:`.
- Optional, omitted when the issue conditionalizes nothing, renames nothing, and changes no contract · matches the ACs' trigger and the sibling bullets' optionality convention · `agents/issue-author.md (Output format)` · rejected: mandatory on every issue, which forces a fabricated line on greenfield issues.
- Rule in clause 3, echoed only where state coverage is already echoed (consumer-template binding, What you refuse) · restating in some functional sites but not all is this issue's own defect class · `agents/issue-author.md (What you refuse)` · rejected: clause 3 alone, leaving the consumer-template path binding Completeness to states only.
- Reverted an initial Rigor-gate edit · the issue's Non-goals state "No change to the Rigor gate," and no AC requires it · issue #342 Non-goals · rejected: keeping it on a wider reading of the non-goal's rationale.

## Code Review

- /code-review run: yes (omission is a park trigger; a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 3 in-scope findings at medium effort
  - Minor: the clause-N-to-driver-criterion-N mapping is loose until the driver mirror lands (`agents/issue-author.md:38`) → accepted (rationale: by design per the issue's Non-goals; the mirror is filed as milestone-driver#380)
  - Minor: cosmetic asymmetry between the trigger's "unconditional behavior conditional" and the omit condition's phrasing (`:46` vs `:88`) → accepted (rationale: semantically equivalent; cosmetic)
  - Minor: `Sites searched:` records the search while the site list lives in Design prose → accepted (rationale: exactly what AC1/AC3 specify; noted to prevent misreading the slot)
- No park-triggering findings.
- Version bump: none needed (base already carries 0.14.1; idempotent)

Gates: check-vocabulary exit 0 · validate-plugin-structure exit 0 (36 files) · check-contract-strings exit 0 (both pinned fragments byte-exact, sole occurrence). Rigor gate byte-identical to base. Coherence pass: one trivial + two small drifts recorded (no Rigor-gate echo, fenced by Non-goals; missing docs/architecture.md subsection and scenario fixture), routed to the run-end follow-up issue alongside the SPEC.md Completeness-row note.

Closes #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
