### PR TITLE
Retire the uiSurfaceGlobs-absent blanket classification rule (#428)

### DIFF
--- a/agents/issue-author.md
+++ b/agents/issue-author.md
@@ -47,7 +47,7 @@ You guarantee the five criteria the driver's triage checks: clause N below is `m
 
 4. **Dependencies.** Record each architect edge touching this candidate as `Depends on #<tag> - <reason / the exact reference>`, transcribing the reference exactly. Never invent an edge, and never reorder the Waves.
 
-5. **UI vs logic + risk.** Classify `Surface: ui | logic`: **ui** when the issue touches a `uiSurfaceGlobs` path or carries a visible or interactive affordance, **logic** otherwise. A **ui** issue's Design section carries:
+5. **UI vs logic + risk.** Classify `Surface: ui | logic`: **ui** when the issue touches a `uiSurfaceGlobs` path or carries a visible or interactive affordance, **logic** otherwise. This test is the run's **only** `ui | logic` classification. You are the single actor that applies it, once, while authoring this issue, and your `LABELS` return is the answer every downstream step carries. It holds whether or not `uiSurfaceGlobs` resolved, because the affordance half needs no globs: an absent `uiSurfaceGlobs` drops the path half and nothing else, and never makes a candidate `logic` by itself (`skills/plan/SKILL.md (Degradation)`). The architect's `surface` value is a pre-classification hint you receive and may overturn (`agents/architect.md` clause 5); nothing re-classifies your answer afterwards. A **ui** issue's Design section carries:
    - the existing pattern to mirror at `path (anchor)` or `file:line` (both defined in `milestone-driver/skills/citation-format.md`, bound by the Rigor gate below)
    - the required states: empty, loading, error, disabled
    - the affordances, including a confirm affordance for any destructive op

--- a/docs/plan-file-contract.md
+++ b/docs/plan-file-contract.md
@@ -70,7 +70,7 @@ Milestone number (GitHub): <n>   # OPTIONAL sibling header line: carried forward
 
 ## Project-docs grounding
 - <each design call carried forward>: grounded in <.project/<doc>.md#<section> | sibling path (anchor) | sibling file:line>
-- Degradations: <e.g. "uiSurfaceGlobs absent → all candidates treated as logic"; "none" otherwise>
+- Degradations: <e.g. "uiSurfaceGlobs absent → no glob-based UI match; each candidate classified by the issue-author's affordance test"; "none" otherwise>
 
 ## Needs human input
 <pointer: "see .milestone-feeder/needs-product-input-<slug>.md" when productGaps is non-empty; "none" otherwise>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -43,7 +43,7 @@ While reading, **also assemble the four Step-0 grounding inputs** the inner rout
 | **Project-local overlay** | The optional `.milestone-config/implied-surfaces.md`, **merged ADDITIVELY** into the global reference (global is the floor, never reduced; empty / add-nothing → merged == global), producing the ONE merged reference handed downstream. |
 | **Consumer issue-template** | The consumer repo's `.github/ISSUE_TEMPLATE/` template the issue-author writes to. Selection is a **four-rung** rule (the driver config's `agentIssueTemplate`, else exactly one selectable template, else the built-in default, and absence never blocks) stated authoritatively at `docs/step-0-grounding.md` §5, **not restated here**. Rung 1 rides the same driver-config chain as the shared keys below and is **not** a fourth shared key. |
 
-Step 0 only **produces** these; the Step-3 architect brief and Step-4 issue-author brief that **consume** them are wired at Steps 3 / 4. The candidate-scoped **file-map is NOT a Step-0 input**. It is built per candidate at Step 4 (`docs/file-map.md`). When `uiSurfaceGlobs` degradation applies (below), the digest is unaffected. It carries no UI-surface distinction.
+Step 0 only **produces** these; the Step-3 architect brief and Step-4 issue-author brief that **consume** them are wired at Steps 3 / 4. The candidate-scoped **file-map is NOT a Step-0 input**. It is built per candidate at Step 4 (`docs/file-map.md`). The digest carries no UI-surface distinction and is unaffected by whether `uiSurfaceGlobs` resolves.
 
 Resolve the **shared keys** the architect and issue-author need for grounding, from the driver config (`docs/profile-schema.md` shared-keys chain):
 
@@ -53,7 +53,7 @@ Resolve the **shared keys** the architect and issue-author need for grounding, f
 
 The shared keys are exactly three: `sourceGlobs`, `uiSurfaceGlobs`, `integrationBranch` (the canonical consumer-facing set: `SPEC.md` §7, `docs/profile-schema.md` §2). Each resolves down the chain above. The `agentIssueTemplate` read at `docs/step-0-grounding.md` §5 rung 1 uses this same chain but does **not** join the triple. That set stays three.
 
