### PR TITLE
feat(scripts): pin the nested .gitignore self-heal block across its three copies (#492)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "milestone-feeder",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Turns a feature brief into a GitHub milestone + small, well-formed issues that milestone-driver can build with no human clarification. Run `plan` to turn your brief into a reviewable plan of independently-buildable issues: each with a full spec (acceptance criteria covering empty/error/disabled states, recorded consistent design, declared dependency edges, and UI/logic + risk classification) and a build order encoded in the milestone description; every issue is drafted to pass the driver's triage cleanly. The driver's triage is the single automated entry gate, so the feeder aims at that bar rather than re-running it. Run `create` to build exactly the plan you approved, and `update` to sync a changed plan onto the existing milestone (never closes or deletes). Reads code, never writes it. Stack-agnostic via a thin per-repo profile.",
   "author": {
     "name": "Ken Mulford",

--- a/scripts/validate-plugin-structure.py
+++ b/scripts/validate-plugin-structure.py
@@ -26,6 +26,12 @@ It checks:
      `description` also stays at or under a flat 150-word ceiling. A
      written size standard with no gate is exactly what let these regrow past
      their targets before (see "--- 6: size budgets ---" below).
+  5. The nested .milestone-config/.gitignore self-heal block (issue #492): its
+     three hand-synced copies stay equal line for line. Those are
+     scripts/emit-notice.json's `writes.lines` array, the fenced block in
+     docs/one-time-notices.md, and this repo's own committed
+     .milestone-config/.gitignore. A drifted copy is named, and so is a
+     missing one (see "--- 7: nested .gitignore three-copy pin ---" below).
 
 Two readers, two rules (read before "upgrading" this):
   Claude Code's frontmatter reader is tolerant: it takes everything after the
@@ -655,9 +661,10 @@ FILE_WORD_CEILINGS: dict[str, int] = {
     # section per unit, each of which must fence that unit's printed text
     # verbatim ("Section fields" in the doc). An eighth such section does not
     # fit in the headroom the 2050 ceiling left, whatever its wording, because
-    # the fenced copy is byte-pinned to scripts/emit-notice.json and is not the
-    # author's to shorten independently. 2185 words times 1.05 is 2294.25,
-    # which rounds up to 2300.
+    # the fenced copy is pinned line for line to BOTH scripts/emit-notice.json's
+    # `writes.lines` array and .milestone-config/.gitignore by check 7 below,
+    # and is not the author's to shorten independently. 2185 words times 1.05
+    # is 2294.25, which rounds up to 2300.
     "docs/one-time-notices.md": 2300,
     "docs/plan-file-contract.md": 1600,
     "docs/profile-schema.md": 2400,
@@ -712,6 +719,189 @@ if agents_dir.is_dir():
                 f"over the flat {AGENT_DESCRIPTION_WORD_CEILING}-word "
                 f"ceiling every agent description is held to. Trim it",
             )
+
+# --- 7: nested .gitignore three-copy pin ------------------------------------
+#
+# Why this exists: the self-heal's ignore block is hand-synced across three
+# files, and hand-syncing it has already failed twice (issues #333 and #366).
+# Nothing reads one copy from another, so a divergence stays invisible until a
+# consumer is handed a block no doc describes. `scripts/emit-notice.json`'s
+# `writes.lines` array is what the self-heal actually WRITES; the fenced block
+# in `docs/one-time-notices.md` is what a reader is told they will get; and
+# `.milestone-config/.gitignore` is this repo's own copy of the result.
+#
+# Naming the drift: a single odd copy out of three is named against the two
+# that agree. When all three differ there is no majority, so the JSON array is
+# the reference (it is the writer) and every copy differing from it is named.
+# A source absent ENTIRELY (the unit gone from the JSON, the fenced block gone
+# from the doc, the committed .gitignore gone from disk) fails naming that
+# source, never a silent pass, on the same rule as "--- 6 ---"'s named-but-
+# missing case above.
+
+SELF_HEAL_UNIT_ID = "self-heal-nested-gitignore"
+SELF_HEAL_DOC_HEADING = "## Self-heal the nested .milestone-config/.gitignore"
+SELF_HEAL_DOC_FENCE = "```gitignore"
+
+
+def read_self_heal_json_lines(path: Path) -> list[str] | None:
+    """Return the self-heal unit's `writes.lines` array, or None on any miss."""
+    data = load_json(path)
+    if data is None:
+        return None
+    units = data.get("units")
+    unit = None
+    if isinstance(units, list):
+        for candidate in units:
+            if (
+                isinstance(candidate, dict)
+                and candidate.get("id") == SELF_HEAL_UNIT_ID
+            ):
+                unit = candidate
+                break
+    if unit is None:
+        err(
+            path,
+            f"has no unit with id '{SELF_HEAL_UNIT_ID}'. That unit is what "
+            f"writes a consumer's .milestone-config/.gitignore, so without "
+            f"it there is nothing for the other two copies to be pinned to",
+        )
+        return None
+    writes = unit.get("writes")
+    lines = writes.get("lines") if isinstance(writes, dict) else None
+    if not isinstance(lines, list) or not all(isinstance(x, str) for x in lines):
+        err(
+            path,
+            f"unit '{SELF_HEAL_UNIT_ID}' has no 'writes.lines' list of "
+            f"strings. That array is the block the self-heal writes",
+        )
+        return None
+    return lines
+
+
+def read_self_heal_doc_lines(path: Path) -> list[str] | None:
+    """Return the fenced gitignore block under the self-heal section heading."""
+    if not path.is_file():
+        # Silent on purpose: this path is in FILE_WORD_CEILINGS, so "--- 6 ---"
+        # above already fails it as missing from disk, and that section states
+        # this check does not double-report. Every other branch below names a
+        # defect no other check can see.
+        return None
+    lines = path.read_text(encoding="utf-8-sig").splitlines()
+    heading_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == SELF_HEAL_DOC_HEADING:
+            heading_idx = i
+            break
+    if heading_idx is None:
+        err(
+            path,
+            f"has no '{SELF_HEAL_DOC_HEADING}' heading, so the fenced copy "
+            f"of the self-heal ignore block cannot be found to pin",
+        )
+        return None
+    # Both scans stop at the next section. Unbounded, a LATER section's
+    # ```gitignore fence stands in for a deleted one here (the block could go
+    # missing and still PASS), an unrelated block gets reported as this one's
+    # drift, and a deleted CLOSING fence is masked by the next section's.
+    section_end = len(lines)
+    for i in range(heading_idx + 1, len(lines)):
+        if lines[i].startswith("## "):
+            section_end = i
+            break
+    open_idx = None
+    for i in range(heading_idx + 1, section_end):
+        if lines[i].startswith(SELF_HEAL_DOC_FENCE):
+            open_idx = i
+            break
+    if open_idx is None:
+        err(
+            path,
+            f"'{SELF_HEAL_DOC_HEADING}' carries no '{SELF_HEAL_DOC_FENCE}' "
+            f"fenced block. That block is the reader-facing copy of what "
+            f"the self-heal writes",
+        )
+        return None
+    for i in range(open_idx + 1, section_end):
+        if lines[i].strip() == "```":
+            return lines[open_idx + 1 : i]
+    err(
+        path,
+        f"'{SELF_HEAL_DOC_FENCE}' block under '{SELF_HEAL_DOC_HEADING}' is "
+        f"never closed",
+    )
+    return None
+
+
+def read_committed_gitignore(path: Path) -> list[str] | None:
+    """Return this repo's own committed nested .gitignore, line by line."""
+    if not path.is_file():
+        err(
+            path,
+            "is missing from disk. This repo's committed copy is one of the "
+            "three the self-heal block is pinned across; deleting or "
+            "renaming it fails here rather than dropping out of the pin",
+        )
+        return None
+    return path.read_text(encoding="utf-8-sig").splitlines()
+
+
+def first_line_difference(actual: list[str], expected: list[str]) -> str:
+    """Describe the first line on which two copies of the block disagree."""
+    for line_no, (got, want) in enumerate(zip(actual, expected), start=1):
+        if got != want:
+            return f"line {line_no} is {got!r} where {want!r} is expected"
+    if len(actual) > len(expected):
+        return (
+            f"carries {len(actual)} lines to {len(expected)}: line "
+            f"{len(expected) + 1}, {actual[len(expected)]!r}, is extra"
+        )
+    return (
+        f"carries {len(actual)} lines to {len(expected)}: line "
+        f"{len(actual) + 1}, {expected[len(actual)]!r}, is missing"
+    )
+
+
+emit_notice_json = REPO_ROOT / "scripts" / "emit-notice.json"
+one_time_notices_md = REPO_ROOT / "docs" / "one-time-notices.md"
+nested_gitignore = REPO_ROOT / ".milestone-config" / ".gitignore"
+
+# JSON first: `present` keeps this order, so present[0] is the writer whenever
+# the JSON parsed, and it is the reference wherever no majority names the drift.
+self_heal_copies = [
+    (emit_notice_json, read_self_heal_json_lines(emit_notice_json)),
+    (one_time_notices_md, read_self_heal_doc_lines(one_time_notices_md)),
+    (nested_gitignore, read_committed_gitignore(nested_gitignore)),
+]
+checked += len(self_heal_copies)
+present = [(p, lines) for p, lines in self_heal_copies if lines is not None]
+
+# Two present still compare: withholding the drift until the missing source is
+# restored would hand a fixer one defect per run instead of both at once.
+if len(present) >= 2:
+    odd = [
+        p
+        for p, lines in present
+        if all(lines != other for q, other in present if q != p)
+    ]
+    if len(odd) == 1:
+        drifted = odd
+        expected_path, expected_lines = next(
+            (p, lines) for p, lines in present if p not in odd
+        )
+    else:
+        expected_path, expected_lines = present[0]
+        drifted = [p for p, lines in present if lines != expected_lines]
+    for drifted_path in drifted:
+        drifted_lines = next(lines for p, lines in present if p == drifted_path)
+        err(
+            drifted_path,
+            f"has drifted from "
+            f"{expected_path.relative_to(REPO_ROOT)}'s copy of the self-heal "
+            f"ignore block: "
+            f"{first_line_difference(drifted_lines, expected_lines)}. The "
+            f"three copies are hand-synced and must stay equal line for "
+            f"line; re-sync this one",
+        )
 
 # --- report -----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #492.

`scripts/validate-plugin-structure.py` gains check 7: the nested `.milestone-config/.gitignore` self-heal block's three hand-synced copies (`scripts/emit-notice.json`'s `self-heal-nested-gitignore` unit `writes.lines`, the fenced block under `## Self-heal the nested .milestone-config/.gitignore` in `docs/one-time-notices.md`, and the committed `.milestone-config/.gitignore`) must be equal line for line. A single odd copy is named against the two that agree; when all three differ the JSON array is the reference (it is what the self-heal writes) and every copy differing from it is named. A source missing entirely (the unit, the fenced block, or the file on disk) fails naming that source. The module docstring gains the matching "It checks:" item, and the `FILE_WORD_CEILINGS` comment for `docs/one-time-notices.md` no longer claims a byte-pin that did not exist.

## Decision Log

- The JSON `writes.lines` array is the reference only when all three copies differ; a single odd copy is named against the two that agree · the array is what the self-heal actually writes, so it decides in the absence of a majority, while a majority localizes the drift more precisely · `scripts/emit-notice.json ("id": "self-heal-nested-gitignore")` · rejected always naming both non-JSON copies, which reports two files when one drifted.
- The comparison runs on two present sources as well as three, the majority rule at three and `present[0]` (the JSON when it parsed) as the reference otherwise · withholding the drift until the missing source is restored hands a fixer one defect per run instead of both at once · `scripts/emit-notice.json ("id": "self-heal-nested-gitignore")` · rejected requiring a complete set of three (the first round's behavior; a review finding).
- An absent `docs/one-time-notices.md` returns `None` with no `err()` of its own · that path is in `FILE_WORD_CEILINGS`, so check 6 already fails it as missing from disk, and that section states this check does not double-report; the heading-absent, fence-absent, and never-closed branches keep their own `err()` · `scripts/validate-plugin-structure.py (already fails that file, so this check does not double-report)` · rejected a second missing-file error (a review finding).
- The three readers are defined inside the section rather than beside `load_json()` · section 4 already defines `parse_hook_agent_set` inside its own section · `scripts/validate-plugin-structure.py (def parse_hook_agent_set(path: Path) -> set[str] | None:)` · rejected hoisting them to the shared helper block, where nothing else calls them.
- Errors go through the existing `err()` reporter, and `checked` bumps once per source examined (`+= len(self_heal_copies)`) · the report line prints "file(s) checked" and the `FILE_WORD_CEILINGS` loop bumps per file including a named-but-absent path · `scripts/validate-plugin-structure.py (is listed in FILE_WORD_CEILINGS)` · rejected one bump per check, which makes the count report checks run rather than files examined (the first round's choice; a review finding).
- All three sources are read with `encoding="utf-8-sig"` and compared by `splitlines()` rather than bytes · the file reads every other governed file that way so a Windows-editor BOM does not fail a line-1 comparison · `scripts/validate-plugin-structure.py (Files are read as utf-8-sig)` · rejected a byte-for-byte compare, which would fail on a BOM or a CRLF checkout rather than on real drift.
- The false `FILE_WORD_CEILINGS` claim is corrected in the same pass rather than filed · correcting a statement the diff makes false, on a line the diff derives, is in scope · `.project/conventions.md#Out-of-scope corrections` · rejected a follow-up issue, which strands a false claim on the integration branch.
- The section comment cites the two prior hand-sync failures by issue number instead of a bare count · the count is checkable at `CHANGELOG.md (#366 Sync the .gitignore self-heal block)` and commit `c70c42f` (#333) · rejected "has drifted twice", which a reader cannot verify.
- Both fence scans are bounded to the section, `heading_idx + 1` to the next line starting with `## ` · unbounded, a later section's fence stands in for a deleted one (the block could go missing and still PASS), an unrelated block is reported as this one's drift, and a deleted closing fence is masked by the next section's · `docs/one-time-notices.md#Self-heal the nested .milestone-config/.gitignore` · rejected the unbounded first-fence-after-the-heading scan (the first round's choice; the review's Important finding).
- Version bump 0.15.2 → 0.15.3 · milestone run, target from the milestone title · `milestone-driver` `solve-issue` step 6.4 · idempotent across the milestone's PRs.
- DOMAIN_SKILLS_INVOKED: plugin-dev:plugin-structure

## Code Review

- /code-review run: yes
- Coherence review (milestone-coherence-reviewer, before the code review): 1 finding, drift-trivial (`checked` bumped once for a three-file scan where every sibling bumps per file) → folded into the review's fourth finding and resolved.
- Review depth: classifier verdict `shallow` (the changed file sits outside `sourceGlobs`), reviewer effort low, cycle cap 1.
- Findings, cycle 1: 4 in-scope findings at low effort (1 Important, 3 Minor)
  - the doc fence scan ran unbounded, so a later section's fence could stand in for a deleted self-heal block (PASS with the block gone), an unrelated block could be reported as this one's drift, and the "never closed" branch was dead (Important) - `scripts/validate-plugin-structure.py (section_end = len(lines))` → re-dispatched and resolved (both scans bounded to the section)
  - drift between two present copies withheld while the third was missing (Minor) - `scripts/validate-plugin-structure.py (if len(present) >= 2:)` → re-dispatched and resolved
  - an absent `docs/one-time-notices.md` double-reported alongside the `FILE_WORD_CEILINGS` check (Minor) - `scripts/validate-plugin-structure.py (already fails that file, so this check does not double-report)` → re-dispatched and resolved
  - `checked` bumped once for a three-file scan against a report line that says "file(s) checked" (Minor) - `scripts/validate-plugin-structure.py (checked += len(self_heal_copies))` → re-dispatched and resolved
- Fresh review on the code-changed delta, the last action before commit: all four confirmed resolved by probe, no regression in the mutation, missing-source, BOM, or CRLF cases; 2 new Minor findings, both latent and unreachable on `develop` today
  - a `## `-prefixed line inside the fenced block would end `section_end` early and false-fail as "never closed" - `scripts/validate-plugin-structure.py (section_end = len(lines))` → accepted (rationale: no copy carries a doubled-hash line and #493 writes none; the failure would be loud, not silent)
  - hiding `docs/one-time-notices.md` AND removing its `FILE_WORD_CEILINGS` entry passes silently - `scripts/validate-plugin-structure.py (Silent on purpose: this path is in FILE_WORD_CEILINGS)` → accepted (rationale: two governed acts on the same PR, and the delegation is recorded at the silent return)
- ⚖️ Cycle cap: the `shallow` verdict grants one review→fix cycle, spent on the four findings above; the two fresh-review Minors were accepted rather than parked, and this PR carries the `judgment call` label so that call is reviewed post-run.
- Version bump: 0.15.2 → 0.15.3, the milestone target (version-bump only - no logic change).
- No park-triggering findings.
