### PR TITLE
Ship the one-time notices as emit-notice script twins with single-source text (#436)

### DIFF
--- a/.project/conventions.md
+++ b/.project/conventions.md
@@ -14,7 +14,7 @@ Skills live at `skills/<verb>/SKILL.md` (verbs: `plan`, `create`, `update`, `set
 
 ## File & folder layout
 Where things go, and the shape of a feature.
-`skills/` (one folder per verb, each a `SKILL.md`) · `agents/` (one `.md` per agent) · `hooks/` (the `no-source-edit` gate + polyglot launcher) · `.claude-plugin/` (`plugin.json` + `marketplace.json`) · `docs/` (architecture, profile-schema, consumer-setup, `specs/`) · `tests/scenarios/NN-*/` (end-to-end fixtures) · `scripts/` (validation helpers) · `.milestone-config/` (`feeder.json`, `driver.json`, nested `.gitignore`). SPEC.md + README.md + CHANGELOG.md at the root. (Grounded in repo layout; `docs/architecture.md` Plugin contents table.)
+`skills/` (one folder per verb, each a `SKILL.md`) · `agents/` (one `.md` per agent) · `hooks/` (the `no-source-edit` gate + polyglot launcher) · `.claude-plugin/` (`plugin.json` + `marketplace.json`) · `docs/` (architecture, profile-schema, consumer-setup, `specs/`) · `tests/scenarios/NN-*/` (end-to-end fixtures) · `scripts/` (the CI gate scripts, plus the one-time-notice emitter twins and the notice-data file they read) · `.milestone-config/` (`feeder.json`, `driver.json`, nested `.gitignore`). SPEC.md + README.md + CHANGELOG.md at the root. (Grounded in repo layout; `docs/architecture.md` Plugin contents table.)
 
 ## Test patterns
 Where tests live, how they're named, fixtures/factories, and what a good test looks like.

--- a/scripts/emit-notice.json
+++ b/scripts/emit-notice.json
@@ -1,0 +1,198 @@
+{
+  "_source": "docs/one-time-notices.md (How each skill runs this file). That file is the authority for what each unit does; this file is the single source of the text each unit prints and the body the self-heal writes.",
+  "_readers": "scripts/emit-notice.sh and scripts/emit-notice.ps1. Both read only the `units` array, in file order, and ignore every other key here.",
+  "_placeholder": "{{projectDocs}} in a text line is replaced with the resolved projectDocs path (trailing slashes stripped) before the line prints. No other placeholder is defined.",
+  "units": [
+    {
+      "id": "self-heal-nested-gitignore",
+      "section": "Self-heal the nested .milestone-config/.gitignore",
+      "skills": [
+        "plan"
+      ],
+      "marker": null,
+      "trigger": {
+        "kind": "file-absent",
+        "path": ".milestone-config/.gitignore"
+      },
+      "text": [],
+      "writes": {
+        "path": ".milestone-config/.gitignore",
+        "lines": [
+          "# milestone-driver / milestone-feeder per-clone scratch, git-invisible by default.",
+          "# Committed so per-run scratch stays out of `git status` with zero user setup.",
+          "# Patterns are relative to this .milestone-config/ directory. Tracked config",
+          "# (driver.json, feeder.json) is intentionally NOT listed, so it stays tracked.",
+          "preflight-notice",
+          "trello-notice",
+          "visualcapture-notice",
+          "parallel-default-notice",
+          "code-review-gate-notice",
+          "aiprefilter-notice",
+          "cost-record-notice",
+          "uisurfaceglobs-notice",
+          "triage-cache.json",
+          "tests-stamp",
+          ".runtime/",
+          "worktrees/"
+        ]
+      }
+    },
+    {
+      "id": "legacy-blanket-notice",
+      "section": "Legacy-blanket root .gitignore notice",
+      "skills": [
+        "plan"
+      ],
+      "marker": ".milestone-config/.runtime/legacy-blanket-notice",
+      "trigger": {
+        "kind": "gitignore-blanket",
+        "path": ".gitignore"
+      },
+      "text": [
+        "🔴 Legacy blanket detected in your root .gitignore",
+        "",
+        "| What | Your root .gitignore ignores the whole .milestone-config/ directory",
+        "|      | (a line like `.milestone-config/`, `.milestone-config/*`, or",
+        "|      | `.milestone-config`). That hides this suite's TRACKED config",
+        "|      | (feeder.json, driver.json, and the nested .milestone-config/.gitignore)",
+        "|      | from git, so your config is silently dropped from version control.",
+        "| Fix  | Edit your root .gitignore BY HAND and delete the `.milestone-config`",
+        "|      | blanket line. The nested .milestone-config/.gitignore (already",
+        "|      | written) then keeps per-run scratch invisible while feeder.json /",
+        "|      | driver.json / the nested .gitignore stay tracked. We never edit your",
+        "|      | root .gitignore for you: it is yours and may hold unrelated rules.",
+        "| Note | This notice shows at most once per clone."
+      ]
+    },
+    {
+      "id": "bootstrap-nudge-notice",
+      "section": "Bootstrap-nudge notice",
+      "skills": [
+        "plan"
+      ],
+      "marker": ".milestone-config/.runtime/bootstrap-nudge-notice",
+      "trigger": {
+        "kind": "unbootstrapped"
+      },
+      "text": [
+        "🟡 This repo isn't bootstrapped: your plan's grounding will be weak",
+        "",
+        "| What | This repo has no {{projectDocs}}/ standing docs and/or no",
+        "|      | .milestone-config/driver.json. Without them, plan has no project",
+        "|      | constitution to ground issue design on and no driver profile to",
+        "|      | resolve shared keys from, so it falls back to thin inferred",
+        "|      | conventions and the issues it writes are weaker.",
+        "| Fix  | Run milestone-bootstrapper first to scaffold your .project/ docs and",
+        "|      | driver profile, then re-run /milestone-feeder:plan. We won't do this",
+        "|      | for you and we won't block: config is optional and plan will",
+        "|      | continue with best-effort grounding.",
+        "| Note | This notice shows at most once per clone."
+      ]
+    },
+    {
+      "id": "roadmap-routing-notice",
+      "section": "Roadmap-routing notice",
+      "skills": [
+        "plan"
+      ],
+      "marker": ".milestone-config/.runtime/roadmap-routing-notice",
+      "trigger": {
+        "kind": "always"
+      },
+      "text": [
+        "🟡 New: an oversized brief now routes into a roadmap flow",
+        "",
+        "| What | When you give plan a whole-app brief that spans several",
+        "|      | releases, plan now hands it to a roadmap step first: it",
+        "|      | proposes a sequenced set of milestones and asks you to",
+        "|      | confirm, merge, split, reorder, or reject the split before",
+        "|      | it plans any single milestone.",
+        "| When | Only when the brief reads as several milestones. A normal,",
+        "|      | single-release brief is unchanged: no roadmap step, no",
+        "|      | extra prompt.",
+        "| Note | This notice shows at most once per clone."
+      ]
+    },
+    {
+      "id": "implied-surfaces-notice",
+      "section": "Implied-surfaces notice",
+      "skills": [
+        "plan",
+        "update"
+      ],
+      "marker": ".milestone-config/.runtime/implied-surfaces-notice",
+      "trigger": {
+        "kind": "file-absent",
+        "path": ".milestone-config/implied-surfaces.md"
+      },
+      "text": [
+        "🟡 Optional: add project-specific implied surfaces",
+        "",
+        "| What | You can add an optional overlay file at",
+        "|      | .milestone-config/implied-surfaces.md. The architect reads it",
+        "|      | alongside the plugin's bundled implied-surfaces reference when it",
+        "|      | breaks your brief into issues.",
+        "| Why  | The bundled reference is universal, so it can't carry capability",
+        "|      | clusters specific to your domain (a church app's \"giving\", say).",
+        "|      | Your overlay merges in additively: it can add a new capability",
+        "|      | and extend an existing one, but never removes a surface the",
+        "|      | bundled reference already defines.",
+        "| How  | Create .milestone-config/implied-surfaces.md and write one",
+        "|      | capability per ## heading with its implied surfaces beneath, the",
+        "|      | same shape as the bundled reference. Leave it out and the bundled",
+        "|      | reference is used as-is; an absent overlay is never an error.",
+        "| Note | This notice shows at most once per clone."
+      ]
+    },
+    {
+      "id": "md-epic-parent-notice",
+      "section": "md-epic parent notice",
+      "skills": [
+        "create",
+        "update"
+      ],
+      "marker": ".milestone-config/.runtime/md-epic-parent-notice",
+      "trigger": {
+        "kind": "always"
+      },
+      "text": [
+        "🟡 New: a roadmap deploy now also creates a driver parent issue",
+        "",
+        "| What | When your roadmap deploys more than one milestone, create (and",
+        "|      | update, on a re-plan) now also creates one md-epic-labeled parent",
+        "|      | issue whose body lists the milestones in build order. The driver",
+        "|      | reads this parent to drive the milestones in sequence for you.",
+        "| When | Only when the roadmap deploys N>1 milestones. A single-milestone",
+        "|      | plan/create is unchanged. No parent issue, nothing new to look at.",
+        "| Note | This notice shows at most once per clone."
+      ]
+    },
+    {
+      "id": "issue-template-notice",
+      "section": "Consumer issue-template notice",
+      "skills": [
+        "plan"
+      ],
+      "marker": ".milestone-config/.runtime/issue-template-notice-v2",
+      "trigger": {
+        "kind": "always"
+      },
+      "text": [
+        "🟡 New: plan now adopts your repo's issue template",
+        "",
+        "| What | plan now authors each issue to your repo's own issue template",
+        "|      | instead of its own built-in structure. It uses the template your",
+        "|      | driver config records as agentIssueTemplate; with no such key, the",
+        "|      | single template under .github/ISSUE_TEMPLATE/ (the reserved",
+        "|      | config.yml is not counted, so bug.yml + config.yml counts as one).",
+        "|      | No key and no single template keeps the built-in structure.",
+        "| When | Every plan run. The built-in structure authors four sections:",
+        "|      | Summary, Acceptance criteria, Design (recorded, consistent),",
+        "|      | and Dependencies, plus Non-goals when the issue records a scope",
+        "|      | boundary.",
+        "| Note | This notice shows once per clone, and again after an upgrade",
+        "|      | that revises it."
+      ]
+    }
+  ]
+}

--- a/scripts/emit-notice.ps1
+++ b/scripts/emit-notice.ps1
@@ -1,0 +1,229 @@
+#!/usr/bin/env pwsh
+#
+# emit-notice.ps1: the one-time-notice emitter (PowerShell 7+ twin of
+# emit-notice.sh).
+#
+# What this does, in plain terms:
+#   docs/one-time-notices.md defines seven Step-0 units shared across `plan`,
+#   `create`, and `update`: one self-heal that writes a file, and six notices
+#   that print at most once per clone. This script runs them. It holds none of
+#   their text. Every unit's printed lines and the self-heal's file body live
+#   in scripts/emit-notice.json, once, so this script and its bash twin cannot
+#   drift from each other or from the doc.
+#
+# Invocation (one form, identical on both twins, so a caller documents one):
+#   scripts/emit-notice.ps1 <plan|create|update>
+#     Caller mode. Walks the units in file order, keeps every unit whose
+#     `skills` list contains the caller's own name, and runs each one.
+#   scripts/emit-notice.ps1 --section <section-id>
+#     Explicit-section mode. Runs exactly the one unit whose `id` matches,
+#     WHATEVER its `skills` list says. This is the mode for a caller that is
+#     not one of the three verbs (`setup`, which runs the self-heal and the
+#     legacy-blanket notice). Only the skills filter is bypassed: the unit's
+#     marker gate and its trigger still decide whether it fires.
+#     `--section` rather than a `-Section` parameter, deliberately: the two
+#     twins take the SAME argv, so a call site documents one invocation and
+#     `param()` would fork that into two.
+#
+# What running one unit means, in order:
+#   1. Marker gate. A unit with a `marker` is skipped when that marker file
+#      already exists. That is what makes a notice show at most once per clone.
+#      A unit with `marker: null` has no gate and re-checks every run (the
+#      self-heal's documented exception).
+#   2. Trigger. Four kinds, and nothing else is recognised:
+#        always             fires whenever the marker gate let it through.
+#        file-absent        fires when `trigger.path` is not a file.
+#        gitignore-blanket  fires when `trigger.path` carries a blanket line
+#                           for .milestone-config that no broad un-ignore
+#                           clears.
+#        unbootstrapped     fires when the resolved projectDocs tree holds no
+#                           file, or .milestone-config/driver.json is missing.
+#      An unrecognised kind does not fire, which is how a data file written by
+#      a newer version degrades here: silently, one unit at a time.
+#   3. Print. The unit's `text` lines, one per line, byte-exact. The single
+#      substitution is `{{projectDocs}}`, replaced with the resolved
+#      projectDocs path with trailing slashes stripped.
+#   4. Write. A unit carrying `writes` creates that file from `writes.lines`.
+#   5. Marker. A unit carrying a `marker` writes it, so it stays silent later.
+#
+# Working directory:
+#   Every path a unit names is relative to the CURRENT working directory: the
+#   consumer's repo root, where the calling skill already stands. The data file
+#   is resolved next to THIS script instead, because the plugin is installed
+#   outside the repo it acts on, so a repo-relative path would not find it.
+#
+# Parity with the bash twin (the emitted bytes are the contract):
+#   Text prints as one `-join "`n"` Write-Host call, matching `printf '%s\n'`
+#   line for line. `Test-Path -PathType Leaf` matches bash `[ -f ]` rather than
+#   bare `Test-Path`, which also answers true for a directory. Files are written
+#   through UTF8Encoding($false): no BOM, LF endings, the form the doc's
+#   PowerShell self-heal already uses. The console encoding is forced to UTF-8
+#   once at the top, in its own try/catch, so the notices' emoji survive a
+#   default Windows codepage and a throwing setter never skips a notice.
+#
+# Best-effort, always:
+#   This script never aborts its caller (.project/design-philosophy.md
+#   (## Error & failure philosophy)). A missing or malformed data file, an
+#   unusable unit, or a failed write is skipped, and the exit status is 0 in
+#   every case, including a usage error (which still prints one line to stderr,
+#   because a mis-wired call site is a bug worth seeing). Each unit runs inside
+#   its own try/catch, so one bad unit costs only that unit.
+#
+# Run it locally from a consumer repo root:  <plugin>/scripts/emit-notice.ps1 plan
+# Exit 0, always.
+
+# UTF-8 console output so the notices' emoji survive a default Windows codepage;
+# own catch so a throwing setter never skips a notice.
+try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() } catch {}
+
+# --- arguments ---------------------------------------------------------------
+$mode = ''
+$sel = ''
+if ($args.Count -ge 2 -and [string]$args[0] -eq '--section') {
+    $mode = 'section'
+    $sel = [string]$args[1]
+} elseif ($args.Count -ge 1 -and @('plan', 'create', 'update') -contains [string]$args[0]) {
+    $mode = 'caller'
+    $sel = [string]$args[0]
+}
+
+if (-not $mode -or -not $sel) {
+    [Console]::Error.WriteLine('usage: emit-notice.ps1 <plan|create|update> | emit-notice.ps1 --section <section-id>')
+    exit 0
+}
+
+# --- guards: no data file, malformed JSON, no unit array -> do nothing --------
+$dataPath = Join-Path $PSScriptRoot 'emit-notice.json'
+try {
+    $data = Get-Content -Raw -LiteralPath $dataPath -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    exit 0
+}
+if ($null -eq $data -or $null -eq $data.units) { exit 0 }
+$units = @($data.units)
+
+# --- resolve projectDocs -----------------------------------------------------
+#
+# Same read and same default as the doc's bootstrap-nudge emitter, so the two
+# can't diverge: a non-string projectDocs (number/array), a missing file, or
+# malformed JSON all fall back to .project/. ALL trailing slashes are stripped
+# for the detect operand; an empty result (e.g. "/") falls back to .project so
+# PowerShell and bash agree. The notice text re-adds the single "/", so the
+# printed path always ends in one.
+$pd = '.project/'
+try {
+    $pdRaw = (Get-Content -Raw -LiteralPath (Join-Path '.milestone-config' 'feeder.json') -ErrorAction Stop | ConvertFrom-Json).projectDocs
+    if ($pdRaw -is [string]) { $pd = $pdRaw }
+} catch {}
+$pd = $pd -replace '/+$', ''
+if (-not $pd) { $pd = '.project' }
+
+# --- trigger kinds -----------------------------------------------------------
+#
+# Returns $true (fires) or $false. Every unrecognised kind returns $false, so an
+# unknown trigger skips its unit rather than firing it blind. The two regexes
+# below are the doc's legacy-blanket detect verbatim: a blanket counts as
+# present UNLESS a broad un-ignore re-exposes the tracked config.
+function Test-NoticeTrigger {
+    param($Unit, [string]$ProjectDocs)
+
+    $kind = [string]$Unit.trigger.kind
+    $path = [string]$Unit.trigger.path
+
+    switch ($kind) {
+        'always' { return $true }
+        'file-absent' {
+            if (-not $path) { return $false }
+            return -not (Test-Path -LiteralPath $path -PathType Leaf)
+        }
+        'gitignore-blanket' {
+            if (-not $path -or -not (Test-Path -LiteralPath $path -PathType Leaf)) { return $false }
+            $lines = Get-Content -LiteralPath $path
+            $blanket = $lines | Where-Object { $_ -match '^\s*/?\.milestone-config(/\*?)?\s*$' }
+            $unignored = $lines | Where-Object { $_ -match '^\s*!/?\.milestone-config(/\*?)?\s*$' }
+            return [bool]($blanket -and -not $unignored)
+        }
+        'unbootstrapped' {
+            $projectEmpty = -not (Test-Path $ProjectDocs) -or -not (Get-ChildItem -LiteralPath $ProjectDocs -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)
+            $driverMissing = -not (Test-Path -LiteralPath (Join-Path '.milestone-config' 'driver.json') -PathType Leaf)
+            return ($projectEmpty -or $driverMissing)
+        }
+        default { return $false }
+    }
+}
+
+# --- run one unit ------------------------------------------------------------
+#
+# Its own function so an early exit is a `return`, and so the caller can wrap
+# each unit in one try/catch.
+function Invoke-NoticeUnit {
+    param($Unit, [string]$ProjectDocs)
+
+    # 0. shape gate. A unit is usable only when its `text` is an array and,
+    #    when it carries `writes`, `writes.lines` is an array too. Anything
+    #    else is a MALFORMED unit and is skipped whole: nothing printed, no
+    #    file written, and NO MARKER, so a bad entry can never permanently
+    #    suppress its own notice. The bash twin applies the same tests inside
+    #    its jq selection, so a degenerate data file produces identical silence
+    #    on both platforms (.project/conventions.md (## Test patterns), which
+    #    makes bash/pwsh parity on degenerate inputs a test obligation).
+    #    Without this gate a scalar `text` would be coerced by @() and printed.
+    if ($Unit.text -isnot [array]) { return }
+    if ($null -ne $Unit.writes -and $Unit.writes.lines -isnot [array]) { return }
+
+    # 1. marker gate
+    $marker = [string]$Unit.marker
+    if ($marker -and (Test-Path -LiteralPath $marker -PathType Leaf)) { return }
+
+    # 2. trigger
+    if (-not (Test-NoticeTrigger -Unit $Unit -ProjectDocs $ProjectDocs)) { return }
+
+    # 3. print the notice text
+    $lines = @(@($Unit.text) | ForEach-Object { ([string]$_).Replace('{{projectDocs}}', $ProjectDocs) })
+    if ($lines.Count -gt 0) { Write-Host ($lines -join "`n") }
+
+    # 4. write the unit's file, when it has one. The only unit that does is the
+    #    self-heal, whose trigger is the absence of exactly this path, so this
+    #    can never clobber a user-edited file. The path is resolved against the
+    #    session's location, because .NET's own current directory can lag it.
+    $writePath = [string]$Unit.writes.path
+    $writeLines = @($Unit.writes.lines)
+    if ($writePath -and $writeLines.Count -gt 0) {
+        $full = if ([System.IO.Path]::IsPathRooted($writePath)) {
+            $writePath
+        } else {
+            Join-Path (Get-Location).Path $writePath
+        }
+        $dir = Split-Path -Parent $full
+        if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+        [System.IO.File]::WriteAllText($full, (($writeLines -join "`n") + "`n"), [System.Text.UTF8Encoding]::new($false))
+    }
+
+    # 5. write the marker, so a marker-gated unit stays silent from here on.
+    #    LAST, and reached only once the text printed and the file (if any) was
+    #    written: a throw at either step unwinds past this into the caller's
+    #    per-unit catch, so the notice is still owed on the next run rather than
+    #    silently retired unshown. Same ordering as the bash twin.
+    if ($marker) {
+        $markerDir = Split-Path -Parent $marker
+        if ($markerDir) { New-Item -ItemType Directory -Force -Path $markerDir | Out-Null }
+        New-Item -ItemType File -Force -Path $marker | Out-Null
+    }
+}
+
+# --- select the units, in file order, and run them ---------------------------
+#
+# Case-SENSITIVE (-ccontains, -ceq) to match jq's case-sensitive `index` and
+# `==` in the bash twin, the same reason hooks/no-source-edit.ps1 reaches for
+# -cnotcontains and -clike. A `skills` that is not an array matches nothing
+# here, which is what the bash twin's `if type == "array"` test reproduces:
+# jq's `index` would otherwise run as substring matching on a string.
+$selected = @($units | Where-Object {
+        if ($mode -eq 'caller') { @($_.skills) -ccontains $sel } else { [string]$_.id -ceq $sel }
+    })
+
+foreach ($unit in $selected) {
+    try { Invoke-NoticeUnit -Unit $unit -ProjectDocs $pd } catch {}
+}
+
+exit 0