-**Degradation:** when `uiSurfaceGlobs` is absent (neither driver file carries it), treat every candidate as **logic** (no UI surface can be matched, so no design-lens distinction is drawn) and **state the degradation** in the plan file's grounding section. The pipeline still runs.
+**Degradation:** when `uiSurfaceGlobs` is absent (neither driver file carries it), no candidate can be matched to a UI surface **by glob**. Classification itself is unaffected: the issue-author classifies every candidate at Step 4 under its own affordance test (`agents/issue-author.md` clause 5), which reads the candidate's own facts and needs no globs. Its `LABELS` return is the run's **single authoritative** `ui | logic` answer, glob-present or glob-absent; the architect's `surface` value (`agents/architect.md` clause 5) is a hint `plan` threads through and never a second verdict. **State the degradation** in the plan file's grounding section as the absent key and its effect (no glob-based UI match), **never** as a `logic` verdict: candidates are not flattened to `logic`. The pipeline still runs.
 
 ### The single-milestone inner routine (Steps 1–7): callable contract
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -113,9 +113,10 @@ loaded as plugin skills.
 - **Brief**: "Build these ~10 pages, each listing <entities> in a table". It **does not
   restate** the table directive. The feeder must pull it from the project docs, apply it to
   every page-issue, and cite it.
-- **Config**: `uiSurfaceGlobs` **must be set** so the page-issues classify as UI and carry the
-  design spec (states / affordances / pattern) the driver's design lens checks (absent →
-  everything is logic and the design spec is never authored).
+- **Config**: `uiSurfaceGlobs` is **set**, mirroring the driver's own config, so the glob half
+  of the classification engages alongside the affordance half and the page-issues carry the
+  design spec (states / affordances / pattern) the driver's design lens checks (absent → no
+  glob-based UI match; the affordance test still classifies these pages `ui`).
 - **Expected** (grader): every page-issue carries the full directive (sortable + filterable
   except actions + pagination 30/page) in its acceptance criteria, verbatim-equivalent (no
   drift, no silent weakening of "30/page"), and cites the convention. Every issue is drafted

--- a/tests/scenarios/11-roadmap-fan-out/expected.grader.md
+++ b/tests/scenarios/11-roadmap-fan-out/expected.grader.md
@@ -79,11 +79,12 @@ assertions exist), not executed.
 - After the fan-out, **each manifest entry's `Plan file:` field is populated** with
   that milestone's real path (no longer PENDING): the handle `create`'s deploy-loop
   later resolves each milestone by (never a name-derived slug).
-- **UI classification engages per milestone:** because `uiSurfaceGlobs` is set, the
-  portal / dashboard / revenue-report **page-issues classify `ui`** and their
-  authoring carries the design spec (states + `DataTable` + 30/page directive
-  cited from `project/conventions.md`) the driver's design lens checks; the auth /
-  data-model / API issues classify `logic`.
+- **UI classification runs per milestone:** the portal / dashboard / revenue-report
+  **page-issues classify `ui`** and their authoring carries the design spec (states +
+  `DataTable` + 30/page directive cited from `project/conventions.md`) the driver's
+  design lens checks; the auth / data-model / API issues classify `logic`. Because
+  `uiSurfaceGlobs` is set, the glob half of the test engages here too, agreeing with
+  the affordance half on every candidate.
 
 ## MUST: empty fan-out: single-milestone collapse is a valid outcome, not an error  (✅ preview)
 

--- a/tests/scenarios/13-layer-aware-breakdown/feeder-env.md
+++ b/tests/scenarios/13-layer-aware-breakdown/feeder-env.md
@@ -17,6 +17,6 @@ dependency-only breakdown.
 - `feeder.json`: defaults (`projectDocs: project/`).
 - Driver shared keys (as if from `.milestone-config/driver.json`):
   - `sourceGlobs`: `["src/**"]`
-  - `uiSurfaceGlobs`: `["src/web/**"]`   # nothing in this backend feature matches → every candidate classifies `logic`
+  - `uiSurfaceGlobs`: `["src/web/**"]`   # no glob match in this backend feature and no candidate carries an affordance → every candidate classifies `logic`
   - `integrationBranch`: `"develop"`
 - Project docs dir: `project/`

--- a/tests/scenarios/15-prose-style/expected.grader.md
+++ b/tests/scenarios/15-prose-style/expected.grader.md
@@ -23,7 +23,12 @@ The expected candidate set (local tags; exact titles may vary):
 
 | Tag | Candidate | Surface | Touches |
 |---|---|---|---|
-| #A | Add a paginated activity-log list | `logic` | list / pagination (30 rows per page) |
+| #A | Add a paginated activity-log list | `ui` | list / pagination (30 rows per page) |
+
+`uiSurfaceGlobs` is absent here, which removes the path half of `agents/issue-author.md`
+clause 5 and nothing else: the pagination affordance carries the classification, so `ui` is
+the one answer both runs must produce. Surface is context for this prose-style scenario and
+is not scored below.
 
 ---
 

