### PR TITLE
chore(scripts): re-pin FILE_WORD_CEILINGS to the post-trim word counts (#451)

### DIFF
--- a/scripts/validate-plugin-structure.py
+++ b/scripts/validate-plugin-structure.py
@@ -596,44 +596,35 @@ for skill_md in sorted((REPO_ROOT / "skills").rglob("SKILL.md")):
 #   - docs/architecture.md, docs/consumer-setup.md, and
 #     docs/never-claims-audit.md carry no skills/ or agents/ reference at all,
 #     so no run loads them.
-# Every value below was measured on the integration branch (issue #394). Two
-# have been tightened since, both when create's Step 3 write-sequence passes
-# a to d moved into the deploy-write-sequence script twins: that change shrank
-# docs/create-deploy-sequence.md, and it re-pinned skills/create/SKILL.md to
-# its formula value (the file grew slightly there; 4650 still sits below the
-# prior 4700, so never-up holds); it has since shrunk, to 4549, and its
-# recorded 4650 stands (the per-entry note below). SPEC.md has since shrunk
-# to 6447 (a tightening pass would record 6800) and its recorded value stands
-# until that pass runs, because the never-up rule permits a descent without
-# compelling one. No other governed file's count moved off its recorded
-# ceiling.
+# Every value below was re-pinned to its governed file's actual
+# `len(text.split())` count as of milestone v0.14.1, by the formula above
+# (that count times 1.05, rounded up to the next 50). Two entries hold their
+# previously recorded value instead, because the formula exceeds it and the
+# never-up rule outranks the formula; each carries a per-entry note.
 FILE_WORD_CEILINGS: dict[str, int] = {
     # 4549 words times 1.05 is 4776.45, which rounds up to 4800. The recorded
     # 4650 stands instead, because the never-up rule outranks the formula.
     "skills/create/SKILL.md": 4650,
     "skills/update/SKILL.md": 6550,
-    "skills/build-roadmap/SKILL.md": 2700,
-    "skills/setup/SKILL.md": 2550,
-    # 9404 words times 1.05 is 9874.2, which rounds up to 9900. The recorded
-    # 9880 stands instead, because the never-up rule outranks the formula.
-    "skills/plan/SKILL.md": 9880,
-    "agents/architect.md": 3500,
-    "agents/issue-author.md": 3200,
-    "agents/roadmap-splitter.md": 2400,
-    "SPEC.md": 6850,
-    # 12625 words times 1.05 is 13256.25, which rounds up to 13300. The
-    # recorded 13250 stands instead, because the never-up rule outranks the
-    # formula.
-    "docs/create-deploy-sequence.md": 13250,
+    "skills/build-roadmap/SKILL.md": 2650,
+    "skills/setup/SKILL.md": 2400,
+    "skills/plan/SKILL.md": 9550,
+    "agents/architect.md": 2950,
+    "agents/issue-author.md": 2900,
+    "agents/roadmap-splitter.md": 1850,
+    "SPEC.md": 6800,
+    "docs/create-deploy-sequence.md": 12100,
     "docs/file-map.md": 1450,
     "docs/implied-surfaces.md": 1250,
-    "docs/one-time-notices.md": 5350,
+    "docs/one-time-notices.md": 2050,
     "docs/plan-file-contract.md": 1600,
     "docs/profile-schema.md": 2400,
     "docs/roadmap-fan-out.md": 2450,
     "docs/roadmap-manifest-format.md": 1050,
     "docs/step-0-grounding.md": 2050,
     "docs/style-contracts.md": 800,
+    # 2450 words times 1.05 is 2572.5, which rounds up to 2600. The recorded
+    # 2450 stands instead, because the never-up rule outranks the formula.
     "docs/update-reconcile-parent.md": 2450,
     "docs/version-ladder.md": 1300,
 }


### PR DESCRIPTION
Closes #451.

## Summary

All 21 `FILE_WORD_CEILINGS` entries in `scripts/validate-plugin-structure.py` re-pinned against the final post-trim tree (develop @ c3ab5f7): 9 lowered to their formula value (`len(text.split())` x 1.05, rounded up to the next 50), 2 held by the never-up rule with per-entry notes (`skills/create/SKILL.md` at 4650 vs formula 4800; `docs/update-reconcile-parent.md` at 2450 vs formula 2600), 10 already at formula, none removed (all 21 governed paths exist). The measurement note is rewritten as-of milestone v0.14.1; two subsumed history comments dropped; `AGENT_DESCRIPTION_WORD_CEILING` untouched. This closes the milestone-end ceiling ratchet recorded on PR #464 (the per-issue ratchet superseded to this issue). Largest single drop: `docs/one-time-notices.md` 5350 to 2050.

## Decision Log

- Nine entries lowered to formula; the ratchet compels the descent; `scripts/validate-plugin-structure.py (Ceiling discipline)`.
- Two entries held above formula per never-up, each with a per-entry note stating the arithmetic; rejected writing 4800/2600, which the never-up rule forbids.
- The two per-entry history comments whose never-up holds this re-pin ended were deleted; their entries now take formula values the fresh note already explains; rejected updating them (restatement).
- Measurement note names milestone v0.14.1 as the as-of point and drops the "pending that pass" phrasing; that pass is this change.
- `AGENT_DESCRIPTION_WORD_CEILING` untouched (flat policy ceiling, per the issue's AC4).

## Code Review

- /code-review run: yes (omission is a park trigger - a submitted PR always carries a real review; a parked run opens no PR)
- Findings: 0 in-scope findings at medium effort (light profile, round 1 clean; commit-direct path)
  - The reviewer AST-compared the dict (21 keys before and after, 9 lowered, 0 raised), spot-checked four entries including both never-up holds (all arithmetically exact), and ran the three gates (all exit 0)
  - One awareness note, no action: `docs/update-reconcile-parent.md` sits at 2450/2450, zero headroom; the next edit to that doc trims as it adds, per the ratchet's design
- Version bump: `.claude-plugin/plugin.json` already at target 0.14.1 (idempotent milestone bump, no change in this PR)
- Coherence pass (never-gating): FINDINGS none; all 21 values independently re-derived and matched exactly; the pass also corrected the implementer summary's count (9 lowered / 10 unchanged, not 10/9 - the table and diff were always right)
- No park-triggering findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