--- a/scripts/emit-notice.sh
+++ b/scripts/emit-notice.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# emit-notice.sh: the one-time-notice emitter (bash twin of emit-notice.ps1).
+#
+# What this does, in plain terms:
+#   docs/one-time-notices.md defines seven Step-0 units shared across `plan`,
+#   `create`, and `update`: one self-heal that writes a file, and six notices
+#   that print at most once per clone. This script runs them. It holds none of
+#   their text. Every unit's printed lines and the self-heal's file body live
+#   in scripts/emit-notice.json, once, so this script and its PowerShell twin
+#   cannot drift from each other or from the doc.
+#
+# Invocation (one form, identical on both twins, so a caller documents one):
+#   scripts/emit-notice.sh <plan|create|update>
+#     Caller mode. Walks the units in file order, keeps every unit whose
+#     `skills` list contains the caller's own name, and runs each one.
+#   scripts/emit-notice.sh --section <section-id>
+#     Explicit-section mode. Runs exactly the one unit whose `id` matches,
+#     WHATEVER its `skills` list says. This is the mode for a caller that is
+#     not one of the three verbs (`setup`, which runs the self-heal and the
+#     legacy-blanket notice). Only the skills filter is bypassed: the unit's
+#     marker gate and its trigger still decide whether it fires.
+#
+# What running one unit means, in order:
+#   1. Marker gate. A unit with a `marker` is skipped when that marker file
+#      already exists. That is what makes a notice show at most once per clone.
+#      A unit with `marker: null` has no gate and re-checks every run (the
+#      self-heal's documented exception).
+#   2. Trigger. Four kinds, and nothing else is recognised:
+#        always             fires whenever the marker gate let it through.
+#        file-absent        fires when `trigger.path` is not a file.
+#        gitignore-blanket  fires when `trigger.path` carries a blanket line
+#                           for .milestone-config that no broad un-ignore
+#                           clears.
+#        unbootstrapped     fires when the resolved projectDocs tree holds no
+#                           file, or .milestone-config/driver.json is missing.
+#      An unrecognised kind does not fire, which is how a data file written by
+#      a newer version degrades here: silently, one unit at a time.
+#   3. Print. The unit's `text` lines, one per line, byte-exact. The single
+#      substitution is `{{projectDocs}}`, replaced with the resolved
+#      projectDocs path with trailing slashes stripped.
+#   4. Write. A unit carrying `writes` creates that file from `writes.lines`.
+#   5. Marker. A unit carrying a `marker` writes it, so it stays silent later.
+#
+# Working directory:
+#   Every path a unit names is relative to the CURRENT working directory: the
+#   consumer's repo root, where the calling skill already stands. The data file
+#   is resolved next to THIS script instead, because the plugin is installed
+#   outside the repo it acts on, so a repo-relative path would not find it.
+#
+# Why jq, and why one call per step:
+#   jq is the approved bash-path JSON parser (.project/library-manifest.md
+#   (## Approved libraries (by purpose)); the PowerShell twin uses native
+#   ConvertFrom-Json). Unit metadata is fetched in ONE call that emits one
+#   `|`-joined row per selected unit, and text/body lines in one call each,
+#   with `jq -r` writing each array element followed by a newline: byte-for-byte
+#   what the `printf '%s\n'` emitters in the doc produce. `|` is safe as the row
+#   separator because every field it carries is an id, a kind, or a path, and
+#   none may contain that character.
+#
+# Best-effort, always:
+#   This script never aborts its caller (.project/design-philosophy.md
+#   (## Error & failure philosophy)). A missing jq, a missing or malformed data
+#   file, an unusable unit, or a failed write is skipped, and the exit status is
+#   0 in every case, including a usage error (which still prints one line to
+#   stderr, because a mis-wired call site is a bug worth seeing). `set -e` is
+#   deliberately NOT set: aborting mid-run on a non-zero status is the one
+#   behavior this contract forbids.
+#
+# Run it locally from a consumer repo root:  <plugin>/scripts/emit-notice.sh plan
+# Exit 0, always.
+
+DATA="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/emit-notice.json"
+
+# --- guards: no jq, no data file, no unit array -> do nothing ----------------
+command -v jq >/dev/null 2>&1 || exit 0
+[ -f "$DATA" ] || exit 0
+jq -e '(.units | type) == "array"' "$DATA" >/dev/null 2>&1 || exit 0
+
+# --- arguments ---------------------------------------------------------------
+mode=""
+sel=""
+case "${1:-}" in
+  --section)
+    mode="section"
+    sel="${2:-}"
+    ;;
+  plan|create|update)
+    mode="caller"
+    sel="$1"
+    ;;
+esac
+
+if [ -z "$mode" ] || [ -z "$sel" ]; then
+  echo "usage: emit-notice.sh <plan|create|update> | emit-notice.sh --section <section-id>" >&2
+  exit 0
+fi
+
+# --- resolve projectDocs -----------------------------------------------------
+#
+# Same read and same default as the doc's bootstrap-nudge emitter, so the two
+# can't diverge: a non-string projectDocs (number/array), a missing file, or
+# malformed JSON all fall back to .project/. ALL trailing slashes are stripped
+# for the detect operand; an empty result (e.g. "/") falls back to .project so
+# bash and PowerShell agree. The notice text re-adds the single "/", so the
+# printed path always ends in one.
+pd="$(jq -r 'if (.projectDocs | type) == "string" then .projectDocs else ".project/" end' .milestone-config/feeder.json 2>/dev/null || echo ".project/")"
+[ -z "$pd" ] && pd=".project/"
+while [ "$pd" != "${pd%/}" ]; do pd="${pd%/}"; done
+[ -z "$pd" ] && pd=".project"
+
+# --- trigger kinds -----------------------------------------------------------
+#
+# Returns 0 (fires) or 1 (does not). Every unrecognised kind returns 1, so an
+# unknown trigger skips its unit rather than firing it blind. The two regexes
+# below are the doc's legacy-blanket detect verbatim: a blanket counts as
+# present UNLESS a broad un-ignore re-exposes the tracked config.
+trigger_fires() {
+  trigger_kind="$1"
+  trigger_path="$2"
+  case "$trigger_kind" in
+    always)
+      return 0
+      ;;
+    file-absent)
+      [ -n "$trigger_path" ] || return 1
+      [ ! -f "$trigger_path" ]
+      ;;
+    gitignore-blanket)
+      [ -n "$trigger_path" ] && [ -f "$trigger_path" ] \
+        && grep -Eq '^[[:space:]]*/?\.milestone-config(/\*?)?[[:space:]]*$' "$trigger_path" 2>/dev/null \
+        && ! grep -Eq '^[[:space:]]*!/?\.milestone-config(/\*?)?[[:space:]]*$' "$trigger_path" 2>/dev/null
+      ;;
+    unbootstrapped)
+      [ -z "$(find -L "$pd" -type f 2>/dev/null | head -1)" ] || [ ! -f ".milestone-config/driver.json" ]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# --- select the units --------------------------------------------------------
+#
+# One row per selected unit, in file order:
+#   <index>|<marker>|<trigger.kind>|<trigger.path>|<writes.path>|<writes.lines count>
+# `index($sel)` yields a number (0 included, which jq treats as truthy) when the
+# caller is listed and null when it is not. `try ... catch empty` scopes a bad
+# entry to ITSELF: a unit that is not an object, or whose fields are the wrong
+# type, contributes no row and the walk continues, which is the same per-unit
+# skip the PowerShell twin performs.
+#
+# Shape gate, ahead of the match: a unit is usable only when it is an object,
+# its `text` is an array, and, when it carries `writes`, `writes.lines` is an
+# array too. Anything else is a MALFORMED unit and is skipped whole: nothing
+# printed, no file written, and NO MARKER, so a bad entry can never permanently
+# suppress its own notice. The PowerShell twin applies the same three tests, so
+# a degenerate data file produces identical silence on both platforms
+# (.project/conventions.md (## Test patterns), which makes bash/pwsh parity on
+# degenerate inputs a test obligation).
+#
+# The caller match tests `skills` for an ARRAY before `index($sel)`. Without
+# that test jq's `index` runs as SUBSTRING matching on a string, so a `skills`
+# of "replanted" would match the caller `plan` here and match nothing in the
+# PowerShell twin's `-contains`.
+rows="$(jq -r --arg sel "$sel" --arg mode "$mode" '
+  .units
+  | to_entries[]
+  | try (
+      select((.value | type) == "object")
+      | select((.value.text | type) == "array")
+      | select((.value.writes | type) == "null"
+               or (.value.writes.lines | type) == "array")
+      | select(if $mode == "caller"
+               then (.value.skills | if type == "array" then index($sel) else false end)
+               else .value.id == $sel
+               end)
+      | [ (.key | tostring),
+          (.value.marker // ""),
+          (.value.trigger.kind // ""),
+          (.value.trigger.path // ""),
+          (.value.writes.path // ""),
+          ((.value.writes.lines // []) | length | tostring),
+          (.value.text | length | tostring) ]
+      | join("|")
+    ) catch empty' "$DATA" 2>/dev/null)"
+
+[ -n "$rows" ] || exit 0
+
+# --- run them ----------------------------------------------------------------
+#
+# A here-string, not a pipe, so the loop body runs in THIS shell.
+#
+# The marker is written LAST, and only once the text has printed and the unit's
+# file (if it has one) has been written. A failure at either step skips the
+# marker, so the notice is still owed on the next run rather than silently
+# retired unshown.
+#
+# Each body is built WHOLE in memory before anything is emitted, so a jq failure
+# costs the unit rather than leaving half a notice on screen or a truncated file
+# on disk. `EOT` is appended inside jq and stripped back off with `%`, because
+# command substitution eats trailing newlines and the emitted bytes are the
+# contract: the sentinel keeps the final newline that `printf '%s\n'` produced
+# in the doc's emitters.
+while IFS='|' read -r idx marker kind tpath wpath wcount tcount; do
+  [ -n "$idx" ] || continue
+
+  # 1. marker gate
+  if [ -n "$marker" ] && [ -f "$marker" ]; then
+    continue
+  fi
+
+  # 2. trigger
+  trigger_fires "$kind" "$tpath" || continue
+
+  # 3. print the notice text. `tostring` before gsub matches the PowerShell
+  #    twin's [string] cast on each element.
+  if [ "$tcount" != "0" ]; then
+    text_out="$(jq -r --argjson i "$idx" --arg pd "$pd" \
+      '[ .units[$i].text[] | tostring | gsub("\\{\\{projectDocs\\}\\}"; $pd) + "\n" ] | join("") + "EOT"' \
+      "$DATA" 2>/dev/null)" || continue
+    [ -n "$text_out" ] || continue
+    printf '%s' "${text_out%EOT}" || continue
+  fi
+
+  # 4. write the unit's file, when it has one. The only unit that does is the
+  #    self-heal, whose trigger is the absence of exactly this path, so this
+  #    can never clobber a user-edited file.
+  if [ -n "$wpath" ] && [ "$wcount" != "0" ]; then
+    write_body="$(jq -r --argjson i "$idx" \
+      '[ .units[$i].writes.lines[] | tostring + "\n" ] | join("") + "EOT"' \
+      "$DATA" 2>/dev/null)" || continue
+    [ -n "$write_body" ] || continue
+    mkdir -p "$(dirname "$wpath")" 2>/dev/null || true
+    printf '%s' "${write_body%EOT}" > "$wpath" 2>/dev/null || continue
+  fi
+
+  # 5. write the marker, so a marker-gated unit stays silent from here on
+  if [ -n "$marker" ]; then
+    mkdir -p "$(dirname "$marker")" 2>/dev/null && : > "$marker" 2>/dev/null || true
+  fi
+done <<< "$rows"
+
+exit 0


### PR DESCRIPTION
Ships the seven one-time notices as a script twin pair with single-source text per #436: `scripts/emit-notice.sh` + `scripts/emit-notice.ps1` (both modes: caller `<plan|create|update>` with the Skills-field filter, and `--section <id>` which bypasses only that filter; marker-gated; best-effort, never aborts the caller) and `scripts/emit-notice.json` (each notice's text exactly once, generated by executing the doc's own emitters, never re-typed; carries #337's UTF-8 guard behavior and #366's 12-entry gitignore block). Nothing calls the scripts yet; #440 wires the four call sites and collapses the doc. Includes the one-line `.project/conventions.md` scripts/ gloss correction this diff makes necessary (Out-of-scope corrections).

Verification highlights: a 52-check byte-parity harness with golden outputs captured by executing `docs/one-time-notices.md`'s fences (sh == ps1 == doc on all seven units, three caller modes, section mode; self-heal writes a file md5-identical to the committed authority; error paths exit 0 quietly; stock bash 3.2 parity). Cycle-2 reviewer independently reproduced byte-neutrality across four implementations and the adversarial sentinel case.

## Decision Log

- Data file generated by executing the doc's emitters, never transcribed · byte-identity is the AC; hand-copying emoji/backticks across two shells is where identity breaks · `docs/one-time-notices.md (How each skill runs this file)` · rejected: transcription plus diff.
- Companion at `scripts/emit-notice.json`, shared basename · jq on the bash path, native ConvertFrom-Json on pwsh, both approved; basename pairing mirrors hooks/no-source-edit · `.project/library-manifest.md (Approved libraries)`; `.project/conventions.md (Naming)` · rejected: markdown data (two hand parsers); per-unit files.
- One argv shape for both twins; `$args` parsing, not `param()` · #440 documents one invocation, not two · `.project/library-manifest.md (Runtime & frameworks)` · rejected: an idiomatic `-Section` parameter.
- Section ids independent of markers · the issue-template marker is versioned by design; a marker-derived id breaks on revision · `docs/one-time-notices.md (Consumer issue-template notice, Note)` · rejected: marker-basename ids.
- Four closed trigger kinds, per-language implementations, path operand in data · a data-stored regex needs two forms and drifts; the single-source invariant covers TEXT · issue #436 invariant notice-text-single-source · rejected: per-language regexes in data.
- No `set -e`; explicit exit 0; usage errors print one stderr line and exit 0 · never-abort is the contract; silence would hide a typo'd caller · `.project/design-philosophy.md (Error & failure philosophy)` · rejected: `set -euo pipefail`; full silence; non-zero exits.
- Post-review: shape gate on `text`/`writes.lines` (non-array skips the unit whole, no marker, both twins); marker written only after a successful print/file write (bash builds content whole, checks status, `continue`s past the marker on failure; a sentinel preserves trailing newlines); string `skills` no longer substring-matches (jq type guard) and pwsh moved to case-sensitive `-ccontains`/`-ceq` · twin parity on degenerate inputs is a recorded obligation · `.project/conventions.md (Test patterns)`; the hooks/no-source-edit.ps1 `-c` idiom · rejected: leaving the divergences.

## Code Review

- /code-review run: yes, twice (omission is a park trigger; a submitted PR always carries a real review; a parked run opens no PR)
- Findings: cycle 1, 2 Important + 4 Minor at high effort; cycle 2 (post-fix, code-changed delta), 1 Minor
  - Important: the vocabulary gate's scripts/ exclusion leaves emit-notice.json's consumer-facing text unscanned once it becomes the only runtime copy → accepted here (rationale: the gate script is outside this issue's file scope; assigned to #440, whose fence deletion falsifies the gate header's coverage claim and whose same-pass-correction convention owns the fix)
  - Important: nothing committed guards emit-notice.json's shape (the parity harness is scratch) → accepted here (rationale: same scope fence; recorded for #440/the follow-up issue as a jq shape assertion or slim committed parity check)
  - Minor (cycle 1): degenerate-data twin divergences → re-dispatched and resolved (shape gate + marker ordering + type/case guards; verified by execution in cycle 2)
  - Minor (cycle 2): a string `skills` exactly equal to the caller fires on pwsh only (`@()` coercion); one-line `-is [array]` guard → accepted (rationale: heavy profile's two-cycle cap; fails in the safe direction and needs a malformed shipped data file; assigned to #440's shape-guard work with the reviewer's exact fix)
  - Minor: JSON self-doc uses three underscore keys vs the siblings' single-key conventions → accepted (rationale: cosmetic; fold into `$comment` on next touch)
  - Minor: jq-less machines now get zero notices from the bash path (doc-era emitters needed jq only for one resolve) → accepted (rationale: within the AC's skip semantics; one sentence owed in #440's call-site docs, recorded there)
- No park-triggering findings.
- Version bump: none needed (base already carries 0.14.1; idempotent)

Gates: check-vocabulary exit 0 · validate-plugin-structure exit 0 (36 files) · check-contract-strings exit 0. Coherence pass: one trivial finding (JSON self-doc key style) + a codify-the-script-header-shape proposal, recorded for the run summary.

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
