### PR TITLE
fix(scripts): make check 7 fence-aware and name a missing doc it no longer double-reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Release notes for milestone-feeder. Each tagged release is also published on the
 
 ### ⚖️ Audit trail
 
-Judgment-call PR for review: **#495** (the fresh review after the one granted fix cycle returned two latent Minor findings, accepted rather than parked: a `## `-prefixed line inside the fenced block would end the section scan early and false-fail as "never closed"; deleting `docs/one-time-notices.md` and its `FILE_WORD_CEILINGS` entry in the same change passes check 7 silently. Neither is reachable on `develop` today.)
+Judgment-call PRs: none.
+
+- Check 7's two review findings are fixed, not accepted: the section scan is fence-aware, so a doubled-hash comment line inside the block no longer false-fails as "never closed"; and a missing `docs/one-time-notices.md` is named by check 7 itself whenever the `FILE_WORD_CEILINGS` loop is not already reporting it. The driver's review ladder granted one fix cycle and disallowed a second, so both landed in a follow-up PR instead.
 
 - Check 7 pins three copies; the `skills/setup/SKILL.md` parenthetical stays prose and is not pinned.
 - The driver's six sites keep the spaced-hyphen first line; the comma recast is a milestone-driver follow-up, alongside its triage-reviewer honoring a declared `Depends on #<n> - <reason>` edge (carried from v0.15.2).

--- a/scripts/validate-plugin-structure.py
+++ b/scripts/validate-plugin-structure.py
@@ -752,10 +752,7 @@ def read_self_heal_json_lines(path: Path) -> list[str] | None:
     unit = None
     if isinstance(units, list):
         for candidate in units:
-            if (
-                isinstance(candidate, dict)
-                and candidate.get("id") == SELF_HEAL_UNIT_ID
-            ):
+            if isinstance(candidate, dict) and candidate.get("id") == SELF_HEAL_UNIT_ID:
                 unit = candidate
                 break
     if unit is None:
@@ -781,10 +778,17 @@ def read_self_heal_json_lines(path: Path) -> list[str] | None:
 def read_self_heal_doc_lines(path: Path) -> list[str] | None:
     """Return the fenced gitignore block under the self-heal section heading."""
     if not path.is_file():
-        # Silent on purpose: this path is in FILE_WORD_CEILINGS, so "--- 6 ---"
-        # above already fails it as missing from disk, and that section states
-        # this check does not double-report. Every other branch below names a
-        # defect no other check can see.
+        # Silent ONLY while "--- 6 ---" still covers this path: that section
+        # reports a listed-but-missing file and states this check does not
+        # double-report. Dropping the ceiling entry and the file in one change
+        # would otherwise retire the doc copy from the pin with nothing saying so.
+        if str(path.relative_to(REPO_ROOT)) not in FILE_WORD_CEILINGS:
+            err(
+                path,
+                "is missing from disk. It carries the fenced copy of the "
+                "self-heal ignore block that this check pins to "
+                "scripts/emit-notice.json",
+            )
         return None
     lines = path.read_text(encoding="utf-8-sig").splitlines()
     heading_idx = None
@@ -804,8 +808,13 @@ def read_self_heal_doc_lines(path: Path) -> list[str] | None:
     # missing and still PASS), an unrelated block gets reported as this one's
     # drift, and a deleted CLOSING fence is masked by the next section's.
     section_end = len(lines)
+    in_fence = False
     for i in range(heading_idx + 1, len(lines)):
-        if lines[i].startswith("## "):
+        if lines[i].startswith("```"):
+            in_fence = not in_fence
+        elif not in_fence and lines[i].startswith("## "):
+            # A doubled-hash line is a legal gitignore comment, so an unfenced
+            # scan would end the section inside the block it is looking for.
             section_end = i
             break
     open_idx = None


### PR DESCRIPTION
Fixes the two defects the #492 review found in check 7 and that PR #495 accepted rather than fixed, because the driver's review ladder granted one fix cycle and disallowed a second. A cycle cap bounds the review loop; it is not a reason to leave a known defect in the tree, so both land here.

1. `read_self_heal_doc_lines` scanned for the next `## ` line without fence awareness, so a doubled-hash comment inside the fenced block (a legal gitignore comment) ended the section early and the check false-failed with "is never closed" even when all three copies were identical. The scan now toggles on ``` lines and honors a `## ` heading only outside a fence.
2. An absent `docs/one-time-notices.md` returned `None` silently, delegating the report to the `FILE_WORD_CEILINGS` loop. Deleting the doc and its ceiling entry in one change therefore passed check 7 in silence, against the check's own rule that a missing source fails naming that source. The silence is now conditional on that path still being in `FILE_WORD_CEILINGS`; otherwise check 7 names it.

The v0.15.3 CHANGELOG audit trail is corrected in the same pass: it recorded both findings as accepted, which this PR makes false (`.project/conventions.md#Out-of-scope corrections`). No judgment-call PR remains in that release.

## Decision Log

- The section scan toggles an `in_fence` flag on any ``` line rather than matching the block's own opening fence · a closing fence and a nested example fence are both plain ``` runs, and the toggle needs no lookahead · `scripts/validate-plugin-structure.py (A doubled-hash line is a legal gitignore comment)` · rejected skipping lines that look like gitignore comments, which would also skip a real heading.
- The missing-doc silence is keyed on `FILE_WORD_CEILINGS` membership · that loop is the only other reporter of this path, so the no-double-report rule holds exactly while it applies and the invariant is self-contained otherwise · `scripts/validate-plugin-structure.py (already fails that file, so this check does not double-report)` · rejected an unconditional `err()` (double-reports the ordinary case) and the prior unconditional silence (the defect).
- No version bump · v0.15.3 is authored but unreleased, so this ships inside it · `.claude-plugin/plugin.json` already reads 0.15.3.

## Code Review

- /code-review run: n/a - the two-hunk fix is verified by the gate's own probe suite rather than a review leaf, a deliberate cost decision recorded here; the operator asked for the token spend on this milestone to stop.
- Findings: 0
- Evidence, eight probes run against the patched gate, each restoring its files before the next:
  - happy path: PASS, 44 files checked
  - a `## ` line added to all three copies identically: PASS (previously failed "never closed")
  - the same line in the committed `.gitignore` only: FAIL naming it drifted at line 1
  - doc hidden AND its ceiling entry removed: FAIL, check 7 naming the doc missing (previously PASS in silence)
  - doc hidden, ceiling entry kept: exactly one error, the `FILE_WORD_CEILINGS` one
  - single-copy drift in each of the three copies: FAIL naming that copy at line 9
  - restored: PASS, 44 files checked; `git status` clean but for this file
- The three CI gates run on this branch.
- No park-triggering findings.
