### PR TITLE
docs: v0.15.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 Release notes for milestone-feeder. Each tagged release is also published on the
 [GitHub Releases page](https://github.com/kenmulford/milestone-feeder/releases).
 
+## v0.15.3: scratch-ignore convergence
+
+**Theme:** The feeder wrote the nested `.milestone-config/.gitignore` as twelve lines naming eight scratch markers one by one, while milestone-driver 1.24 writes five patterns with `*-notice`, so a consumer the feeder self-healed first kept a file that left every newer driver marker untracked. The three copies here now carry the driver's five patterns, a check in `scripts/validate-plugin-structure.py` pins them line for line, and the setup skill names the glob instead of eight marker names.
+
+### ✨ Structural gate
+
+| Issue | PR | What |
+|---|---|---|
+| #492 Pin the three nested .gitignore copies line for line in validate-plugin-structure.py | #495 | Check 7 in `scripts/validate-plugin-structure.py` reads `scripts/emit-notice.json`'s `self-heal-nested-gitignore` `writes.lines`, the fenced block under `## Self-heal the nested .milestone-config/.gitignore` in `docs/one-time-notices.md`, and the committed `.milestone-config/.gitignore`, and fails naming the drifted copy (a single odd copy against the two that agree; all three differing, the JSON array as reference) or the missing source; the false "byte-pinned" claim in the `FILE_WORD_CEILINGS` comment is corrected |
+
+### 🔧 Fixes
+
+| Issue | PR | What |
+|---|---|---|
+| #493 Converge the nested .milestone-config/.gitignore on the driver's five patterns at all three pinned sites | #496 | All three copies carry `*-notice`, `triage-cache.json`, `tests-stamp`, `.runtime/`, `worktrees/` under the four unchanged comment lines; the doc's Sync bullet states five entries, the driver's six writing sites, the one differing comment-line mark, and the check 7 pin |
+| #494 Name the *-notice glob in setup Phase 3 instead of eight marker names | #497 | The self-heal bullet's parenthetical in `skills/setup/SKILL.md` reads `*-notice`, `triage-cache.json`, `tests-stamp`, plus the `.runtime/` and `worktrees/` dirs |
+
+### Consumer notes (upgrading from v0.15.2)
+
+- **No schema changes** to `.milestone-config/feeder.json` or `.milestone-config/driver.json`. No new config key, no changed default.
+- **A consumer with no nested `.milestone-config/.gitignore` now receives the nine-line five-pattern body** from `plan` Step 0 or `setup` Phase 3, and `*-notice` covers every current and future driver marker. Both plugins write create-only: a consumer already holding the eight-name file keeps it. To adopt the glob, delete the nested file and re-run `plan` or `setup`, or edit it by hand.
+- The feeder's block and the driver's differ on one byte-run, the first comment line's mark (a comma here, a spaced hyphen there); the driver recasts its line in its own follow-up.
+
+### ⚖️ Audit trail
+
+Judgment-call PR for review: **#495** (the fresh review after the one granted fix cycle returned two latent Minor findings, accepted rather than parked: a `## `-prefixed line inside the fenced block would end the section scan early and false-fail as "never closed"; deleting `docs/one-time-notices.md` and its `FILE_WORD_CEILINGS` entry in the same change passes check 7 silently. Neither is reachable on `develop` today.)
+
+- Check 7 pins three copies; the `skills/setup/SKILL.md` parenthetical stays prose and is not pinned.
+- The driver's six sites keep the spaced-hyphen first line; the comma recast is a milestone-driver follow-up, alongside its triage-reviewer honoring a declared `Depends on #<n> - <reason>` edge (carried from v0.15.2).
+- Ceilings after this release: `docs/one-time-notices.md` 2163 of 2300, `skills/setup/SKILL.md` 2269 of 2400; neither moved.
+
 ## v0.15.2: shared-file ordering
 
 **Theme:** Two candidates that edit the same existing file used to share a parallel Wave, because the architect emitted an edge only when one candidate consumed an artifact another introduced; every fold after the first conflicted. Each candidate now declares the existing files it modifies, two intersecting lists get one ordering edge the Wave sort consumes like any other, and the list reaches the issue body so the driver sees the file scope before it cuts a branch.


### PR DESCRIPTION
## CHANGELOG preview

## v0.15.3: scratch-ignore convergence

**Theme:** The feeder wrote the nested `.milestone-config/.gitignore` as twelve lines naming eight scratch markers one by one, while milestone-driver 1.24 writes five patterns with `*-notice`, so a consumer the feeder self-healed first kept a file that left every newer driver marker untracked. The three copies here now carry the driver's five patterns, a check in `scripts/validate-plugin-structure.py` pins them line for line, and the setup skill names the glob instead of eight marker names.

### ✨ Structural gate

| Issue | PR | What |
|---|---|---|
| #492 Pin the three nested .gitignore copies line for line in validate-plugin-structure.py | #495 | Check 7 in `scripts/validate-plugin-structure.py` reads `scripts/emit-notice.json`'s `self-heal-nested-gitignore` `writes.lines`, the fenced block under `## Self-heal the nested .milestone-config/.gitignore` in `docs/one-time-notices.md`, and the committed `.milestone-config/.gitignore`, and fails naming the drifted copy (a single odd copy against the two that agree; all three differing, the JSON array as reference) or the missing source; the false "byte-pinned" claim in the `FILE_WORD_CEILINGS` comment is corrected |

### 🔧 Fixes

| Issue | PR | What |
|---|---|---|
| #493 Converge the nested .milestone-config/.gitignore on the driver's five patterns at all three pinned sites | #496 | All three copies carry `*-notice`, `triage-cache.json`, `tests-stamp`, `.runtime/`, `worktrees/` under the four unchanged comment lines; the doc's Sync bullet states five entries, the driver's six writing sites, the one differing comment-line mark, and the check 7 pin |
| #494 Name the *-notice glob in setup Phase 3 instead of eight marker names | #497 | The self-heal bullet's parenthetical in `skills/setup/SKILL.md` reads `*-notice`, `triage-cache.json`, `tests-stamp`, plus the `.runtime/` and `worktrees/` dirs |

### Consumer notes (upgrading from v0.15.2)

- **No schema changes** to `.milestone-config/feeder.json` or `.milestone-config/driver.json`. No new config key, no changed default.
- **A consumer with no nested `.milestone-config/.gitignore` now receives the nine-line five-pattern body** from `plan` Step 0 or `setup` Phase 3, and `*-notice` covers every current and future driver marker. Both plugins write create-only: a consumer already holding the eight-name file keeps it. To adopt the glob, delete the nested file and re-run `plan` or `setup`, or edit it by hand.
- The feeder's block and the driver's differ on one byte-run, the first comment line's mark (a comma here, a spaced hyphen there); the driver recasts its line in its own follow-up.

### ⚖️ Audit trail

Judgment-call PR for review: **#495** (the fresh review after the one granted fix cycle returned two latent Minor findings, accepted rather than parked: a `## `-prefixed line inside the fenced block would end the section scan early and false-fail as "never closed"; deleting `docs/one-time-notices.md` and its `FILE_WORD_CEILINGS` entry in the same change passes check 7 silently. Neither is reachable on `develop` today.)

- Check 7 pins three copies; the `skills/setup/SKILL.md` parenthetical stays prose and is not pinned.
- The driver's six sites keep the spaced-hyphen first line; the comma recast is a milestone-driver follow-up, alongside its triage-reviewer honoring a declared `Depends on #<n> - <reason>` edge (carried from v0.15.2).
- Ceilings after this release: `docs/one-time-notices.md` 2163 of 2300, `skills/setup/SKILL.md` 2269 of 2400; neither moved.

---

_This entry doubles as the GitHub-release body for the human release step._

## Code Review

- /code-review run: n/a - doc-only CHANGELOG entry, no executable surface.
- Findings: 0
  - none
- Evidence: every entry row carries its issue and its merged PR (#492/#495, #493/#496, #494/#497), bucketing matches each PR's title prefix (feat for #492, fix for #493 and #494), structure matches the prior `## v0.15.2` entry, the ⚖️ audit-trail line names the one judgment-call PR (#495).
- No park-triggering findings.