--- a/tests/scenarios/15-prose-style/feeder-env.md
+++ b/tests/scenarios/15-prose-style/feeder-env.md
@@ -23,6 +23,6 @@ plan-side portion of scenarios 11–14.
 - `feeder.json`: defaults (`projectDocs: project/`).
 - Driver shared keys (as if from `.milestone-config/driver.json`):
   - `sourceGlobs`: `["src/**"]`
-  - `uiSurfaceGlobs`: absent   # no UI surface matched → the candidate classifies `logic`
+  - `uiSurfaceGlobs`: absent   # no glob-based UI match; the issue-author classifies #A `ui` on its pagination affordance (`agents/issue-author.md` clause 5)
   - `integrationBranch`: `"develop"`
 - Project docs dir: `project/`


### PR DESCRIPTION
Retires the uiSurfaceGlobs-absent "treat every candidate as logic" blanket rule per the recorded decision on #428 (2026-08-17): `skills/plan/SKILL.md`'s Degradation paragraph now states that glob absence removes only the glob half of the classification test, the issue-author's affordance test (agents/issue-author.md clause 5) is the run's single authoritative classifier at Step 4, and the degradation is still recorded in the plan file's grounding section but never as a `logic` verdict. Clause 5 names the actor, the step, and the carrier (`LABELS`), marks the architect's `surface` an overturnable hint, and keeps the test itself byte-identical to base. The AC4 sweep re-pinned every live site quoting the retired rule: `docs/plan-file-contract.md`'s example Degradations line, `tests/README.md`'s scenario-06 Config bullet, scenario 15's fixture + grader (Surface cell flipped logic → ui on the pagination affordance, with a note that Surface is unscored there), scenario 13's comment (now names both halves), and scenario 11's grader (classification unconditional; the glob half is what globs condition). The four dated 2026-08-13 observed/RESULTS records stay byte-unchanged per the issue's Non-goals. Full sweep listing (8 re-pinned, 1 touched up, 4 protected, the inspected-clean set) is on the issue.

## Decision Log

- Retired the plan-skill rule and kept clause 5 · the recorded decision binds the direction; the affordance half needs no globs, so absence never justifies flattening a surface-rendering candidate · issue #428 decision comment · rejected: both rules with a precedence note.
- Kept the grounding-section degradation note while forbidding a logic verdict there · an absent shared key is still a real degradation the reader must see; only its wrong consequence retired · `docs/plan-file-contract.md (Project-docs grounding)` · rejected: dropping the note.
- Stated the authority ranking inside clause 5 rather than editing the architect · the triage advisory pins the architect's hint and the plan hand-in untouched · `agents/architect.md` clause 5 ("UI-vs-logic + risk hint", "Pre-classify") · rejected: a "non-binding" qualifier on the architect, restating the invariant in two files.
- Flipped scenario 15's declared Surface to ui · the fixture derived logic from glob absence (the retired inference) and a paginated activity-log list carries an interactive affordance · `.project/conventions.md (## Out-of-scope corrections)` · rejected: leaving a false expectation as "unscored".
- Left every dated record byte-unchanged · true records of a past commit, protected by the issue's Non-goals · issue #428 (## Non-goals) · rejected: appending resolution notes to protected records.

## Code Review

- /code-review run: yes, twice (omission is a park trigger; a submitted PR always carries a real review; a parked run opens no PR)
- Findings: cycle 1, 1 Critical + 3 Minor at high effort; cycle 2 (post-fix, code-changed delta), 1 Minor
  - Critical: tests/README.md:116-118 still stated the retired rule live (AC4 unmet) → re-dispatched and resolved (re-pinned to the two-half rule; verified in cycle 2)
  - Minor: scenario 13's comment elided the affordance half → re-dispatched and resolved
  - Minor: scenario 11's grader implied classification is glob-conditioned → re-dispatched and resolved
  - Minor: AC4's sweep listing owed on the record → resolved (posted with the citations comment on the issue)
  - Minor (cycle 2, pre-existing base text): two graders' "(uiSurfaceGlobs ignored)" parenthetical is an incomplete diagnosis under the surviving rule → accepted (rationale: not a statement of the retired rule; outside this diff; recorded for the run-end follow-up set)
- No park-triggering findings.
- Version bump: none needed (base already carries 0.14.1; idempotent)

Gates: check-vocabulary exit 0 · validate-plugin-structure exit 0 (36 files) · check-contract-strings exit 0. Clause 5's test byte-identical to base (probe-verified both cycles). Coherence pass: clean fit, no findings.

Closes #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
